### PR TITLE
fix(ci): restore required status check with skip-job pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,26 +3,33 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'packages/**'
-      - 'pyproject.toml'
-      - '.pre-commit-config.yaml'
-      - '.github/workflows/**'
   push:
     branches: [main]
-    paths:
-      - 'packages/**'
-      - 'pyproject.toml'
-      - '.pre-commit-config.yaml'
-      - '.github/workflows/**'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'packages/**'
+              - 'pyproject.toml'
+              - '.pre-commit-config.yaml'
+              - '.github/workflows/**'
+
   lint-and-test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: packages/garmin-mcp-server
-
     steps:
       - uses: actions/checkout@v4
 
@@ -47,3 +54,19 @@ jobs:
 
       - name: Run unit tests with coverage
         run: uv run pytest -m unit --tb=short -n 4 --maxfail=5 --cov=garmin_mcp --cov-report=term-missing --cov-fail-under=60
+
+  ci-guard:
+    needs: [changes, lint-and-test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CI result
+        run: |
+          if [ "${{ needs.changes.outputs.code }}" == "false" ]; then
+            echo "No code changes — skipping CI"
+            exit 0
+          fi
+          if [ "${{ needs.lint-and-test.result }}" != "success" ]; then
+            echo "lint-and-test failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Replace workflow-level path filters with `dorny/paths-filter` + `ci-guard` job
- `ci-guard` always runs: passes when no code changes, or when `lint-and-test` succeeds
- Enables `ci-guard` as a required status check without blocking non-code PRs

Refs: #112

## Test plan
- [ ] This PR triggers `lint-and-test` (CI workflow changed) → `ci-guard` success
- [ ] Next non-code PR skips `lint-and-test` → `ci-guard` success → mergeable
- [ ] Ruleset shows `ci-guard` as required check

🤖 Generated with [Claude Code](https://claude.com/claude-code)