### PR TITLE
docs: add L1/L2/L3 validation levels to worktree protocol

### DIFF
--- a/.claude/rules/e2e-verification.md
+++ b/.claude/rules/e2e-verification.md
@@ -1,6 +1,23 @@
 # E2E Verification Rules
 
-## 検証基準
+## Validation Level ガイドライン
+
+計画時（Issue Design 作成時）に以下の表を参照し、変更対象に応じた検証レベルを決定する。
+
+| 変更対象 | Level | 理由 |
+|----------|-------|------|
+| `.claude/agents/*-analyst.md` | L3 | 分析品質に直結 |
+| `src/garmin_mcp/handlers/` | L1 | MCP tool の入出力確認で十分 |
+| `src/garmin_mcp/database/readers/` | L1 | 同上 |
+| `src/garmin_mcp/reporting/` | L2 | report pipeline は integration test でカバー |
+| `src/garmin_mcp/ingest/` | L2 | DB 構造変更は integration test |
+| `database/migrations/` | L2 | スキーマ変更 |
+| `.claude/rules/`, `docs/`, `CLAUDE.md` | skip | コード変更なし |
+
+**複数カテゴリにまたがる場合**: 最も高いレベルを採用する。
+**判断に迷う場合**: L2 を選択する。L3 は agent 定義変更時のみ。
+
+## L3 検証基準
 
 ### 構造チェック（FAIL = 致命的）
 
@@ -13,10 +30,6 @@
 - ペース値が fixture と整合（5:15-5:45/km 範囲の activity に対して 3:00/km 等の異常値がないか）
 - HR 値が fixture と整合（130-165 bpm 範囲）
 - セクション間で矛盾がないか（efficiency が「優秀」なのに summary が「要改善」等）
-
-### スキップ条件
-
-分析エージェント (`.claude/agents/*-analyst.md`)、Handler (`src/garmin_mcp/handlers/`)、Reader (`src/garmin_mcp/database/readers/`)、Report (`src/garmin_mcp/reporting/`) のいずれにも変更がない場合はスキップ。
 
 ## Verification Activity
 

--- a/.claude/rules/project-workflow.md
+++ b/.claude/rules/project-workflow.md
@@ -22,6 +22,12 @@ Type: Implementation | Roadmap
 | **Implementation** | 具体的なコード変更プラン |
 | **Roadmap** | 優先度付き改善提案リスト |
 
+Issue Design セクションに以下を必須で含める:
+```
+Validation Level: L1|L2|L3|skip
+```
+`e2e-verification.md` のガイドラインを参照してレベルを決定する。
+
 ### Plan 承認後の自動遷移ルール
 
 **実行順序（スキップ禁止）:**
@@ -41,7 +47,8 @@ Type: Implementation | Roadmap
 
 | Gate | Timing | Who | Criteria |
 |------|--------|-----|----------|
-| Design | Issue 作成時 | User (/decompose で確認) | Design セクション完備 |
+| Design | Issue 作成時 | User (/decompose で確認) | Design セクション完備 + Validation Level 明記 |
 | Test Plan | テスト追加後 | CI + レビュー | テストが Design をカバー |
 | Code | PR ready 後 | User + CI | CI pass + diff 確認 |
+| Validation | PR ready 後 | Validation Agent | `validation_level` に応じた検証 pass |
 | Merge | /ship --pr | User | 全チェック green |

--- a/.claude/rules/worktree-validation-protocol.md
+++ b/.claude/rules/worktree-validation-protocol.md
@@ -1,0 +1,126 @@
+# Worktree Validation Protocol
+
+## Overview
+
+並行 worktree 実装エージェントの検証を FIFO キューで逐次処理する。
+MCP server は単一プロセスのため、検証は直列実行が必須。
+
+## Architecture
+
+```
+Main Session (queue manager — 検証作業はしない)
+│
+├─ Implementation Agent A (background, worktree) ──完了──┐
+├─ Implementation Agent B (background, worktree) ──完了──┤
+└─ Implementation Agent C (background, worktree) ──完了──┘
+                                                         │
+                                          FIFO 順 ◄──────┘
+                  Validation Agent #1 (foreground) → A 検証
+                  Validation Agent #2 (foreground) → B 検証
+                  Validation Agent #3 (foreground) → C 検証
+```
+
+## Validation Levels
+
+| Level | 名称 | 内容 | コスト |
+|-------|------|------|--------|
+| L1 | MCP check | reload_server → MCP tool 呼び出し → 値の妥当性 | ~20K tokens |
+| L2 | Integration | L1 + worktree 内で `uv run pytest -m integration` | ~30K tokens |
+| L3 | Full E2E | `/analyze-activity` を worktree 上で実行 + 検証基準チェック | ~150K tokens |
+
+計画時に `e2e-verification.md` のガイドラインを参照してレベルを決定する。
+
+## Implementation Agent の責務
+
+1. Worktree で実装 + unit/integration テスト pass
+2. Validation manifest を書き出し:
+   ```
+   /tmp/validation_queue/<branch-name>.json
+   ```
+   ```json
+   {
+     "branch": "feature/xxx",
+     "worktree_path": "/absolute/path/to/worktree",
+     "server_dir": "/absolute/path/to/worktree/packages/garmin-mcp-server",
+     "pr_number": 123,
+     "issue_number": 72,
+     "validation_level": "L1|L2|L3",
+     "change_category": "handler|reader|agent|reporting|ingest|schema|other",
+     "changed_files": ["src/garmin_mcp/handlers/foo.py"],
+     "test_results": {"unit": "pass", "integration": "pass"},
+     "verification_activity_id": 12345678901
+   }
+   ```
+3. PR 作成 (draft)
+
+## Main Session の責務 (Queue Manager)
+
+- 完了通知を受信したら Validation Agent を **foreground** で起動（毎回新規）
+- Validation Agent の結果に応じて:
+  - **pass**: PR を ready にする / `/ship` 候補としてユーザーに報告
+  - **fail**: PR にコメント追記、修正指示
+- 検証作業は一切しない（委譲のみ）
+
+## Validation Agent の責務
+
+毎回独立起動。前回の検証コンテキストは持たない。
+manifest の `validation_level` に応じた手順を実行する。
+
+### L1: MCP Check
+
+1. Manifest 読み込み (`/tmp/validation_queue/<branch>.json`)
+2. `mcp__garmin-db__reload_server(server_dir=worktree_server_dir)` で worktree に切替
+3. Health check: `mcp__garmin-db__get_server_info()` で server_dir が worktree を指すことを確認
+4. `changed_files` から影響を受ける MCP tool を特定し、`verification_activity_id` で呼び出す
+5. 結果の妥当性チェック:
+   - 返却値が非 null
+   - 期待される型・構造と一致
+   - 値が妥当な範囲内（ペース 3:00-9:00/km、HR 80-200 bpm 等）
+6. `mcp__garmin-db__reload_server()` で main 復帰
+7. pass/fail + 詳細を返却
+8. Manifest ファイルを削除
+
+### L2: Integration
+
+1-3. L1 と同じ（reload_server + health check）
+4. L1 の MCP check を実行（上記 4-5）
+5. Worktree ディレクトリで integration テスト実行:
+   ```bash
+   cd {worktree_path} && uv run pytest -m integration --tb=short -q
+   ```
+6. テスト結果の判定:
+   - 全 pass → L2 pass
+   - 失敗あり → 失敗テスト名とエラー内容を記録、L2 fail
+7. `mcp__garmin-db__reload_server()` で main 復帰
+8. pass/fail + 詳細を返却
+9. Manifest ファイルを削除
+
+### L3: Full E2E
+
+1-3. L1 と同じ（reload_server + health check）
+4. `/analyze-activity {fixture_date}` を実行（analyze-activity.md が Single Source of Truth）
+   - fixture_date: `e2e-verification.md` の Verification Activity を使用
+5. `e2e-verification.md` の検証基準でチェック:
+   - **構造チェック**: 5 セクションの `analysis_data` が非 null、必須フィールド存在
+   - **内容チェック**: ペース・HR 値が fixture 範囲と整合、セクション間矛盾なし
+6. `mcp__garmin-db__reload_server()` で main 復帰
+7. pass/fail + 詳細を返却
+8. Manifest ファイルを削除
+
+### 判定基準
+
+- **構造チェック失敗**: FAIL（致命的）— PR にブロッキングコメント
+- **内容チェック失敗**: WARNING — PR にコメント記載、マージ判断はユーザーに委ねる
+- **テスト失敗 (L2)**: FAIL — 失敗テストの詳細を PR コメントに記載
+
+## Skip 条件
+
+`validation_level` 未指定かつ変更が `.claude/rules/`, `docs/`, `CLAUDE.md` のみの場合、検証スキップ。
+
+## Manifest ディレクトリ
+
+```bash
+mkdir -p /tmp/validation_queue
+```
+
+検証完了後、manifest ファイルは Validation Agent が削除する。


### PR DESCRIPTION
## Summary
- Define 3 validation levels (L1/L2/L3) for worktree E2E verification
- Add validation level guidelines per change category to `e2e-verification.md`
- Add Validation gate to `project-workflow.md` review gates
- Add `validation_level` field to manifest schema

Part of #53 P2 (worktree E2E 検証自律化)

## Test plan
- [ ] Rule files load correctly (no syntax errors)
- [ ] Validation level guidelines are referenced during planning
- [ ] #72 re-implementation uses L2 validation successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)