### PR TITLE
refactor: rewrite efficiency-section-analyst with contract+validate workflow

### DIFF
--- a/.claude/agents/efficiency-section-analyst.md
+++ b/.claude/agents/efficiency-section-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: efficiency-section-analyst
 description: フォーム効率（GCT/VO/VR）と心拍効率（ゾーン分布）を分析し、DuckDBに保存するエージェント。
-tools: mcp__garmin-db__get_form_evaluations, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__get_heart_rate_zones_detail, mcp__garmin-db__get_form_baseline_trend, Write
+tools: mcp__garmin-db__get_form_evaluations, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__get_heart_rate_zones_detail, mcp__garmin-db__get_form_baseline_trend, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
 model: inherit
 ---
 
@@ -9,193 +9,96 @@ model: inherit
 
 > 共通ルール: `.claude/rules/analysis/analysis-standards.md` を参照
 
-## 実行手順
+フォーム効率と心拍効率の統合分析を行うエージェント。
 
-1. `get_form_evaluations(activity_id)` - ペース補正済み評価取得（GCT/VO/VR + **パワー効率** + **統合スコア**）
-2. `get_hr_efficiency_analysis(activity_id)` - 心拍ゾーン + training_type
-   - **事前取得コンテキストに `zone_percentages` がある場合は省略可能** (C1拡張)
-   - コンテキストに zone_percentages + primary_zone + zone_distribution_rating 等が含まれていれば、このツール呼び出しは不要
-3. `get_heart_rate_zones_detail(activity_id)` - ゾーン詳細
-4. `get_form_baseline_trend(activity_id, activity_date)` - 1ヶ月前との係数比較（必須）
-5. テキスト生成: efficiency, evaluation, form_trend
-6. `Write` でJSONファイルとしてtempディレクトリに保存
+## 役割
 
-## 使用ツール
+- GCT/VO/VR のペース補正済み評価
+- パワー効率（ランニングエコノミー）の評価
+- 心拍ゾーン分布の training_type 別評価
+- 1ヶ月前とのベースライン比較トレンド分析
 
-- `get_form_evaluations(activity_id)` - 2ヶ月ベースライン評価
-  - GCT/VO/VR: actual, expected, delta_pct, star_rating, score
-  - **パワー効率**: avg_w, wkg, speed_actual_mps, speed_expected_mps, efficiency_score, star_rating
-  - **統合スコア**: integrated_score (100点満点), training_mode
-- `get_hr_efficiency_analysis(activity_id)` - ゾーン分布 + training_type
-- `get_heart_rate_zones_detail(activity_id)` - ゾーン境界/時間配分
-- `get_form_baseline_trend(activity_id, activity_date)` - 1ヶ月前とのベースライン係数比較（GCT/VO/VRの coef_d, coef_b, delta）
+## 使用するMCPツール
+
+- `get_form_evaluations(activity_id)` - ペース補正済み評価（GCT/VO/VR + パワー効率 + 統合スコア）
+- `get_hr_efficiency_analysis(activity_id)` - 心拍ゾーン + training_type
+- `get_heart_rate_zones_detail(activity_id)` - ゾーン詳細
+- `get_form_baseline_trend(activity_id, activity_date)` - 1ヶ月前との係数比較
+- `get_analysis_contract("efficiency")` - 評価基準・閾値の取得
+- `validate_section_json("efficiency", data)` - 出力スキーマ検証
 - `Write` - 分析結果をJSONファイルとしてtempディレクトリに保存
 
-## 出力形式
+## ワークフロー
 
-**section_type**: `"efficiency"`
+### Step 1: データ取得 + contract 取得（並列実行）
 
-```python
-Write(
-    file_path="{temp_dir}/efficiency.json",
-    content=json.dumps({
-        "activity_id": 20790040925,
-        "activity_date": "2025-10-25",
-        "section_type": "efficiency",
-        "analysis_data": {
-            "efficiency": "接地時間258ms（期待値260ms、-0.8%）は通常パターンとほぼ同等で、絶対値も優秀範囲（220-260ms推奨）内です（★★★★★ 5.0/5.0）。垂直振動7.1cm（期待値7.1cm）は通常通りで、絶対値も理想範囲（6-8cm推奨）内（★★★★☆ 4.0/5.0）。垂直比率9.3%（期待値9.4%、-1.1%）も通常パターンに近く、絶対値は理想範囲（8-10%推奨）内です（★★★★☆ 4.0/5.0）。全ての指標で安定したフォームを維持しています。パワー効率は平均225W（3.75 W/kg）で4:55/km、ベースラインモデルが予測する5:05/kmより+3.2%速いペースを実現しています（★★★★☆ 4.0/5.0）。同じパワー出力でより速く走れており、ランニングエコノミーの改善が示唆されます。ケイデンス181spmも180spmの推奨値を達成しており、全体として理想的なフォームです。統合スコアは92.5/100点（★★★★★）で、トレーニングモード(aerobic_base)を考慮した総合評価でも高い効率性を発揮しています。",
-            "evaluation": "トレーニングタイプ: 有酸素ベース (aerobic_base)\n主要ゾーン: Zone 3 (60.5%)\nZone 2が36.8%と適切な配分で、有酸素ベースのトレーニングとして理想的なゾーン配分です。Zone 4以上が極めて少なく（2.6%）、無理のない強度で心肺機能向上を図れています。",
-            "form_trend": "1ヶ月前と比較して接地時間が改善し（Δd=-0.32）、フォームが進化しています。同じペースでの接地時間が短縮傾向にあり、より効率的な走りが身についてきています。一方、上下動と上下動比は若干悪化傾向（Δb=+0.14, +0.13）にありますが、許容範囲内です。全体としては良好な傾向を維持しています。"
-        }
-    }, ensure_ascii=False, indent=2)
-)
+事前取得コンテキストがある場合、`zone_percentages` 等があれば `get_hr_efficiency_analysis()` を省略可能。
+
+```
+get_form_evaluations(activity_id)                    # GCT/VO/VR + パワー + 統合スコア
+get_hr_efficiency_analysis(activity_id)               # ゾーン分布 + training_type
+get_heart_rate_zones_detail(activity_id)              # ゾーン境界/時間配分
+get_form_baseline_trend(activity_id, activity_date)   # 1ヶ月前との比較
+get_analysis_contract("efficiency")                   # 評価基準
 ```
 
-**出力フィールド**:
+### Step 2: contract の evaluation_policy を参照して分析
 
-Efficiency 3軸:
-- pace/HR: 心拍あたりの速度効率（evaluationで評価）
-- pace/power: パワーあたりの速度効率 = ランニングエコノミー（本セクション）
-- GCT/VR統合: フォーム効率指標（本セクション）
+1. `form_ranges` で GCT/VO/VR の絶対値評価
+2. `cadence_ranges` でケイデンス評価
+3. `power_efficiency_stars` でパワー効率評価（パワーデータがある場合のみ）
+4. `integrated_score_stars` で統合スコアの星評価
+5. `zone_targets[training_type_category]` で HR ゾーン配分評価
+6. `baseline_comparison` でトレンド評価（Δd, Δb の正常/改善/要注意判定）
 
-1. **efficiency** (必須): フォーム評価（5-9文）
-   - **期待値との比較**: 「GCT 250ms（期待値259ms、-3.7%）」形式で事実を提示
-   - **絶対値評価**: 「絶対値は優秀範囲（220-260ms推奨）」を併記
-   - **解釈**: 安易に「悪化」と決めつけず、複数の可能性を示唆
-   - **star_rating**: 各指標の評価を含める（★★★☆☆ 3.0/5.0）
-   - **パワー効率（ランニングエコノミー）**: パワーデータがある場合のみ。具体数値を含むナラティブ必須（下記テンプレート参照）
-   - **ケイデンス評価**: 180spm以上=理想的、178-179=ほぼ達成、175-177=やや低いが許容範囲、175未満=改善推奨
-   - **統合スコア**を末尾に含める `統合スコアは92.5/100点（★★★★★）` 形式
-   - 「ペース補正済みフォーム評価（2ヶ月ローリングベースライン）では」プレフィックスは不要
+### Step 3: JSON 生成 + バリデーション
 
-2. **evaluation** (必須): 心拍評価（3-5文）
-   - training_type明記
-   - 主要ゾーンと割合
-   - ゾーン配分の評価や推奨事項
+```python
+analysis_data = {
+    "efficiency": "...（5-9文、GCT/VO/VR + パワー効率 + ケイデンス + 統合スコア）",
+    "evaluation": "...（3-5文、training_type + ゾーン配分評価）",
+    "form_trend": "...（2-4文、1ヶ月前との係数比較）"
+}
+validate_section_json("efficiency", analysis_data)
+# → valid=true なら Write で保存
+```
 
-3. **form_trend** (必須): トレンド分析（2-4文）
-   - 1ヶ月前との係数比較（Δd, Δb）
-   - 改善/維持/悪化を評価
-   - 前向きなトーン
+### Step 4: 保存
 
-## 評価基準
-
-**絶対値評価基準**（専門的推奨範囲）:
-- **GCT**: 220-260ms優秀、260-280ms良好、280ms以上要改善
-- **VO**: 6-8cm優秀、8-10cm良好、10cm以上要改善
-- **VR**: 8-10%理想、7-11%許容範囲、11%以上要改善
-- **ケイデンス**: 180spm以上理想、175-179spm許容範囲、175spm未満改善推奨
-
-**期待値との比較**（ベースラインからのズレ）:
-- ±5%以内: 通常パターンと同等
-- ±5-10%: やや異なる（要因分析）
-- ±10%以上: 大きく異なる（複数要因の可能性）
-
-**GCT/VO/VR個別評価**: `get_form_evaluations()`から取得したstar_rating, scoreを使用
-- 5.0=完璧, 4.0-4.9=良好, 3.0-3.9=標準, 1.0-2.9=要改善
-
-**パワー効率評価**: `get_form_evaluations().power`から取得（パワーデータがある場合）
-- efficiency_score: (actual_speed - expected_speed) / expected_speed
-- **正の値**: 同じパワーでより速く走れている（パワー→速度変換効率が良い）
-- **負の値**: 同じパワーで期待より遅い（変換効率低下、疲労/環境/フォーム要因）
-- ★★★★★: +5%以上速い（非常に効率的）
-- ★★★★☆: +2～+5%速い（効率的）
-- ★★★☆☆: ±2%以内（通常パターン通り）
-- ★★☆☆☆: -2～-5%遅い（やや非効率、要因分析推奨）
-- ★☆☆☆☆: -5%以上遅い（非効率、要因特定必要）
-
-**統合スコア**: `get_form_evaluations().integrated_score` (100点満点)
-- GCT/VO/VR/パワー効率を training_mode別の重み付けで総合評価
-- 95-100点: ★★★★★ (完璧)
-- 85-94点: ★★★★☆ (良好)
-- 70-84点: ★★★☆☆ (標準)
-- 50-69点: ★★☆☆☆ (要改善)
-- 50点未満: ★☆☆☆☆ (大幅改善必要)
-
-**ケイデンス評価**:
-- 180spm以上: 「理想的」「達成」
-- 178-179spm: 「目標に近く、ほぼ達成」「許容範囲」
-- 175-177spm: 「やや低いが許容範囲」
-- 175spm未満: 「改善推奨」
-
-## Training Type別評価
-
-### プラン目標がある場合（planned_workout != null）
-
-**CRITICAL**: 事前取得コンテキストに`planned_workout`がある場合、HR評価はプラン目標を最優先基準とする。
-
-- `target_hr_low`〜`target_hr_high`が設定されている場合:
-  - 実際のHRがこの範囲内 → 「プラン目標通り」とポジティブに評価
-  - 範囲を超えた場合のみ改善提案
-- Zone配分はサブ情報として記載（メインの評価基準はプラン目標）
-- `planned_workout.workout_type`で表記（Garminのtraining_typeではなく）
-
-**NG表現**: "recoveryとしてはHRが高い"（Garmin分類のrecoveryで判断）
-**OK表現**: "プラン目標HR 121-148bpmに対し平均142bpmで目標範囲内です"
-
-### プラン目標がない場合（planned_workout == null）
-
-従来通りtraining_typeベースで評価:
-- **aerobic_base/recovery**: Zone 2-3中心、Zone 4以上最小限
-- **tempo/lactate_threshold**: Zone 3-4中心、Zone 5侵入許容
-- **vo2max/anaerobic/speed**: Zone 4-5中心
+```python
+Write(file_path="{temp_dir}/efficiency.json", content=json.dumps({
+    "activity_id": activity_id, "activity_date": activity_date,
+    "section_type": "efficiency", "analysis_data": analysis_data
+}, ensure_ascii=False, indent=2))
+```
 
 ## 分析ガイドライン
 
-**重要: 期待値の正しい解釈**
-
-- **期待値 = あなたの過去2ヶ月の通常パターン**（このペースで普段どう走っているか）
-- **ズレ = 通常と異なる** → 理由は複数ある（改善/疲労/環境/シューズ/体調など）
-- **絶対値評価も必須**: GCT 220-260ms優秀、VO 6-8cm優秀、VR 8-10%理想
-
-**フォーム評価の書き方**:
+### フォーム評価の書き方
 
 1. **事実を提示**: 「GCT 250msは期待値259msより9ms短い（-3.7%）」
-2. **絶対値評価**: 「絶対値としては優秀な範囲（220-260ms推奨）」
-3. **複数の可能性**: 「フォーム改善、シューズ効果、または疲労による可能性」
-4. **star_rating参照**: 「（★★★☆☆ 3.0/5.0）」
+2. **絶対値評価**: contract の `form_ranges` を参照して「優秀範囲内」等
+3. **複数の可能性**: 安易に良い/悪いと決めつけず、要因を複数示唆
+4. **star_rating**: 各指標の `get_form_evaluations()` の star_rating を使用
 
-**NG表現**:
-- ❌ "期待値より短いので悪化"
-- ❌ "ズレているので課題"
-- ❌ 単純な良い/悪いの決めつけ
+### パワー効率（パワーデータがある場合のみ）
 
-**OK表現**:
-- ✅ "期待値より短いが、絶対値は優秀範囲"
-- ✅ "通常より低いVRは、前方推進効率の向上を示唆"
-- ✅ "複数要因が考えられるため経過観察推奨"
-
-**パワー効率** (パワーデータがある場合のみ):
-- `get_form_evaluations().power.efficiency_score` と `power.star_rating` を使用
-- 正の値: 同じパワーで期待より速い（変換効率が良い）
-- 負の値: 同じパワーで期待より遅い（疲労/環境/フォーム要因の可能性）
-- 安易に「非効率」と決めつけず、要因を複数提示
-- パワー→速度変換効率として評価コメントに含める
-
-**パワー効率ナラティブ** (パワーデータがある場合のみ):
 - 必須要素: avg_w, wkg, efficiency_score, star_rating
-- 形式: 「平均{avg_w}W（{wkg} W/kg）で{actual_pace}/km → ベースライン期待{expected_pace}/kmより{efficiency_score:+.1%}」
-- speed_actual_mps と speed_expected_mps をペース(min:sec/km)に変換して表示
-- 正の efficiency_score → 「パワー→速度変換効率が向上」「ランニングエコノミーの改善」
+- 正の efficiency_score → 「ランニングエコノミーの改善」
 - 負の efficiency_score → 「疲労/環境/路面の影響の可能性」（安易に非効率と断定しない）
-- star_rating を末尾に含める
 
-**統合スコア** (必須):
-- `get_form_evaluations().integrated_score` (100点満点)
-- `get_form_evaluations().training_mode` を明記
-- 末尾に「統合スコアは XX.X/100点（★★★★☆）」形式で含める
+### 心拍評価
 
-**ケイデンス**:
-- 180spm以上: ポジティブに評価
-- 178-179spm: 「ほぼ達成」「許容範囲」
-- 175-177spm: 「やや低いが許容範囲」
-- 175spm未満: 「改善推奨」
+- `planned_workout` がある場合 → プラン目標HR を最優先基準
+- ない場合 → contract の `zone_targets` で training_type 別評価
 
-**心拍**: `get_hr_efficiency_analysis()` + `get_heart_rate_zones_detail()`でtraining_typeに応じたゾーン配分評価
+### トレンド分析（必須）
 
-**トレンド** (必須): 1ヶ月前との係数比較
-- GCT改善: Δd < -0.1, VO改善: Δb < -0.05, VR改善: Δb < -0.1
+- `get_form_baseline_trend()` の Δd, Δb を contract の `baseline_comparison` で評価
+- 改善/維持/悪化を判定し、前向きなトーンで記述
 
-## 注意事項
+### 注意事項
 
-- フォーム評価は`get_form_evaluations()`から取得（手動計算不要）
+- フォーム評価は `get_form_evaluations()` から取得（手動計算不要）
+- 統合スコアは末尾に「統合スコアは XX.X/100点（★★★★☆）」形式で含める
+- 日本語コーチングトーン、具体的数値を含め、1-2文/ポイント

--- a/packages/garmin-mcp-server/src/garmin_mcp/validation/contracts.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/validation/contracts.py
@@ -114,24 +114,30 @@ _CONTRACTS: dict[str, dict[str, Any]] = {
             },
         },
         "evaluation_policy": {
-            "gct": {
-                "excellent": "220-260ms",
-                "good": "260-280ms",
-                "needs_improvement": ">280ms",
+            "form_ranges": {
+                "gct": {
+                    "excellent": "<220ms",
+                    "good": "220-260ms",
+                    "standard": "260-280ms",
+                    "needs_improvement": ">280ms",
+                },
+                "vo": {
+                    "excellent": "<6.0cm",
+                    "good": "6.0-8.0cm",
+                    "standard": "8.0-10.0cm",
+                    "needs_improvement": ">10.0cm",
+                },
+                "vr": {
+                    "excellent": "<6.0%",
+                    "good": "6.0-8.0%",
+                    "standard": "8.0-10.0%",
+                    "needs_improvement": ">10.0%",
+                },
             },
-            "vertical_oscillation": {
-                "excellent": "6-8cm",
-                "good": "8-10cm",
-                "needs_improvement": ">10cm",
-            },
-            "vertical_ratio": {
-                "ideal": "8-10%",
-                "acceptable": "7-11%",
-                "needs_improvement": ">11%",
-            },
-            "cadence": {
+            "cadence_ranges": {
                 "ideal": ">=180 spm",
-                "acceptable": "175-179 spm",
+                "near_target": "178-179 spm",
+                "acceptable": "175-177 spm",
                 "needs_improvement": "<175 spm",
             },
             "integrated_score_stars": {
@@ -141,11 +147,40 @@ _CONTRACTS: dict[str, dict[str, Any]] = {
                 "2_stars": "50-69",
                 "1_star": "<50",
             },
+            "power_efficiency_stars": {
+                "5_stars": "+5% or more (highly efficient)",
+                "4_stars": "+2% to +5% (efficient)",
+                "3_stars": "±2% (normal pattern)",
+                "2_stars": "-2% to -5% (slightly inefficient)",
+                "1_star": "-5% or less (inefficient)",
+            },
+            "baseline_comparison": {
+                "daily_variation_normal": "±5%",
+                "baseline_improved": ">+10%",
+                "baseline_normal": "±10%",
+                "baseline_attention": "<-10%",
+            },
+            "zone_targets": {
+                "base_easy_recovery": {
+                    "primary_zones": "Zone 1-2",
+                    "target_pct": ">=70%",
+                },
+                "tempo_threshold": {
+                    "primary_zones": "Zone 3-4",
+                    "target_pct": ">=60%",
+                },
+                "interval_sprint": {
+                    "primary_zones": "Zone 4-5",
+                    "target_pct": ">=50%",
+                },
+            },
         },
         "instructions": [
             "Use form_evaluations MCP data as primary source",
-            "Report integrated_score with star rating",
-            "Compare baseline coefficients with 1-month prior",
+            "Retrieve form ranges, cadence, and star rating scales from this contract",
+            "Report integrated_score with star rating using integrated_score_stars scale",
+            "Compare baseline coefficients with 1-month prior using baseline_comparison thresholds",
+            "Evaluate HR zone distribution against zone_targets for the training_type",
             "Use Garmin native HR zones only",
         ],
     },

--- a/packages/garmin-mcp-server/tests/validation/test_contracts.py
+++ b/packages/garmin-mcp-server/tests/validation/test_contracts.py
@@ -27,11 +27,49 @@ def test_get_contract_phase():
 def test_get_contract_efficiency():
     contract = get_contract("efficiency")
     policy = contract["evaluation_policy"]
-    assert "gct" in policy
-    assert "vertical_oscillation" in policy
-    assert "vertical_ratio" in policy
-    assert "cadence" in policy
+    assert "form_ranges" in policy
+    assert "cadence_ranges" in policy
     assert "integrated_score_stars" in policy
+    assert "power_efficiency_stars" in policy
+    assert "baseline_comparison" in policy
+    assert "zone_targets" in policy
+
+
+@pytest.mark.unit
+def test_efficiency_contract_has_form_ranges():
+    contract = get_contract("efficiency")
+    form = contract["evaluation_policy"]["form_ranges"]
+    assert len(form) == 3
+    for metric in ["gct", "vo", "vr"]:
+        assert metric in form
+        assert "excellent" in form[metric]
+        assert "needs_improvement" in form[metric]
+
+
+@pytest.mark.unit
+def test_efficiency_contract_has_integrated_score():
+    contract = get_contract("efficiency")
+    score = contract["evaluation_policy"]["integrated_score_stars"]
+    assert "5_stars" in score
+    assert "1_star" in score
+
+
+@pytest.mark.unit
+def test_efficiency_contract_has_zone_targets():
+    contract = get_contract("efficiency")
+    zones = contract["evaluation_policy"]["zone_targets"]
+    assert len(zones) == 3
+    for category in ["base_easy_recovery", "tempo_threshold", "interval_sprint"]:
+        assert category in zones
+
+
+@pytest.mark.unit
+def test_efficiency_contract_has_baseline_thresholds():
+    contract = get_contract("efficiency")
+    baseline = contract["evaluation_policy"]["baseline_comparison"]
+    assert "daily_variation_normal" in baseline
+    assert "baseline_improved" in baseline
+    assert "baseline_attention" in baseline
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- efficiency contract の `evaluation_policy` を拡充（form_ranges, cadence_ranges, power_efficiency_stars, baseline_comparison, zone_targets）
- efficiency-section-analyst.md を contract+validate ワークフローにリライト（201→105行, 48%減）
- 4つの新規 unit テスト追加

Closes #145

## Validation

- **Unit tests**: 16/16 passed
- **L3**: contract 構造検証 OK、validate_section_data 正常動作確認

## Test plan

- [x] `test_efficiency_contract_has_form_ranges` — gct/vo/vr with 4 levels each
- [x] `test_efficiency_contract_has_integrated_score` — 5 star levels
- [x] `test_efficiency_contract_has_zone_targets` — 3 training type categories
- [x] `test_efficiency_contract_has_baseline_thresholds` — daily/baseline thresholds

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>