### PR TITLE
feat: add weekly/monthly progress report worker

### DIFF
--- a/.claude/commands/progress-report.md
+++ b/.claude/commands/progress-report.md
@@ -1,0 +1,49 @@
+# Progress Report Command
+
+指定期間のプログレスレポートを生成してください。
+
+## パラメータ
+
+- `{{arg1}}`: 開始日 (YYYY-MM-DD)
+- `{{arg2}}`: 終了日 (YYYY-MM-DD)
+
+## ワークフロー
+
+### Step 1: アクティビティ一覧の取得
+
+MCP export ツールで対象期間のアクティビティデータを取得:
+
+```
+mcp__garmin-db__export(
+    query="SELECT a.activity_id, a.activity_date, a.distance / 100000.0 as distance_km, a.avg_speed, a.avg_hr, a.training_type FROM activities a WHERE a.activity_date >= '{{arg1}}' AND a.activity_date <= '{{arg2}}' AND a.activity_type = 'running' ORDER BY a.activity_date",
+    format="parquet"
+)
+```
+
+### Step 2: 各アクティビティの詳細取得
+
+取得した activity_id リストに対して、以下のデータを収集:
+- `get_splits_comprehensive(activity_id, statistics_only=True)` -- ペース・HR
+- `get_hr_efficiency_analysis(activity_id)` -- Zone 2%
+- `get_form_efficiency_summary(activity_id)` -- フォームスコア
+
+### Step 3: レポート生成
+
+収集したデータを `ProgressReportWorker` の入力形式に変換し、`render()` でマークダウン生成。
+
+```python
+from garmin_mcp.reporting.progress_report_worker import ProgressReportWorker
+
+worker = ProgressReportWorker()
+markdown = worker.render(activities, start_date="{{arg1}}", end_date="{{arg2}}")
+```
+
+### Step 4: 結果表示
+
+生成されたマークダウンをユーザーに表示してください。
+
+## 重要事項
+
+- MCP ツール経由でデータ取得（直接 DuckDB アクセス禁止）
+- 日本語で出力
+- アクティビティ数が多い場合は export + Python スクリプトで効率化

--- a/packages/garmin-mcp-server/src/garmin_mcp/reporting/progress_report_worker.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/reporting/progress_report_worker.py
@@ -1,0 +1,278 @@
+"""
+Progress Report Worker
+
+Generates weekly/monthly progress reports from activity data.
+"""
+
+import logging
+from datetime import date, datetime
+from typing import Any
+
+from garmin_mcp.reporting.components.formatting import format_pace
+from garmin_mcp.reporting.report_template_renderer import ReportTemplateRenderer
+
+logger = logging.getLogger(__name__)
+
+
+class ProgressReportWorker:
+    """Generate weekly/monthly progress reports."""
+
+    def __init__(self, renderer: ReportTemplateRenderer | None = None):
+        """Initialize progress report worker.
+
+        Args:
+            renderer: Template renderer instance (default: creates new one)
+        """
+        self.renderer = renderer or ReportTemplateRenderer()
+
+    def generate(
+        self,
+        activities: list[dict[str, Any]],
+        start_date: str,
+        end_date: str,
+        period: str = "weekly",
+    ) -> dict[str, Any]:
+        """Generate progress report for given date range.
+
+        Args:
+            activities: List of activity dicts with keys:
+                - date (str): YYYY-MM-DD
+                - distance_km (float): Distance in km
+                - avg_pace_seconds_per_km (float): Average pace
+                - avg_hr (float | None): Average heart rate
+                - zone2_pct (float | None): Zone 2 percentage (0-100)
+                - form_score (float | None): Form efficiency score
+                - cadence (float | None): Average cadence
+                - training_type (str | None): Training type
+            start_date: Start date (YYYY-MM-DD)
+            end_date: End date (YYYY-MM-DD)
+            period: Report period ("weekly" or "monthly")
+
+        Returns:
+            Report data dict with keys: weeks, trends, start_date, end_date, period
+        """
+        weeks = self._aggregate_weekly(activities)
+        trends = self._calculate_trends(weeks)
+
+        return {
+            "weeks": weeks,
+            "trends": trends,
+            "start_date": start_date,
+            "end_date": end_date,
+            "period": period,
+            "total_activities": len(activities),
+        }
+
+    def render(
+        self,
+        activities: list[dict[str, Any]],
+        start_date: str,
+        end_date: str,
+        period: str = "weekly",
+    ) -> str:
+        """Generate and render progress report as markdown.
+
+        Args:
+            activities: List of activity dicts (see generate() for schema)
+            start_date: Start date (YYYY-MM-DD)
+            end_date: End date (YYYY-MM-DD)
+            period: Report period ("weekly" or "monthly")
+
+        Returns:
+            Rendered markdown report
+        """
+        from typing import cast
+
+        report_data = self.generate(activities, start_date, end_date, period)
+        template = self.renderer.load_template("progress_report.j2")
+        return cast(str, template.render(**report_data))
+
+    def _aggregate_weekly(
+        self, activities: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        """Group activities by ISO week and aggregate metrics.
+
+        Args:
+            activities: List of activity dicts
+
+        Returns:
+            List of weekly aggregation dicts, sorted by week number
+        """
+        if not activities:
+            return []
+
+        # Group by ISO week
+        weekly_groups: dict[str, list[dict[str, Any]]] = {}
+        for activity in activities:
+            activity_date = self._parse_date(activity["date"])
+            iso_year, iso_week, _ = activity_date.isocalendar()
+            week_key = f"{iso_year}-W{iso_week:02d}"
+            if week_key not in weekly_groups:
+                weekly_groups[week_key] = []
+            weekly_groups[week_key].append(activity)
+
+        # Aggregate each week
+        weeks = []
+        for week_key in sorted(weekly_groups.keys()):
+            group = weekly_groups[week_key]
+            week_data = self._aggregate_group(group, week_key)
+            weeks.append(week_data)
+
+        # Assign sequential labels
+        for i, week in enumerate(weeks):
+            week["label"] = f"W{i + 1}"
+
+        return weeks
+
+    def _aggregate_group(
+        self, activities: list[dict[str, Any]], label: str
+    ) -> dict[str, Any]:
+        """Aggregate metrics for a group of activities.
+
+        Args:
+            activities: Activities in this group
+            label: Group label (e.g., "2025-W42")
+
+        Returns:
+            Aggregated metrics dict
+        """
+        total_distance = sum(a.get("distance_km", 0.0) for a in activities)
+
+        # Weighted average pace (weighted by distance)
+        pace_sum = 0.0
+        distance_sum = 0.0
+        for a in activities:
+            dist = a.get("distance_km", 0.0)
+            pace = a.get("avg_pace_seconds_per_km", 0.0)
+            if dist > 0 and pace > 0:
+                pace_sum += pace * dist
+                distance_sum += dist
+        avg_pace = pace_sum / distance_sum if distance_sum > 0 else 0.0
+
+        # Simple averages for other metrics
+        zone2_values = [
+            a["zone2_pct"] for a in activities if a.get("zone2_pct") is not None
+        ]
+        form_values = [
+            a["form_score"] for a in activities if a.get("form_score") is not None
+        ]
+        hr_values = [a["avg_hr"] for a in activities if a.get("avg_hr") is not None]
+        cadence_values = [
+            a["cadence"] for a in activities if a.get("cadence") is not None
+        ]
+
+        return {
+            "week_key": label,
+            "label": label,
+            "run_count": len(activities),
+            "total_distance_km": round(total_distance, 1),
+            "avg_pace_seconds_per_km": round(avg_pace, 1) if avg_pace > 0 else None,
+            "avg_pace_formatted": self._format_pace(avg_pace) if avg_pace > 0 else None,
+            "avg_zone2_pct": (
+                round(sum(zone2_values) / len(zone2_values), 1)
+                if zone2_values
+                else None
+            ),
+            "avg_form_score": (
+                round(sum(form_values) / len(form_values), 1) if form_values else None
+            ),
+            "avg_hr": (
+                round(sum(hr_values) / len(hr_values), 1) if hr_values else None
+            ),
+            "avg_cadence": (
+                round(sum(cadence_values) / len(cadence_values), 1)
+                if cadence_values
+                else None
+            ),
+        }
+
+    def _calculate_trends(self, weeks: list[dict[str, Any]]) -> dict[str, Any]:
+        """Calculate trends between first and last week.
+
+        Args:
+            weeks: Aggregated weekly data (sorted chronologically)
+
+        Returns:
+            Trends dict with change values between first and last week
+        """
+        if len(weeks) < 2:
+            return {}
+
+        first = weeks[0]
+        last = weeks[-1]
+
+        trends: dict[str, Any] = {}
+
+        # Pace change (negative = improvement)
+        if first.get("avg_pace_seconds_per_km") and last.get("avg_pace_seconds_per_km"):
+            pace_change = (
+                last["avg_pace_seconds_per_km"] - first["avg_pace_seconds_per_km"]
+            )
+            trends["pace_change"] = round(pace_change, 1)
+            trends["pace_change_formatted"] = self._format_pace_change(pace_change)
+
+        # Distance change
+        if first.get("total_distance_km") and last.get("total_distance_km"):
+            dist_change = last["total_distance_km"] - first["total_distance_km"]
+            trends["distance_change_km"] = round(dist_change, 1)
+
+        # Zone 2 change (positive = improvement)
+        if (
+            first.get("avg_zone2_pct") is not None
+            and last.get("avg_zone2_pct") is not None
+        ):
+            zone2_change = last["avg_zone2_pct"] - first["avg_zone2_pct"]
+            trends["zone2_change_pp"] = round(zone2_change, 1)
+
+        # Form score change (positive = improvement)
+        if (
+            first.get("avg_form_score") is not None
+            and last.get("avg_form_score") is not None
+        ):
+            form_change = last["avg_form_score"] - first["avg_form_score"]
+            trends["form_score_change"] = round(form_change, 1)
+
+        # HR change
+        if first.get("avg_hr") is not None and last.get("avg_hr") is not None:
+            hr_change = last["avg_hr"] - first["avg_hr"]
+            trends["hr_change"] = round(hr_change, 1)
+
+        return trends
+
+    @staticmethod
+    def _format_pace(seconds_per_km: float) -> str:
+        """Format pace as M:SS/km.
+
+        Args:
+            seconds_per_km: Pace in seconds per kilometer
+
+        Returns:
+            Formatted pace string (e.g., "6:45/km")
+        """
+        return format_pace(seconds_per_km)
+
+    @staticmethod
+    def _format_pace_change(change_seconds: float) -> str:
+        """Format pace change with direction indicator.
+
+        Args:
+            change_seconds: Change in seconds (negative = faster)
+
+        Returns:
+            Formatted change string (e.g., "-10秒/km (改善)")
+        """
+        sign = "+" if change_seconds >= 0 else ""
+        label = "改善" if change_seconds < 0 else "低下"
+        return f"{sign}{int(change_seconds)}秒/km ({label})"
+
+    @staticmethod
+    def _parse_date(date_str: str) -> date:
+        """Parse date string to date object.
+
+        Args:
+            date_str: Date in YYYY-MM-DD format
+
+        Returns:
+            date object
+        """
+        return datetime.strptime(date_str, "%Y-%m-%d").date()

--- a/packages/garmin-mcp-server/src/garmin_mcp/reporting/templates/progress_report.j2
+++ b/packages/garmin-mcp-server/src/garmin_mcp/reporting/templates/progress_report.j2
@@ -1,0 +1,33 @@
+## {{ weeks | length }}週間プログレスレポート ({{ start_date }} ~ {{ end_date }})
+
+**期間**: {{ start_date }} ~ {{ end_date }} | **アクティビティ数**: {{ total_activities }}件
+
+{% if weeks %}
+| 週 | 回数 | 距離 | 平均ペース | 平均HR | Zone 2% | フォームスコア |
+|----|------|------|-----------|--------|---------|-------------|
+{% for week in weeks %}
+| {{ week.label }} | {{ week.run_count }} | {{ week.total_distance_km }}km | {{ week.avg_pace_formatted or "N/A" }} | {{ week.avg_hr or "N/A" }}{% if week.avg_hr %} bpm{% endif %} | {{ week.avg_zone2_pct or "N/A" }}{% if week.avg_zone2_pct %}%{% endif %} | {{ week.avg_form_score or "N/A" }} |
+{% endfor %}
+
+{% if trends %}
+### トレンド ({{ weeks[0].label }} → {{ weeks[-1].label }})
+
+{% if trends.pace_change is defined %}
+- **平均ペース**: {{ trends.pace_change_formatted }}
+{% endif %}
+{% if trends.distance_change_km is defined %}
+- **週間距離**: {{ "+" if trends.distance_change_km >= 0 }}{{ trends.distance_change_km }}km
+{% endif %}
+{% if trends.zone2_change_pp is defined %}
+- **Zone 2比率**: {{ "+" if trends.zone2_change_pp >= 0 }}{{ trends.zone2_change_pp }}pp ({{ weeks[0].avg_zone2_pct }}%→{{ weeks[-1].avg_zone2_pct }}%)
+{% endif %}
+{% if trends.form_score_change is defined %}
+- **フォームスコア**: {{ "+" if trends.form_score_change >= 0 }}{{ trends.form_score_change }} ({{ weeks[0].avg_form_score }}→{{ weeks[-1].avg_form_score }})
+{% endif %}
+{% if trends.hr_change is defined %}
+- **平均HR**: {{ "+" if trends.hr_change >= 0 }}{{ trends.hr_change }} bpm
+{% endif %}
+{% endif %}
+{% else %}
+_対象期間にアクティビティがありません。_
+{% endif %}

--- a/packages/garmin-mcp-server/tests/reporting/test_progress_report_worker.py
+++ b/packages/garmin-mcp-server/tests/reporting/test_progress_report_worker.py
@@ -1,0 +1,247 @@
+"""Tests for ProgressReportWorker."""
+
+import pytest
+
+from garmin_mcp.reporting.progress_report_worker import ProgressReportWorker
+
+
+def _make_activity(
+    date: str,
+    distance_km: float = 7.0,
+    avg_pace: float = 405.0,
+    avg_hr: float | None = 145.0,
+    zone2_pct: float | None = 40.0,
+    form_score: float | None = 85.0,
+    cadence: float | None = 175.0,
+) -> dict:
+    return {
+        "date": date,
+        "distance_km": distance_km,
+        "avg_pace_seconds_per_km": avg_pace,
+        "avg_hr": avg_hr,
+        "zone2_pct": zone2_pct,
+        "form_score": form_score,
+        "cadence": cadence,
+        "training_type": "aerobic_base",
+    }
+
+
+def _make_4_weeks_activities() -> list[dict]:
+    """Create 4 weeks of activities with improving trends."""
+    return [
+        # Week 1 (2025-10-06 Mon ~ 2025-10-12 Sun)
+        _make_activity("2025-10-06", 10.0, 405.0, 150.0, 35.0, 85.0),
+        _make_activity("2025-10-08", 7.0, 410.0, 148.0, 33.0, 84.0),
+        _make_activity("2025-10-10", 15.0, 400.0, 152.0, 37.0, 86.0),
+        # Week 2 (2025-10-13 ~ 2025-10-19)
+        _make_activity("2025-10-13", 10.0, 400.0, 147.0, 40.0, 87.0),
+        _make_activity("2025-10-15", 8.0, 395.0, 145.0, 44.0, 88.0),
+        _make_activity("2025-10-17", 17.0, 405.0, 149.0, 42.0, 88.0),
+        # Week 3 (2025-10-20 ~ 2025-10-26)
+        _make_activity("2025-10-20", 12.0, 395.0, 144.0, 46.0, 89.0),
+        _make_activity("2025-10-22", 8.0, 390.0, 142.0, 50.0, 90.0),
+        _make_activity("2025-10-24", 18.0, 398.0, 146.0, 48.0, 89.0),
+        # Week 4 (2025-10-27 ~ 2025-11-02)
+        _make_activity("2025-10-27", 10.0, 393.0, 143.0, 44.0, 91.0),
+        _make_activity("2025-10-29", 8.0, 388.0, 140.0, 48.0, 91.5),
+        _make_activity("2025-10-31", 18.0, 395.0, 145.0, 43.0, 90.5),
+    ]
+
+
+@pytest.mark.unit
+class TestProgressReportWorker:
+    """Unit tests for ProgressReportWorker."""
+
+    def test_generate_weekly_report_structure(self) -> None:
+        """Mock 4 weeks of data -> weeks array has 4 items."""
+        worker = ProgressReportWorker()
+        activities = _make_4_weeks_activities()
+
+        result = worker.generate(
+            activities,
+            start_date="2025-10-01",
+            end_date="2025-10-31",
+            period="weekly",
+        )
+
+        assert "weeks" in result
+        assert len(result["weeks"]) == 4
+        assert "trends" in result
+        assert result["total_activities"] == 12
+
+        # Each week should have required fields
+        for week in result["weeks"]:
+            assert "label" in week
+            assert "total_distance_km" in week
+            assert "avg_pace_formatted" in week
+            assert "run_count" in week
+
+    def test_generate_with_empty_period(self) -> None:
+        """0 activities -> no error, empty report."""
+        worker = ProgressReportWorker()
+
+        result = worker.generate(
+            activities=[],
+            start_date="2025-10-01",
+            end_date="2025-10-31",
+            period="weekly",
+        )
+
+        assert result["weeks"] == []
+        assert result["trends"] == {}
+        assert result["total_activities"] == 0
+
+    def test_generate_calculates_trends(self) -> None:
+        """Mock 4 weeks with improving pace -> trends.pace_change < 0."""
+        worker = ProgressReportWorker()
+        activities = _make_4_weeks_activities()
+
+        result = worker.generate(
+            activities,
+            start_date="2025-10-01",
+            end_date="2025-10-31",
+        )
+
+        trends = result["trends"]
+        # Activities have decreasing pace values (improving)
+        assert "pace_change" in trends
+        assert (
+            trends["pace_change"] < 0
+        ), f"Expected pace improvement (negative change), got {trends['pace_change']}"
+
+    def test_aggregate_weekly_grouping(self) -> None:
+        """14 days of activities -> 2 weeks correctly grouped."""
+        worker = ProgressReportWorker()
+        activities = [
+            # Week 1 (2025-10-06 Mon ~ 2025-10-12 Sun, ISO week 41)
+            _make_activity("2025-10-06", 5.0),
+            _make_activity("2025-10-08", 7.0),
+            _make_activity("2025-10-10", 10.0),
+            # Week 2 (2025-10-13 Mon ~ 2025-10-19 Sun, ISO week 42)
+            _make_activity("2025-10-13", 6.0),
+            _make_activity("2025-10-15", 8.0),
+        ]
+
+        weeks = worker._aggregate_weekly(activities)
+
+        assert len(weeks) == 2
+        assert weeks[0]["run_count"] == 3
+        assert weeks[1]["run_count"] == 2
+        assert weeks[0]["label"] == "W1"
+        assert weeks[1]["label"] == "W2"
+
+    def test_aggregate_weekly_metrics(self) -> None:
+        """1 week with 3 runs (6:30, 6:40, 6:50/km) -> accurate avg pace."""
+        worker = ProgressReportWorker()
+        # All same distance for simple average
+        activities = [
+            _make_activity("2025-10-06", 7.0, 390.0),  # 6:30/km
+            _make_activity("2025-10-08", 7.0, 400.0),  # 6:40/km
+            _make_activity("2025-10-10", 7.0, 410.0),  # 6:50/km
+        ]
+
+        weeks = worker._aggregate_weekly(activities)
+
+        assert len(weeks) == 1
+        # Equal distances -> simple average: (390+400+410)/3 = 400.0
+        assert weeks[0]["avg_pace_seconds_per_km"] == 400.0
+        assert weeks[0]["avg_pace_formatted"] == "6:40/km"
+        assert weeks[0]["total_distance_km"] == 21.0
+
+    def test_format_pace_static(self) -> None:
+        """Static method formats pace correctly."""
+        assert ProgressReportWorker._format_pace(400.0) == "6:40/km"
+        assert ProgressReportWorker._format_pace(330.0) == "5:30/km"
+        assert ProgressReportWorker._format_pace(270.0) == "4:30/km"
+
+    def test_render_produces_markdown(self) -> None:
+        """Render produces markdown with table and trends."""
+        worker = ProgressReportWorker()
+        activities = _make_4_weeks_activities()
+
+        markdown = worker.render(
+            activities,
+            start_date="2025-10-01",
+            end_date="2025-10-31",
+        )
+
+        assert "プログレスレポート" in markdown
+        assert "W1" in markdown
+        assert "W4" in markdown
+        assert "トレンド" in markdown
+        assert "平均ペース" in markdown
+
+    def test_render_empty_activities(self) -> None:
+        """Render with no activities produces empty-state message."""
+        worker = ProgressReportWorker()
+
+        markdown = worker.render(
+            activities=[],
+            start_date="2025-10-01",
+            end_date="2025-10-31",
+        )
+
+        assert "アクティビティがありません" in markdown
+
+    def test_single_week_no_trends(self) -> None:
+        """Single week produces no trends (need at least 2 weeks)."""
+        worker = ProgressReportWorker()
+        activities = [
+            _make_activity("2025-10-06", 7.0),
+            _make_activity("2025-10-08", 10.0),
+        ]
+
+        result = worker.generate(
+            activities,
+            start_date="2025-10-06",
+            end_date="2025-10-12",
+        )
+
+        assert len(result["weeks"]) == 1
+        assert result["trends"] == {}
+
+    def test_weighted_average_pace(self) -> None:
+        """Pace is weighted by distance, not simple average."""
+        worker = ProgressReportWorker()
+        activities = [
+            # Short run at fast pace
+            _make_activity("2025-10-06", 3.0, 300.0),  # 5:00/km, 3km
+            # Long run at slow pace
+            _make_activity("2025-10-08", 12.0, 420.0),  # 7:00/km, 12km
+        ]
+
+        weeks = worker._aggregate_weekly(activities)
+
+        # Weighted: (300*3 + 420*12) / (3+12) = (900+5040)/15 = 396.0
+        assert weeks[0]["avg_pace_seconds_per_km"] == 396.0
+
+    def test_none_metrics_handled(self) -> None:
+        """Activities with None metrics don't cause errors."""
+        worker = ProgressReportWorker()
+        activities = [
+            _make_activity(
+                "2025-10-06",
+                avg_hr=None,
+                zone2_pct=None,
+                form_score=None,
+                cadence=None,
+            ),
+            _make_activity(
+                "2025-10-08",
+                avg_hr=None,
+                zone2_pct=None,
+                form_score=None,
+                cadence=None,
+            ),
+        ]
+
+        result = worker.generate(
+            activities,
+            start_date="2025-10-06",
+            end_date="2025-10-12",
+        )
+
+        week = result["weeks"][0]
+        assert week["avg_hr"] is None
+        assert week["avg_zone2_pct"] is None
+        assert week["avg_form_score"] is None


### PR DESCRIPTION
## Summary
- Add `ProgressReportWorker` class that aggregates activities by ISO week with distance-weighted pace averages, Zone 2%, form scores, and HR trends
- Add Jinja2 template (`progress_report.j2`) rendering markdown tables with trend analysis
- Add `/progress-report` command for generating reports from date ranges
- 11 unit tests covering structure, empty data, trends, grouping, weighted averages, and edge cases

## Test plan
- [x] `test_generate_weekly_report_structure` -- 4 weeks data produces 4-week report
- [x] `test_generate_with_empty_period` -- 0 activities returns empty report without error
- [x] `test_generate_calculates_trends` -- improving pace yields negative pace_change
- [x] `test_aggregate_weekly_grouping` -- 14 days correctly grouped into 2 ISO weeks
- [x] `test_aggregate_weekly_metrics` -- 3 equal-distance runs produce correct average pace
- [x] `test_format_pace_static` -- pace formatting M:SS/km
- [x] `test_render_produces_markdown` -- full markdown output with table and trends
- [x] `test_render_empty_activities` -- empty state message rendered
- [x] `test_single_week_no_trends` -- single week produces no trends
- [x] `test_weighted_average_pace` -- distance-weighted pace calculation
- [x] `test_none_metrics_handled` -- None values handled gracefully

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)