### PR TITLE
feat: add GoalProgressTracker for race goal progress

### DIFF
--- a/.claude/agents/summary-section-analyst.md
+++ b/.claude/agents/summary-section-analyst.md
@@ -344,7 +344,40 @@ Write(
 
    **データ不足時:** `"next_run_target": {"insufficient_data": true, "summary_ja": "...理由..."}`
 
-8. **recommendations**: 改善提案（構造化マークダウン、**最大2件**）
+8. **goal_progress**: レース目標への進捗（dict、**条件付き**）
+
+   アクティブなトレーニングプランにレース目標がある場合のみ出力。fitness/return_to_run プランの場合は省略。
+
+   **算出手順:**
+   - `get_training_plan()` からプランデータを取得（事前取得コンテキストにない場合）
+   - `get_vo2_max_data(activity_id)` から VO2max を取得（事前取得コンテキストにない場合）
+   - `GoalProgressTracker` を使って進捗を計算
+
+   ```json
+   "goal_progress": {
+     "goal_type": "race_10k",
+     "goal_type_ja": "10K目標",
+     "race_distance_km": 10.0,
+     "goal_time_seconds": 2580,
+     "goal_time_formatted": "43:00",
+     "predicted_time_seconds": 2625,
+     "predicted_time_formatted": "43:45",
+     "gap_seconds": -45,
+     "gap_formatted": "-45秒",
+     "pace_gap_per_km": 4.5,
+     "pace_gap_formatted": "あと5秒/km改善が必要",
+     "current_vdot": 47.2,
+     "weeks_remaining": 8,
+     "status": "behind"
+   }
+   ```
+
+   **null ハンドリング:**
+   - トレーニングプランなし → `goal_progress` フィールドを出力しない
+   - goal_type が "fitness" or "return_to_run" で始まる → 出力しない
+   - VO2max データなし → 出力しない
+
+9. **recommendations**: 改善提案（構造化マークダウン、**最大2件**）
 
    **MANDATORY FORMAT - 以下の構造を厳密に守ること:**
 

--- a/packages/garmin-mcp-server/src/garmin_mcp/reporting/components/__init__.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/reporting/components/__init__.py
@@ -8,6 +8,7 @@ from garmin_mcp.reporting.components.formatting import (
     get_activity_type_display,
     get_training_type_category,
 )
+from garmin_mcp.reporting.components.goal_progress_tracker import GoalProgressTracker
 from garmin_mcp.reporting.components.insight_generator import InsightGenerator
 from garmin_mcp.reporting.components.next_run_calculator import NextRunCalculator
 from garmin_mcp.reporting.components.physiological_calculator import (
@@ -17,6 +18,7 @@ from garmin_mcp.reporting.components.workout_comparator import WorkoutComparator
 
 __all__ = [
     "ChartGenerator",
+    "GoalProgressTracker",
     "InsightGenerator",
     "NextRunCalculator",
     "PhysiologicalCalculator",

--- a/packages/garmin-mcp-server/src/garmin_mcp/reporting/components/goal_progress_tracker.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/reporting/components/goal_progress_tracker.py
@@ -1,0 +1,164 @@
+"""Track progress toward race goals using VDOT predictions."""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+from garmin_mcp.training_plan.vdot import VDOTCalculator
+
+DISTANCE_MAP: dict[str, float] = {
+    "race_5k": 5.0,
+    "5k": 5.0,
+    "race_10k": 10.0,
+    "10k": 10.0,
+    "race_half": 21.0975,
+    "half": 21.0975,
+    "race_full": 42.195,
+    "full": 42.195,
+}
+
+GOAL_TYPE_JA: dict[str, str] = {
+    "race_5k": "5K目標",
+    "race_10k": "10K目標",
+    "race_half": "ハーフ目標",
+    "race_full": "フル目標",
+}
+
+
+def _format_time(seconds: int) -> str:
+    """Format seconds to human-readable time string."""
+    h, remainder = divmod(seconds, 3600)
+    m, s = divmod(remainder, 60)
+    if h > 0:
+        return f"{h}:{m:02d}:{s:02d}"
+    return f"{m}:{s:02d}"
+
+
+class GoalProgressTracker:
+    """Track progress toward race goals using VDOT predictions."""
+
+    def get_active_plan_goal(
+        self, plan_data: dict[str, Any] | None
+    ) -> dict[str, Any] | None:
+        """Get goal from active training plan data.
+
+        Extract goal_type, target_time_seconds, target_race_date from plan_data.
+        Return None if plan_data is None, or if goal_type starts with
+        'fitness' or 'return_to_run'.
+        """
+        if plan_data is None:
+            return None
+
+        goal_type = plan_data.get("goal_type", "")
+        if not goal_type:
+            return None
+
+        if goal_type.startswith("fitness") or goal_type.startswith("return_to_run"):
+            return None
+
+        target_time_seconds = plan_data.get("target_time_seconds")
+        if target_time_seconds is None:
+            return None
+
+        result: dict[str, Any] = {
+            "goal_type": goal_type,
+            "target_time_seconds": int(target_time_seconds),
+        }
+
+        target_race_date = plan_data.get("target_race_date")
+        if target_race_date is not None:
+            result["target_race_date"] = str(target_race_date)
+
+        return result
+
+    def predict_race_time(self, vdot: float, distance: str) -> int:
+        """Predict race time from current VDOT. Returns seconds.
+
+        Uses VDOTCalculator to predict race time for the given distance.
+        """
+        distance_km = DISTANCE_MAP.get(distance)
+        if distance_km is None:
+            raise ValueError(
+                f"Unknown distance: {distance}. "
+                f"Supported: {', '.join(DISTANCE_MAP.keys())}"
+            )
+
+        return VDOTCalculator.predict_race_time(vdot, distance_km)
+
+    def calculate_progress(
+        self, goal: dict[str, Any] | None, current_vdot: float
+    ) -> dict[str, Any] | None:
+        """Calculate gap between predicted and goal time.
+
+        Returns None if goal is None.
+        """
+        if goal is None:
+            return None
+
+        goal_type = goal["goal_type"]
+        goal_time_seconds = goal["target_time_seconds"]
+
+        # Resolve distance
+        distance_km = DISTANCE_MAP.get(goal_type)
+        if distance_km is None:
+            return None
+
+        predicted_time_seconds = VDOTCalculator.predict_race_time(
+            current_vdot, distance_km
+        )
+
+        gap_seconds = predicted_time_seconds - goal_time_seconds
+
+        # Determine status
+        if gap_seconds <= 0:
+            status = "ahead"
+        elif gap_seconds <= 30:
+            status = "on_track"
+        else:
+            status = "behind"
+
+        # Format gap
+        if gap_seconds <= 0:
+            gap_formatted = f"+{abs(gap_seconds)}秒余裕"
+        else:
+            gap_formatted = f"-{gap_seconds}秒"
+
+        # Pace gap per km
+        pace_gap_per_km = gap_seconds / distance_km
+        if gap_seconds > 0:
+            pace_gap_formatted = f"あと{pace_gap_per_km:.0f}秒/km改善が必要"
+        else:
+            pace_gap_formatted = f"{abs(pace_gap_per_km):.0f}秒/km余裕あり"
+
+        # Weeks remaining
+        weeks_remaining: int | None = None
+        target_race_date = goal.get("target_race_date")
+        if target_race_date is not None:
+            try:
+                race_date = datetime.date.fromisoformat(str(target_race_date))
+                today = datetime.date.today()
+                days_remaining = (race_date - today).days
+                weeks_remaining = max(0, days_remaining // 7)
+            except (ValueError, TypeError):
+                weeks_remaining = None
+
+        # Goal type Japanese label
+        goal_type_ja = GOAL_TYPE_JA.get(goal_type, goal_type)
+
+        return {
+            "goal_type": goal_type,
+            "goal_type_ja": goal_type_ja,
+            "race_distance_km": distance_km,
+            "goal_time_seconds": goal_time_seconds,
+            "goal_time_formatted": _format_time(goal_time_seconds),
+            "predicted_time_seconds": predicted_time_seconds,
+            "predicted_time_formatted": _format_time(predicted_time_seconds),
+            "gap_seconds": -gap_seconds if gap_seconds > 0 else abs(gap_seconds),
+            "gap_formatted": gap_formatted,
+            "pace_gap_per_km": pace_gap_per_km,
+            "pace_gap_formatted": pace_gap_formatted,
+            "current_vdot": current_vdot,
+            "weeks_remaining": weeks_remaining,
+            "status": status,
+        }

--- a/packages/garmin-mcp-server/src/garmin_mcp/reporting/templates/detailed_report.j2
+++ b/packages/garmin-mcp-server/src/garmin_mcp/reporting/templates/detailed_report.j2
@@ -396,6 +396,20 @@ VO2 Maxデータがありません。
 ---
 
 {# =================================================================== #}
+{# Goal Progress (optional) #}
+{# =================================================================== #}
+{% if summary and summary.goal_progress %}
+## 🎯 ゴール進捗
+
+{{ summary.goal_progress.goal_type_ja }}: {{ summary.goal_progress.goal_time_formatted }}{% if summary.goal_progress.weeks_remaining is not none %} (残り{{ summary.goal_progress.weeks_remaining }}週間){% endif %}
+
+現在の予測: {{ summary.goal_progress.predicted_time_formatted }} (VDOT {{ summary.goal_progress.current_vdot }})
+ギャップ: {{ summary.goal_progress.gap_formatted }} → {{ summary.goal_progress.pace_gap_formatted }}
+
+---
+
+{% endif %}
+{# =================================================================== #}
 {# SECTION 8 (or 7 or 6): 💡 改善ポイント #}
 {# =================================================================== #}
 ## 💡 改善ポイント

--- a/packages/garmin-mcp-server/tests/reporting/components/test_goal_progress_tracker.py
+++ b/packages/garmin-mcp-server/tests/reporting/components/test_goal_progress_tracker.py
@@ -1,0 +1,266 @@
+"""Tests for GoalProgressTracker - race goal progress tracking."""
+
+import pytest
+
+from garmin_mcp.reporting.components.goal_progress_tracker import GoalProgressTracker
+
+
+@pytest.mark.unit
+class TestPredictRaceTime:
+    """Test race time prediction from VDOT."""
+
+    def setup_method(self) -> None:
+        self.tracker = GoalProgressTracker()
+
+    def test_predict_5k_from_vdot(self) -> None:
+        """vdot=48.2 should predict a reasonable 5K time (~20:30)."""
+        result = self.tracker.predict_race_time(48.2, "race_5k")
+        # VDOT 48.2 predicts ~1234s (20:34) per Daniels' formula
+        assert 1200 <= result <= 1300
+
+    def test_predict_10k_from_vdot(self) -> None:
+        """vdot=48.2 should predict a reasonable 10K time (~42:39)."""
+        result = self.tracker.predict_race_time(48.2, "race_10k")
+        # VDOT 48.2 predicts ~2559s (42:39) per Daniels' formula
+        assert 2500 <= result <= 2650
+
+    def test_predict_half_from_vdot(self) -> None:
+        """vdot=48.2 should predict a reasonable Half time (~1:34:28)."""
+        result = self.tracker.predict_race_time(48.2, "race_half")
+        # VDOT 48.2 predicts ~5668s (1:34:28) per Daniels' formula
+        assert 5600 <= result <= 5800
+
+    def test_predict_full_from_vdot(self) -> None:
+        """vdot=48.2 should predict a reasonable Full time (~3:16:38)."""
+        result = self.tracker.predict_race_time(48.2, "race_full")
+        # VDOT 48.2 predicts ~11798s (3:16:38) per Daniels' formula
+        assert 11700 <= result <= 11900
+
+    def test_predict_short_form_distance(self) -> None:
+        """Short form distance strings should also work."""
+        result_short = self.tracker.predict_race_time(48.2, "5k")
+        result_long = self.tracker.predict_race_time(48.2, "race_5k")
+        assert result_short == result_long
+
+    def test_predict_unknown_distance_raises(self) -> None:
+        """Unknown distance should raise ValueError."""
+        with pytest.raises(ValueError, match="Unknown distance"):
+            self.tracker.predict_race_time(48.2, "race_3k")
+
+
+@pytest.mark.unit
+class TestGetActiveGoal:
+    """Test goal extraction from plan data."""
+
+    def setup_method(self) -> None:
+        self.tracker = GoalProgressTracker()
+
+    def test_get_goal_from_plan(self) -> None:
+        """Plan with goal_type='race_10k' and target_time should return goal dict."""
+        plan_data = {
+            "goal_type": "race_10k",
+            "target_time_seconds": 2580,
+            "target_race_date": "2026-06-15",
+        }
+        result = self.tracker.get_active_plan_goal(plan_data)
+
+        assert result is not None
+        assert result["goal_type"] == "race_10k"
+        assert result["target_time_seconds"] == 2580
+        assert result["target_race_date"] == "2026-06-15"
+
+    def test_get_goal_no_plan(self) -> None:
+        """None plan data should return None."""
+        result = self.tracker.get_active_plan_goal(None)
+        assert result is None
+
+    def test_get_goal_fitness_plan(self) -> None:
+        """Fitness plan should return None."""
+        plan_data = {
+            "goal_type": "fitness_improvement",
+            "target_time_seconds": 2580,
+        }
+        result = self.tracker.get_active_plan_goal(plan_data)
+        assert result is None
+
+    def test_get_goal_return_to_run_plan(self) -> None:
+        """Return-to-run plan should return None."""
+        plan_data = {
+            "goal_type": "return_to_run",
+            "target_time_seconds": 2580,
+        }
+        result = self.tracker.get_active_plan_goal(plan_data)
+        assert result is None
+
+    def test_get_goal_no_target_time(self) -> None:
+        """Plan without target_time_seconds should return None."""
+        plan_data = {
+            "goal_type": "race_10k",
+        }
+        result = self.tracker.get_active_plan_goal(plan_data)
+        assert result is None
+
+    def test_get_goal_empty_goal_type(self) -> None:
+        """Plan with empty goal_type should return None."""
+        plan_data = {
+            "goal_type": "",
+            "target_time_seconds": 2580,
+        }
+        result = self.tracker.get_active_plan_goal(plan_data)
+        assert result is None
+
+
+@pytest.mark.unit
+class TestCalculateProgress:
+    """Test progress calculation."""
+
+    def setup_method(self) -> None:
+        self.tracker = GoalProgressTracker()
+
+    def test_progress_with_active_plan(self) -> None:
+        """goal_time=2580 (43:00), predicted=2625 (43:45) -> gap=-45s."""
+        goal = {
+            "goal_type": "race_10k",
+            "target_time_seconds": 2580,
+        }
+        # Find a VDOT that predicts ~2625s for 10K
+        # We'll use a VDOT and check the structure
+        result = self.tracker.calculate_progress(goal, current_vdot=46.0)
+
+        assert result is not None
+        assert result["goal_type"] == "race_10k"
+        assert result["goal_type_ja"] == "10K目標"
+        assert result["race_distance_km"] == 10.0
+        assert result["goal_time_seconds"] == 2580
+        assert result["goal_time_formatted"] == "43:00"
+        assert "predicted_time_seconds" in result
+        assert "predicted_time_formatted" in result
+        assert "gap_seconds" in result
+        assert "gap_formatted" in result
+        assert "pace_gap_per_km" in result
+        assert "pace_gap_formatted" in result
+        assert result["current_vdot"] == 46.0
+        assert result["status"] in ("ahead", "on_track", "behind")
+
+    def test_progress_without_active_plan(self) -> None:
+        """None goal should return None."""
+        result = self.tracker.calculate_progress(None, current_vdot=48.2)
+        assert result is None
+
+    def test_progress_ahead_of_target(self) -> None:
+        """When predicted time is faster than goal, status should be 'ahead'."""
+        goal = {
+            "goal_type": "race_5k",
+            "target_time_seconds": 1500,  # 25:00 - slow target
+        }
+        # High VDOT should easily beat this
+        result = self.tracker.calculate_progress(goal, current_vdot=50.0)
+
+        assert result is not None
+        assert result["status"] == "ahead"
+        assert "余裕" in result["gap_formatted"]
+
+    def test_progress_behind_target(self) -> None:
+        """When predicted time is slower than goal, status should be 'behind'."""
+        goal = {
+            "goal_type": "race_5k",
+            "target_time_seconds": 1000,  # 16:40 - very fast target
+        }
+        # Moderate VDOT should not beat this
+        result = self.tracker.calculate_progress(goal, current_vdot=45.0)
+
+        assert result is not None
+        assert result["status"] == "behind"
+        assert "改善が必要" in result["pace_gap_formatted"]
+
+    def test_progress_with_race_date(self) -> None:
+        """When target_race_date is set, weeks_remaining should be calculated."""
+        goal = {
+            "goal_type": "race_10k",
+            "target_time_seconds": 2700,
+            "target_race_date": "2027-06-15",  # Far future
+        }
+        result = self.tracker.calculate_progress(goal, current_vdot=48.0)
+
+        assert result is not None
+        assert result["weeks_remaining"] is not None
+        assert result["weeks_remaining"] > 0
+
+    def test_progress_without_race_date(self) -> None:
+        """When no target_race_date, weeks_remaining should be None."""
+        goal = {
+            "goal_type": "race_10k",
+            "target_time_seconds": 2700,
+        }
+        result = self.tracker.calculate_progress(goal, current_vdot=48.0)
+
+        assert result is not None
+        assert result["weeks_remaining"] is None
+
+    def test_progress_unknown_goal_type(self) -> None:
+        """Unknown goal_type should return None."""
+        goal = {
+            "goal_type": "race_3k",
+            "target_time_seconds": 600,
+        }
+        result = self.tracker.calculate_progress(goal, current_vdot=48.0)
+        assert result is None
+
+
+@pytest.mark.integration
+class TestE2EGoalProgress:
+    """End-to-end test with realistic data."""
+
+    def test_e2e_goal_progress_with_real_data(self) -> None:
+        """Full workflow: plan -> goal -> predict -> progress."""
+        tracker = GoalProgressTracker()
+
+        # Simulate realistic plan data
+        plan_data = {
+            "goal_type": "race_10k",
+            "target_time_seconds": 2700,  # 45:00
+            "target_race_date": "2027-06-01",
+        }
+
+        # Step 1: Extract goal
+        goal = tracker.get_active_plan_goal(plan_data)
+        assert goal is not None
+
+        # Step 2: Simulate VO2max -> VDOT conversion
+        from garmin_mcp.training_plan.vdot import VDOTCalculator
+
+        vo2max = 49.0
+        vdot = VDOTCalculator.vdot_from_vo2max(vo2max)
+        assert vdot > 0
+
+        # Step 3: Calculate progress
+        progress = tracker.calculate_progress(goal, current_vdot=vdot)
+        assert progress is not None
+
+        # Step 4: Verify all expected fields
+        expected_fields = [
+            "goal_type",
+            "goal_type_ja",
+            "race_distance_km",
+            "goal_time_seconds",
+            "goal_time_formatted",
+            "predicted_time_seconds",
+            "predicted_time_formatted",
+            "gap_seconds",
+            "gap_formatted",
+            "pace_gap_per_km",
+            "pace_gap_formatted",
+            "current_vdot",
+            "weeks_remaining",
+            "status",
+        ]
+        for field in expected_fields:
+            assert field in progress, f"Missing field: {field}"
+
+        # Step 5: Verify reasonable values
+        assert progress["goal_time_formatted"] == "45:00"
+        assert progress["race_distance_km"] == 10.0
+        assert progress["current_vdot"] == vdot
+        assert progress["weeks_remaining"] is not None
+        assert progress["weeks_remaining"] > 0
+        assert progress["status"] in ("ahead", "on_track", "behind")


### PR DESCRIPTION
## Summary

- **New** `GoalProgressTracker` component: VDOT-based race time prediction + goal gap calculation
- **Updated** `summary-section-analyst.md`: `goal_progress` field (#8) with calculation instructions and null handling
- **Updated** `detailed_report.j2`: Goal progress section between environment and improvement points

### How it works
1. Extract goal from active training plan (`goal_type`, `target_time_seconds`, `target_race_date`)
2. Convert VO2max → VDOT via existing `VDOTCalculator`
3. Predict race time for goal distance
4. Calculate gap (seconds + pace/km) and status (ahead/on_track/behind)

Closes #60

## Test plan
- [x] 19 unit tests passing (predict 5k/10k/half/full, goal extraction, progress calculation)
- [x] 1 integration test passing (end-to-end workflow)
- [x] Pre-commit hooks passing (black, ruff, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)