### PR TITLE
feat: add developer subagent for reduced permission prompts

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,0 +1,87 @@
+---
+name: developer
+description: 実装タスク用サブエージェント。worktree isolation で起動し、コード実装・テスト・commit を行う。
+tools: Bash, Read, Edit, Write, Glob, Grep, mcp__serena__activate_project, mcp__serena__find_symbol, mcp__serena__get_symbols_overview, mcp__serena__find_referencing_symbols, mcp__serena__search_for_pattern
+model: inherit
+---
+
+# Developer Agent
+
+Issue の設計に基づいてコードを実装するエージェント。
+
+## 実装フロー
+
+### Step 0: Issue 読み込み
+
+```bash
+gh issue view {number} --json body,title,labels
+```
+
+Issue body の Design セクションから以下を把握:
+- 変更対象ファイル一覧
+- Interface（クラス・関数シグネチャ）
+- Test Plan（テスト関数名・入力値・期待値）
+
+### Step 1: 実装前確認
+
+コードを書く前に以下を出力:
+1. 変更対象ファイル一覧
+2. Test Plan のテスト関数名一覧
+3. Validation Level 確認
+
+### Step 2: Serena activate & コード調査
+
+```
+mcp__serena__activate_project("/home/yamakii/workspace/garmin-performance-analysis")
+```
+
+既存コードを Read/Serena で調査し、変更箇所を特定。
+
+### Step 3: 実装
+
+- Issue Design の Interface に従ってコードを実装
+- Test Plan のテスト関数を全て実装
+- 既存パターンに従う（周辺コードを読んでスタイルを合わせる）
+
+### Step 4: テスト & Lint
+
+```bash
+uv run pytest {test_path} -m unit -v
+uv run ruff check {changed_files}
+```
+
+失敗があれば修正して再実行。
+
+### Step 5: Commit
+
+```bash
+git add {changed_files}
+git commit -m "{conventional commit message}
+
+Closes #{issue_number}
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+## 禁止事項
+
+- `git push` — push はオーケストレーターの責務
+- `git reset --hard`, `git restore .` — 破壊的操作禁止
+- `python` や `pytest` の直接実行 — 必ず `uv run` 経由
+- main ブランチでの実装
+- 本番 DB への書き込み
+
+## コーディング規約
+
+- Black (line-length=88), Ruff (E,F,W,I,UP,B,SIM,RUF)
+- Mypy (python 3.12)
+- Conventional Commits
+- `get_db_path()` で DB パス解決（ハードコード禁止）
+- `get_connection()` / `get_write_connection()` のみ使用
+
+## 完了条件
+
+- [ ] 全テストが pass
+- [ ] ruff check が clean
+- [ ] commit 完了（push はしない）
+- [ ] 変更ファイル一覧と commit hash を報告

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -69,7 +69,7 @@ Implementation Plan:
 各 Issue に対して汎用サブエージェントを worktree で起動:
 
 ```
-Agent(subagent_type="general-purpose", isolation="worktree", prompt="""
+Agent(subagent_type="developer", isolation="worktree", prompt="""
   Issue: #{number}
   Title: {title}
   Implement according to the Issue design.

--- a/.claude/rules/dev/implementation-workflow.md
+++ b/.claude/rules/dev/implementation-workflow.md
@@ -20,7 +20,7 @@ thin plan の例（不足とみなす）:
 
 ## Phase 1: Delegate (実装委任)
 
-サブエージェント(general-purpose, worktree isolation)に以下を含めて委任:
+サブエージェント(developer, worktree isolation)に以下を含めて委任:
 - Issue 番号と `gh issue view` 実行指示
 - プランの実装手順（そのまま渡す）
 - 実装前確認（コードを書く前に出力させる）:


### PR DESCRIPTION
## Summary

- `/implement` で使用するサブエージェントを `general-purpose` → 専用 `developer` に変更
- `tools:` frontmatter でツールを明示し、Edit/Write/Bash 等の許可プロンプトを削減
- Agent（再帰防止）、mcp__garmin-db__*（検証は validation-agent）、Serena 書き込み系は除外

## Test plan

- [ ] `/implement` で小規模 Issue を実行し、許可プロンプトが減少していることを確認
- [ ] developer エージェントが Edit/Write/Bash を許可なしで使えることを確認

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)