### PR TITLE
chore(rules): enforce PR-only workflow for all changes to main

### DIFF
--- a/.claude/hooks/block-commit-on-main.sh
+++ b/.claude/hooks/block-commit-on-main.sh
@@ -17,13 +17,7 @@ echo "$command" | grep -q "^git commit" || exit 0
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
 [ "$branch" != "main" ] && [ "$branch" != "master" ] && exit 0
 
-# rules/docs のみの変更は例外として許可 (.claude/, .github/, docs/, CLAUDE.md)
-staged=$(git diff --cached --name-only 2>/dev/null)
-[ -z "$staged" ] && { echo "BLOCKED: mainブランチへの直接コミットは禁止です" >&2; exit 2; }
-non_docs=$(echo "$staged" | grep -v "^\.claude/" | grep -v "^\.github/" | grep -v "^docs/" | grep -v "^CLAUDE\.md$" || true)
-[ -z "$non_docs" ] && exit 0
-
-# mainブランチでのcommit → ブロック
+# mainブランチでのcommit → ブロック（branch protection により全変更がPR必須）
 echo "BLOCKED: mainブランチへの直接コミットは禁止です" >&2
 echo "worktreeを作成してください: git worktree add -b feature/name ../garmin-name main" >&2
 exit 2

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -17,7 +17,7 @@ mcp__serena__activate_project("/home/yamakii/workspace/garmin-performance-analys
 ## Branch Strategy
 
 - **Code changes** (`packages/`, `tests/`): worktree MANDATORY
-- **Rules/docs** (`.claude/rules/`, `docs/`, `CLAUDE.md`): main OK
+- **Rules/docs** (`.claude/rules/`, `docs/`, `CLAUDE.md`): PR required (branch protection)
 - **Planning**: main branch (read-only)
 
 ### Worktree Setup
@@ -36,7 +36,7 @@ git worktree remove ../garmin-feature-name
 ## PR Convention
 
 - merge commit --no-ff (`--delete-branch` で自動ブランチ削除、TDD履歴保持)
-- main 直 push は rules/docs のみ (既存ルール維持)
+- main への直接 push は禁止（branch protection 有効）
 - `/ship --pr N` でマージ
 
 ### Parallel Branches

--- a/.claude/rules/prohibited-practices.md
+++ b/.claude/rules/prohibited-practices.md
@@ -5,6 +5,7 @@
 - Edit code without Serena MCP
 - Implement on main branch (use worktree for code changes)
 - `git worktree remove --force` without checking status
+- Push directly to main (branch protection enabled — all changes require PR)
 - Force push to main/master
 - 複数の無関係な変更を1コミットに混在させる
 


### PR DESCRIPTION
## Summary
- Update branch strategy rules: rules/docs changes now require PR (no more main direct push exception)
- Simplify `block-commit-on-main.sh` hook: remove rules/docs exception, block all commits on main uniformly
- Add explicit prohibition in `prohibited-practices.md`: direct push to main is forbidden

## Changed files
- `.claude/rules/git-workflow.md` — Branch Strategy + PR Convention sections updated
- `.claude/rules/prohibited-practices.md` — Added direct push prohibition
- `.claude/hooks/block-commit-on-main.sh` — Removed lines 20-24 exception logic

## Verification
- `grep -r "main OK\|main 直 push" .claude/` returns no matches
- Hook now blocks all commits on main regardless of file type

🤖 Generated with [Claude Code](https://claude.com/claude-code)