### PR TITLE
chore(ci): add path filters + remove required status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'packages/**'
+      - 'pyproject.toml'
+      - '.pre-commit-config.yaml'
+      - '.github/workflows/**'
   push:
     branches: [main]
+    paths:
+      - 'packages/**'
+      - 'pyproject.toml'
+      - '.pre-commit-config.yaml'
+      - '.github/workflows/**'
 
 jobs:
   lint-and-test:


### PR DESCRIPTION
## Summary
- Add `paths` filter to CI workflow so lint/test only runs on code changes (`packages/**`, `pyproject.toml`, etc.)
- Remove `required_status_checks` from ruleset (prevents merge-block when CI is skipped by path filter)
- Disable strict mode to avoid rebase hell in parallel development

Closes #112

## Test plan
- [x] Ruleset verified: `required_status_checks` rule removed
- [ ] This PR (CI workflow change) triggers CI ✓
- [ ] Future docs/rules-only PRs skip CI and are mergeable

🤖 Generated with [Claude Code](https://claude.com/claude-code)