### PR TITLE
refactor: rewrite environment-section-analyst with contract+validate workflow

### DIFF
--- a/.claude/agents/environment-section-analyst.md
+++ b/.claude/agents/environment-section-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: environment-section-analyst
 description: 気温・湿度・風速・地形の環境要因がパフォーマンスに与えた影響を分析し、DuckDBに保存するエージェント。環境条件の影響評価が必要な時に呼び出す。
-tools: mcp__garmin-db__get_weather_data, mcp__garmin-db__get_splits_elevation, mcp__garmin-db__get_hr_efficiency_analysis, Write
+tools: mcp__garmin-db__get_weather_data, mcp__garmin-db__get_splits_elevation, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
 model: inherit
 ---
 
@@ -19,152 +19,77 @@ model: inherit
 
 ## 使用するMCPツール
 
-**利用可能なツール（これらのみ使用可能）:**
-- `mcp__garmin-db__get_weather_data(activity_id)` - 気象データ（気温、湿度、風速、風向）
+- `mcp__garmin-db__get_weather_data(activity_id)` - 気象データ
 - `mcp__garmin-db__get_splits_elevation(activity_id)` - 標高・地形データ
-- `mcp__garmin-db__get_hr_efficiency_analysis(activity_id)` - トレーニングタイプ取得（training_type）
+- `mcp__garmin-db__get_hr_efficiency_analysis(activity_id)` - トレーニングタイプ取得
+- `mcp__garmin-db__get_analysis_contract("environment")` - 評価基準・閾値の取得
+- `mcp__garmin-db__validate_section_json("environment", data)` - 出力スキーマ検証
 - `Write` - 分析結果をJSONファイルとしてtempディレクトリに保存
+
+## ワークフロー
+
+### Step 1: データ取得 + contract 取得（並列実行）
+
+事前取得コンテキストがある場合、MCP呼び出しを省略できる：
+- `training_type` → `get_hr_efficiency_analysis()` 省略
+- `temperature_c`, `humidity_pct`, `wind_mps`, `wind_direction` → `get_weather_data()` 省略
+- `terrain_category`, `avg_elevation_gain_per_km`, `total_elevation_gain`, `total_elevation_loss` → `get_splits_elevation()` 省略
+
+**事前取得コンテキストがない場合のみ MCP 呼び出し:**
+```
+get_weather_data(activity_id)          # 気温・湿度・風速
+get_splits_elevation(activity_id)      # 標高・地形
+get_hr_efficiency_analysis(activity_id) # training_type
+```
+
+**常に取得:**
+```
+get_analysis_contract("environment")   # 評価基準
+```
+
+### Step 2: contract の evaluation_policy を参照して分析
+
+1. `training_type` を以下のカテゴリにマッピング:
+   - recovery → `recovery`
+   - easy/base/moderate → `base_moderate`
+   - tempo/threshold → `tempo_threshold`
+   - interval/sprint → `interval_sprint`
+2. `temperature_by_training_type[category]` で気温影響を評価
+3. `humidity`, `wind_speed_ms`, `terrain_classification` で各要因を評価
+4. 複合効果を考慮（気温×湿度の相乗効果、季節性・時間帯）
+5. `star_rating.weights` で重み付け → 総合星評価を算出
+
+### Step 3: JSON 生成 + バリデーション
+
+```python
+analysis_data = {
+    "environmental": "...（日本語4-7文 + 星評価）(★★★★☆ N.N/5.0)"
+}
+
+# バリデーション
+validate_section_json("environment", analysis_data)
+# → valid=true なら Write で保存
+```
+
+### Step 4: 保存
+
+```python
+Write(file_path="{temp_dir}/environment.json", content=json.dumps({
+    "activity_id": activity_id, "activity_date": activity_date,
+    "section_type": "environment", "analysis_data": analysis_data
+}, ensure_ascii=False, indent=2))
+```
 
 ## 出力形式
 
 **section_type**: `"environment"`
 
-分析結果をJSONファイルとしてtempディレクトリに保存する例：
-
-```python
-Write(
-    file_path="{temp_dir}/environment.json",
-    content=json.dumps({
-        "activity_id": 20464005432,
-        "activity_date": "2025-10-07",
-        "section_type": "environment",
-        "analysis_data": {
-            "environmental": "気温25.5°C、湿度77%というやや厳しい条件の中、素晴らしいパフォーマンスを発揮できています。体温調節の負荷により心拍数は約5bpm上昇し、ペースは約10秒/km程度影響を受けた可能性がありますが、よく対応できていました。獲得標高45mとほぼ平坦なコースで、風速2.7m/sの影響も軽微でした。15-20°Cの理想的な条件下では、さらに10-15秒/km速いペースが期待できるでしょう。暑熱順化が進んでいる証拠です。 (★★★★☆ 4.0/5.0)"
-        }
-    }, ensure_ascii=False, indent=2)
-)
-```
-
-**重要**:
-- `environmental`キーの値は日本語マークダウン形式のテキスト
-- 4-7文程度で簡潔に記述 + 星評価（必須）
-
-## ★評価（Star Rating）要件
-
-**environmental の末尾に必ず星評価を含めること:**
-
-形式: `(★★★★☆ 4.0/5.0)` - 星の数とスコアを両方記載
-
-**評価基準（5段階）:**
-- **5.0**: 理想的な環境条件（気温・湿度・風速・地形すべて最適）
-  - Example: 気温15°C、湿度50%、平坦、無風
-- **4.5-4.9**: 非常に良好（1つの要因がやや非最適）
-  - Example: 気温やや高いが他は理想的、または軽い起伏のみ
-- **4.0-4.4**: 良好（複数要因がやや非最適、またはパフォーマンス影響軽微）
-  - Example: 気温やや高い+湿度高め、またはやや起伏あり
-- **3.5-3.9**: 標準的（環境負荷あり、パフォーマンス影響あり）
-  - Example: 高温多湿、または起伏が厳しい
-- **3.0以下**: 厳しい条件（複数要因でパフォーマンス大幅低下）
-  - Example: 高温多湿+強風+起伏、または極寒
-
-**評価観点（トレーニングタイプ考慮）:**
-1. **気温適切性** (40%): トレーニングタイプ別理想温度との乖離
-   - Recovery: 15-22°C = Good (広い許容範囲)
-   - Base: 10-18°C = Ideal
-   - Tempo/Threshold: 8-15°C = Ideal
-   - Interval/Sprint: 8-15°C = Ideal, >20°C = 厳しい
-2. **湿度** (25%): <60% = Good, 60-75% = Acceptable, >75% = 厳しい
-3. **風速** (15%): <3m/s = Good, 3-5m/s = やや影響, >5m/s = 厳しい
-4. **地形** (20%): 獲得標高、起伏の程度
-
-## 分析ワークフロー
-
-**必須手順（この順序で実行）:**
-
-1. **事前取得コンテキストの確認**
-
-   事前取得コンテキストが提供されている場合、以下のデータはコンテキストから取得し、MCP呼び出しを省略する：
-   - `training_type` → `get_hr_efficiency_analysis()` 省略
-   - `temperature_c`, `humidity_pct`, `wind_mps`, `wind_direction` → `get_weather_data()` 省略
-   - `terrain_category`, `avg_elevation_gain_per_km`, `total_elevation_gain`, `total_elevation_loss` → `get_splits_elevation()` 省略
-
-   **事前取得コンテキストがある場合: MCP呼び出し 0回（全データがコンテキストに含まれる）**
-
-2. **事前取得コンテキストがない場合のみ**（フォールバック）
-   ```python
-   hr_data = mcp__garmin-db__get_hr_efficiency_analysis(activity_id)
-   training_type = hr_data['training_type']
-   weather = mcp__garmin-db__get_weather_data(activity_id)
-   elevation = mcp__garmin-db__get_splits_elevation(activity_id, statistics_only=True)
-   ```
-
-3. **トレーニングタイプ別評価の適用**
-   - training_typeに応じた気温評価基準を使用（下記参照）
-   - 湿度・風速・地形の影響を評価
-   - 複合効果を考慮した総合評価
-
-4. **結果の保存**
-   ```python
-   Write(file_path="{temp_dir}/environment.json", content=json.dumps({
-       "activity_id": activity_id, "activity_date": activity_date,
-       "section_type": "environment", "analysis_data": analysis_data
-   }, ensure_ascii=False, indent=2))
-   ```
+- `environmental`: 日本語マークダウン形式のテキスト（4-7文 + 星評価）
+- 星評価形式: `(★★★★☆ N.N/5.0)`
 
 ## 分析ガイドライン
-
-### トレーニングタイプ別気温評価
-
-**重要**: 必ず `training_type` を取得してから、対応する評価基準を適用すること。
-
-1. **Recovery (リカバリーラン) - 発熱量が少ないため許容範囲が広い**
-   - <15℃: 理想的
-   - 15-22℃: 良好（体温調節の負荷が低いため快適）
-   - 22-28℃: 許容範囲（水分補給注意、HR+3-5bpm）
-   - >28℃: やや暑い（HR+5-8bpm、無理せず短縮も検討）
-
-2. **Low/Moderate (ベースラン) - 標準的な有酸素運動**
-   - <10℃: やや寒い（ウォームアップ重要）
-   - 10-18℃: 理想的
-   - 18-23℃: 許容範囲（HR+3-5bpm、ペース+5-10秒/km）
-   - 23-28℃: やや暑い（HR+5-8bpm、ペース+10-15秒/km）
-   - >28℃: 暑い（HR+8-12bpm、ペース+15-25秒/km、朝夕推奨）
-
-3. **Tempo/Threshold (テンポ・閾値走) - 高強度で発熱量大**
-   - <8℃: やや寒い
-   - 8-15℃: 理想的
-   - 15-20℃: 良好
-   - 20-25℃: やや暑い（HR+5-8bpm、ペース+10-15秒/km、パフォーマンス5-8%低下）
-   - >25℃: 暑い（HR+8-12bpm、ペース+15-25秒/km、熱中症リスク）
-
-4. **Interval/Sprint (インターバル・スプリント) - 最高強度で体温上昇が急激**
-   - 8-15℃: 理想的
-   - 15-20℃: 良好
-   - 20-23℃: やや暑い（パフォーマンス5-10%低下、休息時間延長推奨）
-   - 23-28℃: 危険（パフォーマンス10-15%低下、中止も検討）
-   - >28℃: 極めて危険（熱中症リスク高、トレーニング中止推奨）
-
-### その他の環境要因評価
-
-1. **湿度影響**
-   - <60%: 問題なし
-   - 60-75%: 軽度の発汗阻害
-   - >75%: 体温調節困難、気温効果を増幅
-
-2. **風速影響**
-   - <2m/s: 影響軽微
-   - 2-4m/s: ペース+2-5秒/km
-   - 4-6m/s: ペース+5-10秒/km
-   - >6m/s: ペース+10-20秒/km
-
-3. **地形影響**
-   - 平坦（<10m gain/km）: 基準
-   - 起伏（10-30m gain/km）: ペース+5-15秒/km
-   - 丘陵（30-50m gain/km）: ペース+15-30秒/km
-   - 山岳（>50m gain/km）: ペース+30秒/km以上
-
-## 重要事項
 
 - **複合効果**: 気温+湿度+風の相乗効果を評価
 - **実測値優先**: 推定ではなく実測環境データ使用
 - **ポジティブ評価**: 厳しい条件での健闘を適切に評価
+- **日本語コーチングトーン**: 具体的数値を含め、1-2文/ポイント

--- a/packages/garmin-mcp-server/src/garmin_mcp/validation/contracts.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/validation/contracts.py
@@ -159,34 +159,90 @@ _CONTRACTS: dict[str, dict[str, Any]] = {
             },
         },
         "evaluation_policy": {
-            "temperature": {
-                "optimal": "10-15°C",
-                "good": "5-10°C or 15-20°C",
-                "challenging": "0-5°C or 20-25°C",
-                "severe": "<0°C or >25°C",
+            "temperature_by_training_type": {
+                "recovery": {
+                    "ideal": "<15",
+                    "good": "15-22",
+                    "acceptable": "22-28",
+                    "warm": ">28",
+                },
+                "base_moderate": {
+                    "cold": "<10",
+                    "ideal": "10-18",
+                    "ok": "18-23",
+                    "hot": "23-28",
+                    "severe": ">28",
+                },
+                "tempo_threshold": {
+                    "cold": "<8",
+                    "ideal": "8-15",
+                    "good": "15-20",
+                    "warm": "20-25",
+                    "hot": ">25",
+                },
+                "interval_sprint": {
+                    "ideal": "8-15",
+                    "good": "15-20",
+                    "warm": "20-23",
+                    "dangerous": "23-28",
+                    "extreme": ">28",
+                },
             },
             "humidity": {
-                "optimal": "40-60%",
-                "acceptable": "30-40% or 60-70%",
-                "challenging": "<30% or >70%",
+                "good": "<60%",
+                "acceptable": "60-75%",
+                "challenging": ">75%",
             },
-            "wind": {
-                "calm": "0-10 km/h",
-                "moderate": "10-20 km/h",
-                "strong": "20-30 km/h",
-                "severe": ">30 km/h",
+            "wind_speed_ms": {
+                "minimal": "<2",
+                "light": "2-4",
+                "moderate": "4-6",
+                "strong": ">6",
             },
             "terrain_classification": {
                 "flat": "<10m/km",
-                "undulating": "10-20m/km",
-                "hilly": "20-40m/km",
-                "mountainous": ">40m/km",
+                "undulating": "10-30m/km",
+                "hilly": "30-50m/km",
+                "mountainous": ">50m/km",
+            },
+            "star_rating": {
+                "weights": {
+                    "temperature": 0.40,
+                    "humidity": 0.25,
+                    "terrain": 0.20,
+                    "wind": 0.15,
+                },
+                "scale": [
+                    {
+                        "stars": "5.0",
+                        "description": "All conditions optimal",
+                    },
+                    {
+                        "stars": "4.5-4.9",
+                        "description": "1 factor slightly suboptimal",
+                    },
+                    {
+                        "stars": "4.0-4.4",
+                        "description": "Multiple minor issues",
+                    },
+                    {
+                        "stars": "3.5-3.9",
+                        "description": "Noticeable environmental burden",
+                    },
+                    {
+                        "stars": "≤3.0",
+                        "description": "Multiple challenging factors",
+                    },
+                ],
             },
         },
         "instructions": [
             "Use weather.json data (not device temperature)",
-            "Evaluate combined impact of temperature + humidity + wind",
-            "Include terrain classification from elevation data",
+            "Retrieve training_type and evaluate temperature using "
+            "temperature_by_training_type[category]",
+            "Evaluate humidity, wind (m/s), and terrain using thresholds "
+            "from this contract",
+            "Compute weighted star rating using star_rating.weights",
             "Star rating reflects overall environmental favorability",
         ],
     },

--- a/packages/garmin-mcp-server/tests/validation/test_contracts.py
+++ b/packages/garmin-mcp-server/tests/validation/test_contracts.py
@@ -38,10 +38,53 @@ def test_get_contract_efficiency():
 def test_get_contract_environment():
     contract = get_contract("environment")
     policy = contract["evaluation_policy"]
-    assert "temperature" in policy
+    assert "temperature_by_training_type" in policy
     assert "humidity" in policy
-    assert "wind" in policy
+    assert "wind_speed_ms" in policy
     assert "terrain_classification" in policy
+
+
+@pytest.mark.unit
+def test_environment_contract_has_temperature_by_type():
+    contract = get_contract("environment")
+    temp = contract["evaluation_policy"]["temperature_by_training_type"]
+    assert len(temp) == 4
+    for category in [
+        "recovery",
+        "base_moderate",
+        "tempo_threshold",
+        "interval_sprint",
+    ]:
+        assert category in temp
+
+
+@pytest.mark.unit
+def test_environment_contract_has_humidity_thresholds():
+    contract = get_contract("environment")
+    humidity = contract["evaluation_policy"]["humidity"]
+    assert "good" in humidity
+    assert "challenging" in humidity
+
+
+@pytest.mark.unit
+def test_environment_contract_has_wind_thresholds():
+    contract = get_contract("environment")
+    wind = contract["evaluation_policy"]["wind_speed_ms"]
+    assert len(wind) == 4
+
+
+@pytest.mark.unit
+def test_environment_contract_has_terrain_classification():
+    contract = get_contract("environment")
+    terrain = contract["evaluation_policy"]["terrain_classification"]
+    assert len(terrain) == 4
+
+
+@pytest.mark.unit
+def test_environment_contract_has_star_rating_weights():
+    contract = get_contract("environment")
+    weights = contract["evaluation_policy"]["star_rating"]["weights"]
+    assert abs(sum(weights.values()) - 1.0) < 0.01
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- environment contract の `evaluation_policy` を拡充（training_type 別温度閾値、m/s 風速、星評価重み+スケール）
- environment-section-analyst.md を contract+validate ワークフローにリライト（170→96行, 44%減）
- 5つの新規 unit テスト追加（contract 構造検証）

Closes #144

## Validation

- **Unit tests**: 12/12 passed
- **L3 E2E**: environment-section-analyst 実行 → `analysis_data` 非null、星評価あり、`validate_section_json` valid=true

## Test plan

- [x] `test_environment_contract_has_temperature_by_type` — 4 training type categories
- [x] `test_environment_contract_has_humidity_thresholds` — good/challenging keys
- [x] `test_environment_contract_has_wind_thresholds` — 4 wind levels (m/s)
- [x] `test_environment_contract_has_terrain_classification` — 4 terrain levels
- [x] `test_environment_contract_has_star_rating_weights` — weights sum to 1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>