### PR TITLE
feat: unify handler error handling with safe_tool_handler

### DIFF
--- a/packages/garmin-mcp-server/src/garmin_mcp/handlers/analysis_handler.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/handlers/analysis_handler.py
@@ -7,6 +7,7 @@ from mcp.types import TextContent
 
 from garmin_mcp.database.db_reader import GarminDBReader
 from garmin_mcp.handlers.base import format_json_response
+from garmin_mcp.utils.error_handling import safe_tool_handler
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,7 @@ class AnalysisHandler:
     def handles(self, name: str) -> bool:
         return name in self._tool_names
 
+    @safe_tool_handler
     async def handle(self, name: str, arguments: dict[str, Any]) -> list[TextContent]:
         if name == "insert_section_analysis_dict":
             return await self._insert_section_analysis_dict(arguments)

--- a/packages/garmin-mcp-server/src/garmin_mcp/handlers/performance_handler.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/handlers/performance_handler.py
@@ -6,6 +6,7 @@ from mcp.types import TextContent
 
 from garmin_mcp.database.db_reader import GarminDBReader
 from garmin_mcp.handlers.base import format_json_response
+from garmin_mcp.utils.error_handling import safe_tool_handler
 
 
 class PerformanceHandler:
@@ -23,6 +24,7 @@ class PerformanceHandler:
     def handles(self, name: str) -> bool:
         return name in self._tool_names
 
+    @safe_tool_handler
     async def handle(self, name: str, arguments: dict[str, Any]) -> list[TextContent]:
         activity_id = arguments["activity_id"]
 

--- a/packages/garmin-mcp-server/src/garmin_mcp/handlers/splits_handler.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/handlers/splits_handler.py
@@ -7,6 +7,7 @@ from mcp.types import TextContent
 
 from garmin_mcp.database.db_reader import GarminDBReader
 from garmin_mcp.handlers.base import format_json_response
+from garmin_mcp.utils.error_handling import safe_tool_handler
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,7 @@ class SplitsHandler:
     def handles(self, name: str) -> bool:
         return name in self._tool_names
 
+    @safe_tool_handler
     async def handle(self, name: str, arguments: dict[str, Any]) -> list[TextContent]:
         activity_id = arguments["activity_id"]
 

--- a/packages/garmin-mcp-server/src/garmin_mcp/handlers/time_series_handler.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/handlers/time_series_handler.py
@@ -6,6 +6,7 @@ from mcp.types import TextContent
 
 from garmin_mcp.database.db_reader import GarminDBReader
 from garmin_mcp.handlers.base import format_json_response
+from garmin_mcp.utils.error_handling import safe_tool_handler
 
 
 class TimeSeriesHandler:
@@ -19,6 +20,7 @@ class TimeSeriesHandler:
     def handles(self, name: str) -> bool:
         return name in self._tool_names
 
+    @safe_tool_handler
     async def handle(self, name: str, arguments: dict[str, Any]) -> list[TextContent]:
         if name == "get_split_time_series_detail":
             return await self._get_split_time_series_detail(arguments)

--- a/packages/garmin-mcp-server/tests/handlers/test_analysis_handler.py
+++ b/packages/garmin-mcp-server/tests/handlers/test_analysis_handler.py
@@ -580,10 +580,12 @@ class TestCompareSimilarWorkouts:
 
 @pytest.mark.unit
 class TestHandleUnknownTool:
-    """Test that unknown tool names raise ValueError."""
+    """Test that unknown tool names return structured error response."""
 
     @pytest.mark.asyncio
-    async def test_raises_value_error(self, mock_db_reader: MagicMock) -> None:
+    async def test_returns_error_response(self, mock_db_reader: MagicMock) -> None:
         handler = AnalysisHandler(mock_db_reader)
-        with pytest.raises(ValueError, match="Unknown tool"):
-            await handler.handle("nonexistent_tool", {})
+        result = await handler.handle("nonexistent_tool", {})
+        body = json.loads(result[0].text)
+        assert "Invalid parameter" in body["error"]
+        assert "Unknown tool" in body["error"]

--- a/packages/garmin-mcp-server/tests/handlers/test_performance_handler.py
+++ b/packages/garmin-mcp-server/tests/handlers/test_performance_handler.py
@@ -154,10 +154,12 @@ class TestPrefetchActivityContext:
 
 @pytest.mark.unit
 class TestHandleUnknownTool:
-    """Test that unknown tool names raise ValueError."""
+    """Test that unknown tool names return structured error response."""
 
     @pytest.mark.asyncio
-    async def test_raises_value_error(self, mock_db_reader: MagicMock) -> None:
+    async def test_returns_error_response(self, mock_db_reader: MagicMock) -> None:
         handler = PerformanceHandler(mock_db_reader)
-        with pytest.raises(ValueError, match="Unknown tool"):
-            await handler.handle("nonexistent_tool", {"activity_id": 12345})
+        result = await handler.handle("nonexistent_tool", {"activity_id": 12345})
+        body = json.loads(result[0].text)
+        assert "Invalid parameter" in body["error"]
+        assert "Unknown tool" in body["error"]

--- a/packages/garmin-mcp-server/tests/handlers/test_splits_handler.py
+++ b/packages/garmin-mcp-server/tests/handlers/test_splits_handler.py
@@ -311,10 +311,12 @@ class TestErrorHandling:
     """Test error cases."""
 
     @pytest.mark.asyncio
-    async def test_unknown_tool_raises_value_error(
+    async def test_unknown_tool_returns_error_response(
         self, mock_db_reader: MagicMock
     ) -> None:
         handler = SplitsHandler(mock_db_reader)
 
-        with pytest.raises(ValueError, match="Unknown tool"):
-            await handler.handle("nonexistent_tool", {"activity_id": ACTIVITY_ID})
+        result = await handler.handle("nonexistent_tool", {"activity_id": ACTIVITY_ID})
+        body = json.loads(result[0].text)
+        assert "Invalid parameter" in body["error"]
+        assert "Unknown tool" in body["error"]

--- a/packages/garmin-mcp-server/tests/handlers/test_time_series_handler.py
+++ b/packages/garmin-mcp-server/tests/handlers/test_time_series_handler.py
@@ -203,10 +203,12 @@ class TestGetTimeRangeDetail:
 
 @pytest.mark.unit
 class TestHandleUnknownTool:
-    """Test that unknown tool names raise ValueError."""
+    """Test that unknown tool names return structured error response."""
 
     @pytest.mark.asyncio
-    async def test_raises_value_error(self, mock_db_reader: MagicMock) -> None:
+    async def test_returns_error_response(self, mock_db_reader: MagicMock) -> None:
         handler = TimeSeriesHandler(mock_db_reader)
-        with pytest.raises(ValueError, match="Unknown tool"):
-            await handler.handle("nonexistent_tool", {"activity_id": 12345})
+        result = await handler.handle("nonexistent_tool", {"activity_id": 12345})
+        body = json.loads(result[0].text)
+        assert "Invalid parameter" in body["error"]
+        assert "Unknown tool" in body["error"]

--- a/packages/garmin-mcp-server/tests/unit/test_safe_tool_handler.py
+++ b/packages/garmin-mcp-server/tests/unit/test_safe_tool_handler.py
@@ -1,0 +1,85 @@
+"""Tests for the safe_tool_handler decorator."""
+
+import json
+
+import pytest
+from mcp.types import TextContent
+
+from garmin_mcp.utils.error_handling import LLMSafeError, safe_tool_handler
+
+
+@pytest.mark.unit
+class TestSafeToolHandler:
+    """Tests for the safe_tool_handler decorator."""
+
+    @pytest.mark.asyncio
+    async def test_normal_response_passes_through(self) -> None:
+        expected = [TextContent(type="text", text='{"ok": true}')]
+
+        @safe_tool_handler
+        async def handler() -> list[TextContent]:
+            return expected
+
+        result = await handler()
+        assert result is expected
+
+    @pytest.mark.asyncio
+    async def test_llm_safe_error_formatted(self) -> None:
+        @safe_tool_handler
+        async def handler() -> list[TextContent]:
+            raise LLMSafeError(
+                message="Activity not found",
+                suggestion="Check the activity ID",
+            )
+
+        result = await handler()
+        assert len(result) == 1
+        body = json.loads(result[0].text)
+        assert body["error"] == "Activity not found"
+        assert body["suggestion"] == "Check the activity ID"
+
+    @pytest.mark.asyncio
+    async def test_value_error_formatted(self) -> None:
+        @safe_tool_handler
+        async def handler() -> list[TextContent]:
+            raise ValueError("activity_id must be positive")
+
+        result = await handler()
+        assert len(result) == 1
+        body = json.loads(result[0].text)
+        assert "Invalid parameter" in body["error"]
+        assert "activity_id must be positive" in body["error"]
+        assert body["suggestion"] == "Check parameter names and types"
+
+    @pytest.mark.asyncio
+    async def test_key_error_formatted(self) -> None:
+        @safe_tool_handler
+        async def handler() -> list[TextContent]:
+            raise KeyError("missing_key")
+
+        result = await handler()
+        assert len(result) == 1
+        body = json.loads(result[0].text)
+        assert "Invalid parameter" in body["error"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_exception_no_traceback(self) -> None:
+        @safe_tool_handler
+        async def handler() -> list[TextContent]:
+            raise RuntimeError("something broke internally")
+
+        result = await handler()
+        assert len(result) == 1
+        body = json.loads(result[0].text)
+        assert body["error"] == "Internal error occurred"
+        assert body["suggestion"] == "Try again or check server logs"
+        # Must not leak internal details
+        assert "something broke" not in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_decorator_preserves_function_name(self) -> None:
+        @safe_tool_handler
+        async def my_handler() -> list[TextContent]:
+            return []
+
+        assert my_handler.__name__ == "my_handler"


### PR DESCRIPTION
## Summary
- Add `safe_tool_handler` decorator to `utils/error_handling.py` that catches exceptions and returns structured JSON error responses
- Apply decorator to 4 handlers without error handling: `SplitsHandler`, `AnalysisHandler`, `PerformanceHandler`, `TimeSeriesHandler`
- Update 4 existing handler tests to expect structured error responses instead of raised exceptions

Closes #82

## Test plan
- [x] 6 new unit tests for decorator behavior (passthrough, LLMSafeError, ValueError, KeyError, unknown exception, `@wraps`)
- [x] 4 updated handler tests for unknown tool error responses
- [x] Full unit suite: 1443 passed
- [x] Pre-commit: black, ruff, mypy, pytest all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)