### PR TITLE
chore: remove pytest from pre-commit hooks (#106)

### DIFF
--- a/.claude/agents/tdd-implementer.md
+++ b/.claude/agents/tdd-implementer.md
@@ -30,7 +30,7 @@ GitHub Issue に記載された設計に基づき、Test-Driven Development（Re
 - Black によるフォーマット
 - Ruff による Lint チェック
 - Mypy による型チェック
-- Pytest によるテスト実行
+- Pytest によるテスト実行（ローカル手動 `uv run pytest -m unit`、pre-commit ではない）
 
 ### 4. Git 管理
 - Worktree内のfeature branchで作業

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -5,9 +5,9 @@
 - **black**: Code formatting (line-length=88)
 - **ruff**: Linting (rules: E, F, W, I, UP, B, SIM, RUF)
 - **mypy**: Type checking (python 3.12, strict optional)
-- **pytest**: Unit tests (`-m unit`)
-
 Source of truth for all settings: `pyproject.toml`
+
+Tests are verified via CI and local manual execution (`uv run pytest -m unit`), not pre-commit.
 
 ## Manual Commands
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,10 +35,3 @@ repos:
         entry: .claude/hooks/no-direct-duckdb-connect.sh
         language: system
         pass_filenames: false
-
-      - id: pytest
-        name: pytest (unit)
-        entry: uv run pytest -m unit --tb=short
-        language: system
-        types: [python]
-        pass_filenames: false


### PR DESCRIPTION
## Summary
- Remove `pytest (unit)` hook from pre-commit to unblock TDD Red phase commits
- Tests verified via CI and local manual execution instead

Closes #106

## Test plan
- [x] Pre-commit hooks (black, ruff, mypy) still run
- [x] pytest hook no longer blocks commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)