### PR TITLE
feat: add validate_section_json and get_analysis_contract MCP tools

### DIFF
--- a/packages/garmin-mcp-server/src/garmin_mcp/tool_schemas.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/tool_schemas.py
@@ -185,6 +185,48 @@ _ANALYSIS_TOOLS: list[dict] = [
         },
     },
     {
+        "name": "validate_section_json",
+        "description": "Validate section analysis data against Pydantic schema. Returns {valid: bool, errors: list[str]}.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "section_type": {
+                    "type": "string",
+                    "enum": [
+                        "split",
+                        "phase",
+                        "efficiency",
+                        "environment",
+                        "summary",
+                    ],
+                },
+                "analysis_data": {"type": "object"},
+            },
+            "required": ["section_type", "analysis_data"],
+        },
+    },
+    {
+        "name": "get_analysis_contract",
+        "description": "Get analysis contract for a section type (output schema, evaluation thresholds, instructions). Agents call this for up-to-date evaluation criteria.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "section_type": {
+                    "type": "string",
+                    "description": "Section type",
+                    "enum": [
+                        "split",
+                        "phase",
+                        "efficiency",
+                        "environment",
+                        "summary",
+                    ],
+                },
+            },
+            "required": ["section_type"],
+        },
+    },
+    {
         "name": "analyze_performance_trends",
         "description": "Analyze performance trends across multiple activities with filtering (Phase 3.1)",
         "inputSchema": {

--- a/packages/garmin-mcp-server/src/garmin_mcp/validation/contracts.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/validation/contracts.py
@@ -1,0 +1,303 @@
+"""Analysis contracts for centralized evaluation policies.
+
+Each section type has a contract that agents can retrieve via
+get_analysis_contract MCP tool. This centralizes changeable parameters
+(thresholds, star rating logic) in the MCP server, enabling hot-reload
+via reload_server() without agent definition changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_CONTRACTS: dict[str, dict[str, Any]] = {
+    "split": {
+        "schema_version": "1.0",
+        "section_type": "split",
+        "required_fields": {
+            "highlights": {
+                "type": "string",
+                "description": "1 sentence summary, 10-500 chars",
+            },
+            "analyses": {
+                "type": "object",
+                "description": "Keys: split_1..split_N, values: Japanese markdown per split",
+            },
+        },
+        "evaluation_policy": {
+            "hr_drift": {
+                "excellent": "<5%",
+                "normal": "5-10%",
+                "fatigue": ">10%",
+            },
+            "pace_stability": {
+                "easy": "±10 sec/km",
+                "tempo": "±5 sec/km",
+            },
+            "form_degradation_triggers": {
+                "gct": "+10ms above first-half average",
+                "vo": "+0.5cm above first-half average",
+                "vr": "+0.3% above first-half average",
+            },
+            "anomaly_thresholds": {
+                "pace_too_fast": "< 3:00/km (180 sec/km)",
+                "hr_too_high": "> 200 bpm",
+            },
+        },
+        "instructions": [
+            "Analyze every 1km split without exception",
+            "Compare first-half vs second-half metrics for drift detection",
+            "Flag measurement anomalies (pace < 3:00/km, HR > 200)",
+            "Use Japanese coaching tone with specific numbers",
+        ],
+    },
+    "phase": {
+        "schema_version": "1.0",
+        "section_type": "phase",
+        "required_fields": {
+            "warmup_evaluation": {
+                "type": "string",
+                "description": "Warmup evaluation with star rating",
+            },
+            "run_evaluation": {
+                "type": "string",
+                "description": "Main run evaluation with star rating",
+            },
+            "cooldown_evaluation": {
+                "type": "string",
+                "description": "Cooldown evaluation with star rating",
+            },
+            "recovery_evaluation": {
+                "type": "string",
+                "description": "Recovery evaluation (interval only)",
+                "optional": True,
+            },
+            "evaluation_criteria": {
+                "type": "string",
+                "description": "Evaluation basis category",
+            },
+        },
+        "evaluation_policy": {
+            "star_rating_format": "(★★★★☆ N.N/5.0)",
+            "warmup_criteria": {
+                "excellent": "Gradual HR rise to Zone 2, 10-15 min",
+                "good": "Adequate preparation, minor inconsistency",
+                "poor": "Too short (<5 min) or too intense (Zone 3+)",
+            },
+            "cooldown_criteria": {
+                "excellent": "Gradual HR descent, 5-10 min",
+                "good": "Present but brief",
+                "poor": "Absent or abrupt stop",
+            },
+        },
+        "instructions": [
+            "Evaluate each phase independently",
+            "Include star rating on its own line in parentheses",
+            "Base evaluation on training_type from prefetch context",
+        ],
+    },
+    "efficiency": {
+        "schema_version": "1.0",
+        "section_type": "efficiency",
+        "required_fields": {
+            "efficiency": {
+                "type": "string",
+                "description": "5-9 sentences: GCT/VO/VR + power + cadence + integrated_score",
+            },
+            "evaluation": {
+                "type": "string",
+                "description": "3-5 sentences: HR zone distribution + training_type",
+            },
+            "form_trend": {
+                "type": "string",
+                "description": "2-4 sentences: 1-month baseline comparison",
+            },
+        },
+        "evaluation_policy": {
+            "gct": {
+                "excellent": "220-260ms",
+                "good": "260-280ms",
+                "needs_improvement": ">280ms",
+            },
+            "vertical_oscillation": {
+                "excellent": "6-8cm",
+                "good": "8-10cm",
+                "needs_improvement": ">10cm",
+            },
+            "vertical_ratio": {
+                "ideal": "8-10%",
+                "acceptable": "7-11%",
+                "needs_improvement": ">11%",
+            },
+            "cadence": {
+                "ideal": ">=180 spm",
+                "acceptable": "175-179 spm",
+                "needs_improvement": "<175 spm",
+            },
+            "integrated_score_stars": {
+                "5_stars": "95-100",
+                "4_stars": "85-94",
+                "3_stars": "70-84",
+                "2_stars": "50-69",
+                "1_star": "<50",
+            },
+        },
+        "instructions": [
+            "Use form_evaluations MCP data as primary source",
+            "Report integrated_score with star rating",
+            "Compare baseline coefficients with 1-month prior",
+            "Use Garmin native HR zones only",
+        ],
+    },
+    "environment": {
+        "schema_version": "1.0",
+        "section_type": "environment",
+        "required_fields": {
+            "environmental": {
+                "type": "string",
+                "description": "4-7 sentences + star rating at end",
+            },
+        },
+        "evaluation_policy": {
+            "temperature": {
+                "optimal": "10-15°C",
+                "good": "5-10°C or 15-20°C",
+                "challenging": "0-5°C or 20-25°C",
+                "severe": "<0°C or >25°C",
+            },
+            "humidity": {
+                "optimal": "40-60%",
+                "acceptable": "30-40% or 60-70%",
+                "challenging": "<30% or >70%",
+            },
+            "wind": {
+                "calm": "0-10 km/h",
+                "moderate": "10-20 km/h",
+                "strong": "20-30 km/h",
+                "severe": ">30 km/h",
+            },
+            "terrain_classification": {
+                "flat": "<10m/km",
+                "undulating": "10-20m/km",
+                "hilly": "20-40m/km",
+                "mountainous": ">40m/km",
+            },
+        },
+        "instructions": [
+            "Use weather.json data (not device temperature)",
+            "Evaluate combined impact of temperature + humidity + wind",
+            "Include terrain classification from elevation data",
+            "Star rating reflects overall environmental favorability",
+        ],
+    },
+    "summary": {
+        "schema_version": "1.0",
+        "section_type": "summary",
+        "required_fields": {
+            "star_rating": {
+                "type": "string",
+                "description": "Format: ★★★★☆ N.N/5.0",
+            },
+            "integrated_score": {
+                "type": "number",
+                "description": "0-100, null if unavailable",
+                "optional": True,
+            },
+            "summary": {
+                "type": "string",
+                "description": "2-3 sentence assessment",
+            },
+            "key_strengths": {
+                "type": "array",
+                "description": "3-5 items with numbers",
+            },
+            "improvement_areas": {
+                "type": "array",
+                "description": "Max 2 items",
+            },
+            "next_action": {
+                "type": "string",
+                "description": "1 action with numeric target + success condition",
+            },
+            "next_run_target": {
+                "type": "object",
+                "description": "Target varying by training type",
+            },
+            "recommendations": {
+                "type": "string",
+                "description": "Max 2 in structured markdown",
+            },
+            "plan_achievement": {
+                "type": "object",
+                "description": "Plan vs actual (if planned_workout exists)",
+                "optional": True,
+            },
+        },
+        "evaluation_policy": {
+            "star_rating_scale": {
+                "5.0": "Exceptional",
+                "4.0-4.9": "Strong",
+                "3.0-3.9": "Adequate",
+                "2.0-2.9": "Below expectations",
+                "1.0-1.9": "Poor",
+            },
+            "next_run_target_variants": {
+                "easy_recovery": [
+                    "recommended_type",
+                    "target_hr_low",
+                    "target_hr_high",
+                    "reference_pace_low_formatted",
+                    "reference_pace_high_formatted",
+                    "success_criterion",
+                    "adjustment_tip",
+                    "summary_ja",
+                ],
+                "tempo_threshold": [
+                    "recommended_type",
+                    "target_pace_low_formatted",
+                    "target_pace_high_formatted",
+                    "target_hr",
+                    "success_criterion",
+                    "adjustment_tip",
+                    "summary_ja",
+                ],
+                "interval": [
+                    "recommended_type",
+                    "target_pace_low_formatted",
+                    "target_pace_high_formatted",
+                    "success_criterion",
+                    "adjustment_tip",
+                    "summary_ja",
+                ],
+                "data_insufficient": [
+                    "insufficient_data",
+                    "summary_ja",
+                ],
+            },
+            "recommendations_max": 2,
+            "next_action_count": 1,
+        },
+        "instructions": [
+            "Exactly 1 next_action with numeric target and success condition",
+            "Maximum 2 recommendations with specific numbers",
+            "Easy run suggestions use HR range, not pace",
+            "Include plan_achievement only when planned_workout exists",
+        ],
+    },
+}
+
+VALID_SECTION_TYPES = set(_CONTRACTS.keys())
+
+
+def get_contract(section_type: str) -> dict[str, Any]:
+    """Return the analysis contract for a given section type.
+
+    Raises:
+        ValueError: If section_type is not recognized.
+    """
+    if section_type not in _CONTRACTS:
+        raise ValueError(
+            f"Unknown section_type: {section_type}. "
+            f"Valid types: {sorted(VALID_SECTION_TYPES)}"
+        )
+    return _CONTRACTS[section_type]

--- a/packages/garmin-mcp-server/src/garmin_mcp/validation/section_schemas.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/validation/section_schemas.py
@@ -1,0 +1,125 @@
+"""Pydantic schemas for section analysis data validation."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class SplitAnalysisData(BaseModel):
+    """Schema for split section analysis data."""
+
+    highlights: str = Field(min_length=10, max_length=500)
+    analyses: dict[str, str]
+
+    @field_validator("analyses")
+    @classmethod
+    def validate_analyses_keys(cls, v: dict[str, str]) -> dict[str, str]:
+        """Keys must be split_N format."""
+        if not v:
+            raise ValueError("analyses must not be empty")
+        for key in v:
+            if not re.match(r"^split_\d+$", key):
+                raise ValueError(f"Invalid key format: '{key}'. Must be 'split_N'")
+        return v
+
+
+class PhaseAnalysisData(BaseModel):
+    """Schema for phase section analysis data."""
+
+    warmup_evaluation: str = Field(min_length=10)
+    run_evaluation: str = Field(min_length=10)
+    cooldown_evaluation: str = Field(min_length=10)
+    recovery_evaluation: str | None = None
+    evaluation_criteria: str = Field(min_length=5)
+
+
+class EfficiencyAnalysisData(BaseModel):
+    """Schema for efficiency section analysis data."""
+
+    efficiency: str = Field(min_length=20)
+    evaluation: str = Field(min_length=20)
+    form_trend: str = Field(min_length=10)
+
+
+class EnvironmentAnalysisData(BaseModel):
+    """Schema for environment section analysis data."""
+
+    environmental: str = Field(min_length=20)
+
+
+class NextRunTarget(BaseModel):
+    """Flexible model - fields vary by training type."""
+
+    model_config = {"extra": "allow"}
+
+    recommended_type: str | None = None
+    summary_ja: str | None = None
+    insufficient_data: bool | None = None
+
+
+class PlanAchievement(BaseModel):
+    """Schema for plan achievement data."""
+
+    workout_type: str
+    description_ja: str
+    targets: dict[str, str]
+    actuals: dict[str, str]
+    hr_achieved: bool
+    pace_achieved: bool
+    evaluation: str
+
+
+class SummaryAnalysisData(BaseModel):
+    """Schema for summary section analysis data."""
+
+    star_rating: str
+    integrated_score: float | None = Field(default=None, ge=0, le=100)
+    summary: str = Field(min_length=10)
+    key_strengths: list[str] = Field(min_length=1)
+    improvement_areas: list[str]
+    next_action: str = Field(min_length=10)
+    next_run_target: NextRunTarget | dict[str, Any]
+    recommendations: str = Field(min_length=5)
+    plan_achievement: PlanAchievement | None = None
+
+
+SECTION_SCHEMAS: dict[str, type[BaseModel]] = {
+    "split": SplitAnalysisData,
+    "phase": PhaseAnalysisData,
+    "efficiency": EfficiencyAnalysisData,
+    "environment": EnvironmentAnalysisData,
+    "summary": SummaryAnalysisData,
+}
+
+VALID_SECTION_TYPES = set(SECTION_SCHEMAS.keys())
+
+
+def validate_section_data(
+    section_type: str, analysis_data: dict[str, Any]
+) -> tuple[bool, list[str]]:
+    """Validate analysis_data against section-specific schema.
+
+    Returns (valid, errors).
+    """
+    if section_type not in SECTION_SCHEMAS:
+        return False, [
+            f"Unknown section_type: {section_type}. "
+            f"Valid types: {sorted(VALID_SECTION_TYPES)}"
+        ]
+
+    schema_cls = SECTION_SCHEMAS[section_type]
+    try:
+        schema_cls.model_validate(analysis_data)
+        return True, []
+    except Exception as e:
+        errors: list[str] = []
+        if hasattr(e, "errors"):
+            for err in e.errors():  # type: ignore[union-attr]
+                loc = " -> ".join(str(x) for x in err["loc"])
+                errors.append(f"{loc}: {err['msg']}")
+        else:
+            errors.append(str(e))
+        return False, errors

--- a/packages/garmin-mcp-server/tests/validation/test_contracts.py
+++ b/packages/garmin-mcp-server/tests/validation/test_contracts.py
@@ -1,0 +1,76 @@
+"""Tests for analysis contracts."""
+
+import pytest
+
+from garmin_mcp.validation.contracts import VALID_SECTION_TYPES, get_contract
+
+
+@pytest.mark.unit
+def test_get_contract_split():
+    contract = get_contract("split")
+    assert contract["schema_version"] == "1.0"
+    assert "highlights" in contract["required_fields"]
+    assert "analyses" in contract["required_fields"]
+    assert "hr_drift" in contract["evaluation_policy"]
+    assert isinstance(contract["instructions"], list)
+
+
+@pytest.mark.unit
+def test_get_contract_phase():
+    contract = get_contract("phase")
+    assert "warmup_criteria" in contract["evaluation_policy"]
+    assert "cooldown_criteria" in contract["evaluation_policy"]
+    assert "star_rating_format" in contract["evaluation_policy"]
+
+
+@pytest.mark.unit
+def test_get_contract_efficiency():
+    contract = get_contract("efficiency")
+    policy = contract["evaluation_policy"]
+    assert "gct" in policy
+    assert "vertical_oscillation" in policy
+    assert "vertical_ratio" in policy
+    assert "cadence" in policy
+    assert "integrated_score_stars" in policy
+
+
+@pytest.mark.unit
+def test_get_contract_environment():
+    contract = get_contract("environment")
+    policy = contract["evaluation_policy"]
+    assert "temperature" in policy
+    assert "humidity" in policy
+    assert "wind" in policy
+    assert "terrain_classification" in policy
+
+
+@pytest.mark.unit
+def test_get_contract_summary():
+    contract = get_contract("summary")
+    policy = contract["evaluation_policy"]
+    assert "star_rating_scale" in policy
+    assert "next_run_target_variants" in policy
+    assert policy["recommendations_max"] == 2
+    assert policy["next_action_count"] == 1
+
+
+@pytest.mark.unit
+def test_get_contract_unknown_type():
+    with pytest.raises(ValueError, match="Unknown section_type"):
+        get_contract("unknown")
+
+
+@pytest.mark.unit
+def test_contract_has_required_keys():
+    required_keys = {
+        "schema_version",
+        "section_type",
+        "required_fields",
+        "evaluation_policy",
+        "instructions",
+    }
+    for section_type in VALID_SECTION_TYPES:
+        contract = get_contract(section_type)
+        assert required_keys.issubset(
+            contract.keys()
+        ), f"{section_type} missing keys: {required_keys - contract.keys()}"

--- a/packages/garmin-mcp-server/tests/validation/test_section_schemas.py
+++ b/packages/garmin-mcp-server/tests/validation/test_section_schemas.py
@@ -1,0 +1,175 @@
+"""Tests for section analysis data validation schemas."""
+
+import pytest
+
+from garmin_mcp.validation.section_schemas import validate_section_data
+
+
+@pytest.mark.unit
+def test_split_valid_data():
+    data = {
+        "highlights": "テストハイライト文章です。",
+        "analyses": {"split_1": "分析テキスト"},
+    }
+    valid, errors = validate_section_data("split", data)
+    assert valid is True
+    assert errors == []
+
+
+@pytest.mark.unit
+def test_split_missing_highlights():
+    data = {"analyses": {"split_1": "分析テキスト"}}
+    valid, errors = validate_section_data("split", data)
+    assert valid is False
+    assert len(errors) > 0
+    assert any("highlights" in e for e in errors)
+
+
+@pytest.mark.unit
+def test_split_empty_analyses():
+    data = {"highlights": "テストハイライト文章です。", "analyses": {}}
+    valid, errors = validate_section_data("split", data)
+    assert valid is False
+    assert len(errors) > 0
+
+
+@pytest.mark.unit
+def test_split_invalid_key_format():
+    data = {
+        "highlights": "テストハイライト文章です。",
+        "analyses": {"bad_key": "分析テキスト"},
+    }
+    valid, errors = validate_section_data("split", data)
+    assert valid is False
+    assert len(errors) > 0
+    assert any("split_N" in e or "bad_key" in e for e in errors)
+
+
+@pytest.mark.unit
+def test_phase_valid_3phase():
+    data = {
+        "warmup_evaluation": "ウォームアップの評価テキストです。",
+        "run_evaluation": "ランニング本体の評価テキストです。",
+        "cooldown_evaluation": "クールダウンの評価テキストです。",
+        "evaluation_criteria": "基準テキスト",
+    }
+    valid, errors = validate_section_data("phase", data)
+    assert valid is True
+    assert errors == []
+
+
+@pytest.mark.unit
+def test_phase_valid_4phase():
+    data = {
+        "warmup_evaluation": "ウォームアップの評価テキストです。",
+        "run_evaluation": "ランニング本体の評価テキストです。",
+        "cooldown_evaluation": "クールダウンの評価テキストです。",
+        "recovery_evaluation": "リカバリーの評価テキストです。",
+        "evaluation_criteria": "基準テキスト",
+    }
+    valid, errors = validate_section_data("phase", data)
+    assert valid is True
+    assert errors == []
+
+
+@pytest.mark.unit
+def test_phase_missing_run():
+    data = {
+        "warmup_evaluation": "ウォームアップの評価テキストです。",
+        "cooldown_evaluation": "クールダウンの評価テキストです。",
+        "evaluation_criteria": "基準テキスト",
+    }
+    valid, errors = validate_section_data("phase", data)
+    assert valid is False
+    assert len(errors) > 0
+    assert any("run_evaluation" in e for e in errors)
+
+
+@pytest.mark.unit
+def test_efficiency_valid():
+    data = {
+        "efficiency": "効率性の分析結果を詳細に記述します。ペースに対するHR効率が良好です。",
+        "evaluation": "総合評価の結果を詳細に記述します。全体的にバランスの取れた走りでした。",
+        "form_trend": "フォームトレンドの分析です。安定傾向にあります。",
+    }
+    valid, errors = validate_section_data("efficiency", data)
+    assert valid is True
+    assert errors == []
+
+
+@pytest.mark.unit
+def test_environment_valid():
+    data = {
+        "environmental": "天候は晴れで気温20度、走りやすい環境でした。",
+    }
+    valid, errors = validate_section_data("environment", data)
+    assert valid is True
+    assert errors == []
+
+
+@pytest.mark.unit
+def test_summary_valid_minimal():
+    data = {
+        "star_rating": "★★★★☆ 4.2/5.0",
+        "integrated_score": 78.5,
+        "summary": "全体的に良いランニングでした。",
+        "key_strengths": ["安定したペース配分"],
+        "improvement_areas": [],
+        "next_action": "次回はHR Zone 2を維持して走りましょう。",
+        "next_run_target": {"recommended_type": "easy_run"},
+        "recommendations": "週3回のランニングを継続してください。",
+    }
+    valid, errors = validate_section_data("summary", data)
+    assert valid is True
+    assert errors == []
+
+
+@pytest.mark.unit
+def test_summary_with_plan_achievement():
+    data = {
+        "star_rating": "★★★★☆ 4.0/5.0",
+        "integrated_score": 80.0,
+        "summary": "プラン通りのトレーニングができました。",
+        "key_strengths": ["目標HR達成"],
+        "improvement_areas": ["ペース安定性"],
+        "next_action": "次回もHR Zone 2を意識して走りましょう。",
+        "next_run_target": {"recommended_type": "easy_run"},
+        "recommendations": "引き続きプランに沿ったトレーニングを推奨します。",
+        "plan_achievement": {
+            "workout_type": "easy_run",
+            "description_ja": "イージーラン",
+            "targets": {"hr_zone": "Zone 2", "pace": "5:30-6:00/km"},
+            "actuals": {"hr_zone": "Zone 2", "pace": "5:35/km"},
+            "hr_achieved": True,
+            "pace_achieved": True,
+            "evaluation": "目標を達成しました。",
+        },
+    }
+    valid, errors = validate_section_data("summary", data)
+    assert valid is True
+    assert errors == []
+
+
+@pytest.mark.unit
+def test_summary_missing_star_rating():
+    data = {
+        "integrated_score": 78.5,
+        "summary": "全体的に良いランニングでした。",
+        "key_strengths": ["安定したペース配分"],
+        "improvement_areas": [],
+        "next_action": "次回はHR Zone 2を維持して走りましょう。",
+        "next_run_target": {},
+        "recommendations": "週3回のランニングを継続してください。",
+    }
+    valid, errors = validate_section_data("summary", data)
+    assert valid is False
+    assert len(errors) > 0
+    assert any("star_rating" in e for e in errors)
+
+
+@pytest.mark.unit
+def test_unknown_section_type():
+    valid, errors = validate_section_data("unknown", {"foo": "bar"})
+    assert valid is False
+    assert len(errors) > 0
+    assert any("Unknown section_type: unknown" in e for e in errors)


### PR DESCRIPTION
## Summary
- Add `validate_section_json` MCP tool with Pydantic schemas for all 5 section types (split, phase, efficiency, environment, summary) — enables post-hoc validation of agent output without agent changes
- Add `get_analysis_contract` MCP tool returning centralized evaluation thresholds, required fields, and generation instructions per section type — enables hot-reload of changeable parameters via `reload_server()`

## Test plan
- [x] 13 unit tests for section schemas (all pass)
- [x] 7 unit tests for contracts (all pass)
- [x] ruff + mypy + black pass

Closes #136
Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)