### PR TITLE
fix: prevent data loss with --tables + date range + --force

### DIFF
--- a/packages/garmin-mcp-server/src/garmin_mcp/scripts/regenerate_duckdb.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/scripts/regenerate_duckdb.py
@@ -312,14 +312,18 @@ class DuckDBRegenerator:
         )
         logger.info(f"Regenerating{tables_info}")
 
+        resolved_ids = [a[0] for a in activities]
+
         # Validate table dependencies before deletion
-        if activity_ids:
-            self.validate_table_dependencies(self.tables, activity_ids)
+        if activity_ids or (start_date and end_date):
+            self.validate_table_dependencies(self.tables, resolved_ids)
 
         # Deletion strategy based on activity_ids AND force flag
         if self.tables and self.force:
             if activity_ids:
                 self.delete_activity_records(activity_ids)
+            elif start_date and end_date:
+                self.delete_activity_records(resolved_ids)
             else:
                 self.delete_table_all_records(self.tables)
         elif self.tables and not self.force:


### PR DESCRIPTION
## Summary

- Fixed `regenerate_duckdb` deleting ALL table records when using `--tables` + `--start-date/--end-date` + `--force`, instead of only the records for activities in the date range
- Date-range cases now use scoped deletion (`delete_activity_records`) with resolved activity IDs, matching `--activity-ids` behavior

Closes #74

## Test plan

- [x] `test_date_range_uses_scoped_deletion` — verifies `delete_activity_records` called (not `delete_table_all_records`)
- [x] `test_date_range_runs_validation` — verifies `validate_table_dependencies` called with resolved IDs
- [x] `test_no_filter_still_uses_table_wide_deletion` — backward compat guard
- [x] All 36 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)