### PR TITLE
refactor: redesign dev rules for autonomous agent workflow

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -127,7 +127,7 @@ If `--close` is specified, or PR body contains `Closes #N`:
         # - YYYY-MM-DD (Ship): Closed via /ship
         printf '%s' "$NEW_BODY" | gh issue edit {number} --body-file -
         ```
-      - If `gh issue edit` fails → warn and proceed (best-effort, see `.claude/rules/dev/dev-standards.md`)
+      - If `gh issue edit` fails → warn and proceed (best-effort, see `.claude/rules/dev/dev-reference.md`)
 
    b. **Close the Issue**:
       ```bash

--- a/.claude/rules/dev/dev-reference.md
+++ b/.claude/rules/dev/dev-reference.md
@@ -1,6 +1,6 @@
-# Development Standards
+# Development Reference
 
-Consolidated reference for all dev rules. `workflow-orchestration.md` is the primary orchestration guide.
+参照用辞書。手続き的ワークフローは `implementation-workflow.md` を参照。
 
 ## 1. Project Workflow
 

--- a/.claude/rules/dev/implementation-workflow.md
+++ b/.claude/rules/dev/implementation-workflow.md
@@ -1,0 +1,46 @@
+# Implementation Workflow
+
+プラン承認後のフロー。各ステップの完了条件を満たさないと次に進めない。
+
+## Phase 1: Delegate (実装委任)
+
+サブエージェント(general-purpose, worktree isolation)に以下を含めて委任:
+- プランの実装手順（そのまま渡す）
+- テスト実行指示: `uv run pytest {test_path} -m unit -v`
+- lint 実行指示: `uv run ruff check {changed_files}`
+- commit 指示: ブランチ名、コミットメッセージ形式
+- **push しない**指示
+
+## Phase 2: Verify (独立検証)
+
+サブエージェント完了後、オーケストレーターが**自分で**以下を実行:
+
+### 2a. コードレビュー
+- worktree の全変更ファイルを Read で読む（diff ではなく全文）
+- プランの各ステップと照合:
+  - [ ] 新規ファイル: クラス名、メソッドシグネチャ、出力形式がプランと一致
+  - [ ] 変更ファイル: 変更箇所がプランの指定位置と一致
+  - [ ] テスト: プランのテスト名が全て存在
+
+### 2b. テスト実行
+プランの Validation Level に応じて（`dev-reference.md` §3 参照）:
+
+| Level | 実行内容 | 完了条件 |
+|-------|---------|---------|
+| L1 | `uv run pytest {test_path} -m unit -v` | 0 failures |
+| L2 | L1 + `uv run pytest -m integration --tb=short -q` | 0 failures |
+| L3 | L2 + `cd analysis/ && claude -p "/analyze-activity 2025-10-09"` | 該当セクション出力あり |
+
+**CRITICAL**: テスト結果は自分のターンで確認する。サブエージェントの報告を信じない。
+
+### 2c. 判定
+- 全チェック通過 → Phase 3 へ
+- 失敗あり → サブエージェントを resume して修正指示、再度 Phase 2
+
+## Phase 3: Ship (PR作成)
+
+Phase 2 完了後のみ実行可能:
+1. worktree ブランチを main repo に fetch
+2. remote に push
+3. `gh pr create` (Closes #{issue})
+4. ユーザーに PR URL を報告

--- a/.claude/rules/dev/workflow-orchestration.md
+++ b/.claude/rules/dev/workflow-orchestration.md
@@ -5,13 +5,9 @@
 - If execution goes sideways: STOP and re-plan. Don't push through with workarounds.
 - Use plan mode for verification steps, not just building
 
-## Subagent Delegation
-- **実装もエージェントに委任する** — 手動実装よりエージェント委任を常に優先
-- 単一 issue: general-purpose agent (worktree isolation) に実装を委任
-- 複数 sub-issue: `/implement` で並列エージェント実行
-- Research/exploration: Explore agent で調査、main context を軽く保つ
-- One focused task per subagent.
-- Complex problems: throw more compute at it via parallel subagents.
+## Implementation
+- プラン承認後は `implementation-workflow.md` に従って実行する
+- 委任・検証・Ship の手順はすべてそちらに定義
 
 ## Self-Improvement Loop
 - After ANY user correction: append to `.claude/tasks/lessons.md`
@@ -19,11 +15,6 @@
 - Write rules in `.claude/rules/` that prevent the same mistake from recurring
 - Ruthlessly iterate until mistake rate drops
 - セッション開始時: lessons.md を確認し、関連する過去の教訓を意識する
-
-## Completion Verification
-- Never mark complete without proof: passing tests, log output, or demonstration.
-- Diff behavior between main and changes when relevant.
-- Self-check: "Would a staff engineer approve this?"
 
 ## Elegance Check
 - 3+ files changed or new pattern introduced: pause and consider alternatives.

--- a/.claude/rules/intent-disambiguation.md
+++ b/.claude/rules/intent-disambiguation.md
@@ -14,7 +14,7 @@
 - **Issue 番号なし**: → `Issue: TBD` でプラン作成 → 承認後に Issue 作成
 - **分解が必要** (複数の独立した作業単位): → プラン内で `/decompose` を推奨
 
-詳細は `.claude/rules/dev/dev-standards.md` を参照。
+詳細は `.claude/rules/dev/dev-reference.md` を参照。
 
 ### User Preference Adoption
 - ユーザーが特定のアプローチを指示したら、代替案を提示せず即座に採用する

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,8 +85,9 @@ See `.claude/rules/analysis/analysis-standards.md` for workflow details and `doc
 **Workflow:** Plan mode → Issue → Worktree → Implement → Ship
 
 Key rules (auto-loaded from `.claude/rules/dev/`):
-- `workflow-orchestration.md` — plan-first, subagent delegation, verification, elegance check
-- `dev-standards.md` — git, testing, code quality, architecture, validation (consolidated)
+- `workflow-orchestration.md` — plan-first, elegance check, core principles
+- `implementation-workflow.md` — delegate → verify → ship (手続き的ワークフロー)
+- `dev-reference.md` — git, testing, code quality, architecture, validation (参照辞書)
 
 ### Analysis Workspace (検証用)
 


### PR DESCRIPTION
## Summary

- **New** `implementation-workflow.md`: 手続き的ワークフロー（Delegate → Verify → Ship）を定義。サブエージェント委任後の独立検証フェーズを明示
- **Renamed** `dev-standards.md` → `dev-reference.md`: 参照辞書として位置付けを明確化
- **Updated** `workflow-orchestration.md`: Subagent Delegation / Completion Verification セクションを `implementation-workflow.md` に移行

### 問題と解決
設計承認後の「実装→検証→PR」が自律的に回らなかった原因:
1. 委任後に何をすべきかがルールに空白だった → Phase 2 (Verify) で明示
2. Validation Level の実行タイミングが不明だった → ワークフローにゲートとして組み込み
3. サブエージェントの自己申告を信じていた → 「自分のターンで確認」をCRITICALルール化

## Test plan
- [ ] ルール間の参照が全て有効（壊れたリンクなし）
- [ ] `dev-standards.md` への参照がmainファイルから消えていること
- [ ] 新ルールの Phase 2 チェックリストが実運用で機能すること（次回の実装タスクで検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)