### PR TITLE
feat(agent): add MCP smoke test and E2E pipeline verification

### DIFF
--- a/.claude/agents/tdd-implementer.md
+++ b/.claude/agents/tdd-implementer.md
@@ -193,6 +193,32 @@ CI を早期に走らせ、WIP を可視化する。
    uv run pytest
    ```
 
+### Phase 3.5: MCP Smoke Test (garmin_mcp コード変更時のみ)
+
+**前提条件**: `packages/garmin-mcp-server/src/garmin_mcp/` 配下のコードを変更した場合のみ実施。agent/rules/docs のみの変更時はスキップ。
+
+1. **Verification DB を生成**
+   ```bash
+   cd {worktree_path}
+   GARMIN_DATA_DIR={worktree_path}/packages/garmin-mcp-server/tests/fixtures/data \
+     uv run python packages/garmin-mcp-server/tests/generate_verification_db.py
+   ```
+
+2. **GARMIN_DATA_DIR を fixture に向けて MCP サーバーをリロード**
+   ```
+   mcp__garmin-db__reload_server(server_dir="{worktree_path}/packages/garmin-mcp-server")
+   ```
+   ※ reload_server 前に環境変数 GARMIN_DATA_DIR が fixture を指していること
+
+3. **変更対象のツールを呼び出し、レスポンスが非エラーであることを確認**
+   - `mcp__garmin-db__get_activity_by_date(date="2025-10-09")` → activity_id `12345678901` が返ること
+   - 変更した Handler/Reader に関連するツールを追加で呼ぶ
+
+4. **検証後、GARMIN_DATA_DIR を元に戻して再リロード**
+   ```
+   mcp__garmin-db__reload_server()  # server_dir 省略でデフォルト復帰
+   ```
+
 ### Phase 4: Commit & Push
 
 1. **Conventional Commit 形式でコミット (in worktree)**

--- a/.claude/rules/e2e-verification.md
+++ b/.claude/rules/e2e-verification.md
@@ -1,0 +1,26 @@
+# E2E Verification Rules
+
+## 検証基準
+
+### 構造チェック（FAIL = 致命的）
+
+- 各セクション (split, phase, efficiency, environment, summary) の `analysis_data` が非 null
+- 必須フィールドが存在（section_type ごとに定義）
+- レポート Markdown が生成される
+
+### 内容チェック（FAIL = 警告、理由を PR コメントに記載）
+
+- ペース値が fixture と整合（5:15-5:45/km 範囲の activity に対して 3:00/km 等の異常値がないか）
+- HR 値が fixture と整合（130-165 bpm 範囲）
+- セクション間で矛盾がないか（efficiency が「優秀」なのに summary が「要改善」等）
+
+### スキップ条件
+
+分析エージェント (`.claude/agents/*-analyst.md`)、Handler (`src/garmin_mcp/handlers/`)、Reader (`src/garmin_mcp/database/readers/`)、Report (`src/garmin_mcp/reporting/`) のいずれにも変更がない場合はスキップ。
+
+## Verification Activity
+
+- **Activity ID**: `12345678901`
+- **Date**: `2025-10-09`
+- **Type**: Easy run (7km, 5:15-5:45/km)
+- **Fixture Location**: `tests/fixtures/data/raw/activity/12345678901/`


### PR DESCRIPTION
## Summary
- Phase 3.5 in tdd-implementer: verification DB smoke test for garmin_mcp changes (#103)
- Phase 2.5 in completion-reporter: LLM-as-Judge E2E verification for analysis agent changes (#104)
- New `.claude/rules/e2e-verification.md` rules for structural and content checks

Closes #103
Closes #104

## Test plan
- [x] Agent definition changes only (no code changes to test)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)