### PR TITLE
docs: add Risks section to plan template

### DIFF
--- a/.claude/rules/dev/dev-reference.md
+++ b/.claude/rules/dev/dev-reference.md
@@ -18,6 +18,11 @@
   class FooBar:
       def method(self, x: int) -> str: ...
 
+  ### Risks
+  - [検証済] DuckDB の JSON 型は nested object をサポート (v0.9+)
+  - [未検証] Garmin API の rate limit が bulk fetch に影響する可能性
+  - [未検証] time_series_metrics の 2000 行を1クエリで返すとタイムアウトする可能性 → spike 推奨
+
   ### Test Plan
   - [ ] test_method_happy_path [unit] -- x=5 → "5"
   - [ ] test_method_edge_case [unit] -- x=-1 → raises ValueError

--- a/.claude/rules/dev/implementation-workflow.md
+++ b/.claude/rules/dev/implementation-workflow.md
@@ -18,6 +18,11 @@ thin plan の例（不足とみなす）:
 
 例外: プロンプト変更のみ（.claude/agents/, .claude/rules/）→ Interface 省略可。Test Plan は必須。
 
+Risks セクション（任意）:
+- 計画時点で不確実な技術的判断・未検証の前提があれば記載する
+- [検証済] / [未検証] タグで区別し、spike 推奨があればユーザーに判断を仰ぐ
+- リスクなしなら省略可
+
 ## Phase 1: Delegate (実装委任)
 
 サブエージェント(general-purpose, worktree isolation)に以下を含めて委任:


### PR DESCRIPTION
## Summary
- プランテンプレートに `### Risks` セクションを追加（Interface と Test Plan の間）
- `[検証済]` / `[未検証]` タグで技術的リスクの確度を明示
- `→ spike 推奨` で spike 要否の判断材料を提供
- Phase 0 に任意の Risks 記載ガイドを追加（必須チェックリストは変更なし）

Closes #133

## Test plan
- [x] dev-reference.md のテンプレート例に Risks セクションが含まれている
- [x] implementation-workflow.md の Phase 0 に Risks ガイドが追加されている
- [x] Phase 0 の必須チェックリストは変更されていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)