### PR TITLE
docs: add plan completeness and design-approved quality requirements

### DIFF
--- a/.claude/rules/dev/dev-reference.md
+++ b/.claude/rules/dev/dev-reference.md
@@ -5,7 +5,23 @@
 ## 1. Project Workflow
 
 - **Issue必須**: 全開発タスクで Issue 作成。Issue なし実装は禁止
-- **Plan冒頭**: `Issue: #{number} | TBD` + `Type: Implementation | Roadmap` + `Validation Level: L1|L2|L3|skip`
+- **Plan構造**（thin plan は Phase 0 でブロック）:
+  ```
+  Issue: #{number} | TBD
+  Type: Implementation | Roadmap
+  Validation Level: L1 | L2 | L3 | skip
+
+  ### Files to Create/Modify
+  - `packages/.../foo.py` -- new | modify
+
+  ### Interface
+  class FooBar:
+      def method(self, x: int) -> str: ...
+
+  ### Test Plan
+  - [ ] test_method_happy_path [unit] -- x=5 → "5"
+  - [ ] test_method_edge_case [unit] -- x=-1 → raises ValueError
+  ```
 - **Plan承認後**: Issue作成(TBD時) → Issue sync → worktree実装 or `/decompose`。再確認不要
 - **Review Gates**: Design → Test Plan → Code(CI) → Validation → Merge(`/ship --pr`)
 
@@ -13,6 +29,16 @@
 
 Issue body の Design/Test Plan は常に最新を反映。Change Log に `(Plan):`, `(Build):`, `(Done):`, `(Ship):` で追記。
 Skip: Design セクションなし、Issue番号不明、dry-run時。
+
+### design-approved 品質基準
+
+`/implement` が `design-approved` ラベルでフィルタする際の品質基準:
+- Test Plan に test_xxx 形式の関数名がある
+- 各テストに [unit|integration] マーカーがある
+- 入力値・期待値が具体的（数値 or 文字列）
+- 新規クラス/関数 → Interface にシグネチャがある
+
+満たさない → ラベルを外し、Issue コメントで補完を依頼。
 
 ## 2. Git & Branching
 

--- a/.claude/rules/dev/implementation-workflow.md
+++ b/.claude/rules/dev/implementation-workflow.md
@@ -2,10 +2,31 @@
 
 プラン承認後のフロー。各ステップの完了条件を満たさないと次に進めない。
 
+## Phase 0: Plan Completeness Check
+
+Phase 1 に進む前に、プランが以下を満たすことを確認。不足 → 補完してユーザーに再提示。
+
+必須チェックリスト:
+- [ ] Issue: #{number} | TBD + Validation Level: L1|L2|L3|skip
+- [ ] Files to Create/Modify — パスと new/modify
+- [ ] Interface — 新規クラス・関数の Python シグネチャ（既存変更のみの場合は変更メソッドのシグネチャ）
+- [ ] Test Plan — test_{name} 形式、[unit|integration] マーカー、具体的入力値と期待値
+
+thin plan の例（不足とみなす）:
+- "Unit: パワーデータありのテスト" → test_xxx 形式でない、入力値なし
+- Interface なしで新規クラス導入
+
+例外: プロンプト変更のみ（.claude/agents/, .claude/rules/）→ Interface 省略可。Test Plan は必須。
+
 ## Phase 1: Delegate (実装委任)
 
 サブエージェント(general-purpose, worktree isolation)に以下を含めて委任:
+- Issue 番号と `gh issue view` 実行指示
 - プランの実装手順（そのまま渡す）
+- 実装前確認（コードを書く前に出力させる）:
+  1. 変更対象ファイル一覧
+  2. Test Plan のテスト関数名一覧
+  3. Validation Level 確認
 - テスト実行指示: `uv run pytest {test_path} -m unit -v`
 - lint 実行指示: `uv run ruff check {changed_files}`
 - commit 指示: ブランチ名、コミットメッセージ形式


### PR DESCRIPTION
## Summary

- Phase 0 (Plan Completeness Check) を `implementation-workflow.md` に追加。Delegate 前にプランの品質（Interface, Test Plan 等）を検証
- Plan 構造フォーマットを `dev-reference.md` に明示（Files/Interface/Test Plan の必須構造）
- `design-approved` ラベルの品質基準を定義
- Phase 1 の委任プロンプトに実装前確認ステップを追加

Closes #129

## Test plan

- [x] Validation Level: skip（ルール変更のみ）
- [ ] 次回の実装タスクで Phase 0 が機能するか実運用で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)