### PR TITLE
refactor: rewrite summary-section-analyst with contract+validate workflow

### DIFF
--- a/.claude/agents/summary-section-analyst.md
+++ b/.claude/agents/summary-section-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: summary-section-analyst
 description: 総合評価と改善提案を生成するエージェント。DuckDBに保存。総合評価が必要な時に呼び出す。
-tools: mcp__garmin-db__get_splits_comprehensive, mcp__garmin-db__get_form_efficiency_summary, mcp__garmin-db__get_form_evaluations, mcp__garmin-db__get_performance_trends, mcp__garmin-db__get_vo2_max_data, mcp__garmin-db__get_lactate_threshold_data, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__compare_similar_workouts, Write
+tools: mcp__garmin-db__get_splits_comprehensive, mcp__garmin-db__get_form_efficiency_summary, mcp__garmin-db__get_form_evaluations, mcp__garmin-db__get_performance_trends, mcp__garmin-db__get_vo2_max_data, mcp__garmin-db__get_lactate_threshold_data, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__compare_similar_workouts, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
 model: inherit
 ---
 
@@ -18,146 +18,101 @@ model: inherit
 
 ## 使用するMCPツール
 
-**利用可能なツール（これらのみ使用可能）:**
-- `mcp__garmin-db__get_splits_comprehensive(activity_id, statistics_only=True)` - **全スプリットデータ統合版（pace/HR/form/elevation を1回で取得）**
-- `mcp__garmin-db__get_form_efficiency_summary(activity_id)` - フォーム効率サマリー
-- `mcp__garmin-db__get_performance_trends(activity_id)` - パフォーマンストレンド
-- `mcp__garmin-db__get_vo2_max_data(activity_id)` - VO2 maxデータ
-- `mcp__garmin-db__get_lactate_threshold_data(activity_id)` - 乳酸閾値データ
-- `mcp__garmin-db__get_hr_efficiency_analysis(activity_id)` - 心拍効率分析（トレーニングタイプ、ゾーン分布）
-- `mcp__garmin-db__compare_similar_workouts(activity_id, pace_tolerance=0.1, distance_tolerance=0.1)` - 類似ワークアウト比較
+- `get_splits_comprehensive(activity_id, statistics_only=True)` - 全スプリットデータ統合版
+- `get_form_efficiency_summary(activity_id)` - フォーム効率サマリー
+- `get_form_evaluations(activity_id)` - ペース補正済み評価（needs_improvement 判定に必須）
+- `get_performance_trends(activity_id)` - パフォーマンストレンド
+- `get_vo2_max_data(activity_id)` - VO2 maxデータ
+- `get_lactate_threshold_data(activity_id)` - 乳酸閾値データ
+- `get_hr_efficiency_analysis(activity_id)` - 心拍効率分析
+- `compare_similar_workouts(activity_id, pace_tolerance=0.1, distance_tolerance=0.1)` - 類似ワークアウト比較
+- `get_analysis_contract("summary")` - 評価基準・閾値の取得
+- `validate_section_json("summary", data)` - 出力スキーマ検証
 - `Write` - 分析結果をJSONファイルとしてtempディレクトリに保存
 
-**事前取得コンテキストによる省略:**
+## 事前取得コンテキストによる省略
 
-事前取得コンテキストが提供されている場合、以下のMCP呼び出しを省略する：
-- `get_weather_data()` → コンテキストの `temperature_c`, `humidity_pct`, `wind_mps` を使用
-- `get_hr_efficiency_analysis()` → コンテキストの `training_type`, `zone_percentages`, `primary_zone` 等を使用（C1拡張により完全省略可能）
-- `get_heart_rate_zones_detail()` → `zone_percentages` がコンテキストに含まれるため不要
-- `get_form_evaluations()` → コンテキストの `form_scores` にstar_rating/score/integrated_score/overall_scoreが含まれる場合は省略可能（C2拡張）。ただし `needs_improvement` フィールドが必要な場合はツール呼び出しが必要
-- `get_performance_trends()` → コンテキストの `phase_structure` にpace_consistency/hr_drift等が含まれる場合は省略可能（C3拡張）。ただしメイン区間の詳細評価が必要な場合はツール呼び出しが必要
+事前取得コンテキストが提供されている場合、以下のMCP呼び出しを省略可能：
+- `get_hr_efficiency_analysis()` → コンテキストの `training_type`, `zone_percentages` を使用
+- `get_form_evaluations()` → `form_scores` にスコアが含まれる場合は省略可能。ただし `needs_improvement` フィールドが必要な場合はツール呼び出しが必要
+- `get_performance_trends()` → `phase_structure` にpace_consistency/hr_drift等が含まれる場合は省略可能
 
-**ツール統合:**
-- ~~`get_splits_pace_hr` + `get_splits_form_metrics`~~ → `get_splits_comprehensive(statistics_only=True)` で1回に統合
+## ワークフロー
 
-**推奨アプローチ:**
-- `statistics_only=True` で軽量版を使用（80%トークン削減）
-- 他セクション分析（efficiency, environment, phase, split）は参照しない
+### Step 1: データ取得 + contract 取得（並列実行）
 
-## フォーム評価の使用（Form Evaluation Usage）
-
-**CRITICAL**: improvement_areas では `get_form_evaluations()` の結果を優先すること。
-
-### 使用手順:
-
-1. **必ず `get_form_evaluations(activity_id)` を呼び出す:**
-   ```python
-   mcp__garmin-db__get_form_evaluations(activity_id=20625808856)
-   ```
-
-2. **`needs_improvement=true` の指標のみを improvement_areas に含める:**
-   - 各指標の `needs_improvement` フィールドを確認
-   - `true` の指標のみを改善点として記載
-   - `false` の指標は key_strengths に含めることができる
-
-3. **達成済み目標は improvement_areas に含めない:**
-   - ❌ NG: "GCT優秀（250ms未満達成）" を improvement_areas に記載
-   - ✅ OK: "GCT優秀（250ms未満達成）" を key_strengths に記載
-   - ❌ NG: "VO良好" を improvement_areas に記載
-   - ✅ OK: "VO改善必要（11.5cm、目標9cm未満）" を improvement_areas に記載
-
-### プラン目標によるフィルタリング:
-
-事前取得コンテキストに`planned_workout`がある場合、improvement_areasとrecommendationsを以下のルールでフィルタする:
-
-- `target_hr_low`〜`target_hr_high`が設定されていて、実際のHRがその範囲内 → HR関連のimprovement_areasに**含めない**
-- `target_pace_low`〜`target_pace_high`が設定されていて、実際のペースがその範囲内 → ペース関連のimprovement_areasに**含めない**
-- プラン目標を超えた場合のみ改善提案を記載
-- `planned_workout`がnullの場合は従来通り（フィルタなし）
-
-### 矛盾防止ガイドライン:
-
-**理由**: `get_form_evaluations()` はペース補正済みの精密評価を提供します。この評価を無視すると、efficiency-section-analyst との間で矛盾が発生します。
-
-**具体例:**
-
-```python
-# get_form_evaluations() の結果:
-{
-    "gct": {
-        "evaluation_text": "接地時間は優秀です（249ms、目標250ms未満）",
-        "needs_improvement": false,
-        "star_rating": "★★★★★"
-    },
-    "vo": {
-        "evaluation_text": "上下動は改善が必要です（11.5cm、目標9cm未満）",
-        "needs_improvement": true,
-        "star_rating": "★★☆☆☆"
-    }
-}
-
-# 正しい使用:
-improvement_areas = [
-    "上下動: 11.5cm（目標9cm未満を2.5cm上回る）",  # needs_improvement=true
-    # GCT は含めない（needs_improvement=false なので達成済み）
-]
-
-key_strengths = [
-    "**GCT優秀**: 249ms（目標250ms未満達成）✅",  # needs_improvement=false
-]
+```
+get_form_evaluations(activity_id)                     # needs_improvement 判定に必須
+get_splits_comprehensive(activity_id, statistics_only=True)  # 統計サマリー
+get_performance_trends(activity_id)                   # HR drift, pace CV
+get_hr_efficiency_analysis(activity_id)               # training_type + ゾーン
+get_vo2_max_data(activity_id)                         # VO2max
+get_lactate_threshold_data(activity_id)               # LT データ
+compare_similar_workouts(activity_id)                 # 類似比較
+get_analysis_contract("summary")                      # 評価基準
 ```
 
-**重要**:
-- この評価はペース補正後の値を使用しているため、生の平均値（`get_form_efficiency_summary()`）とは異なる場合があります
-- efficiency-section-analyst も同じ `get_form_evaluations()` を使用するため、矛盾は発生しません
-- `needs_improvement=true` の指標のみを improvement_areas に含めることで、一貫性が保たれます
+### Step 2: contract の evaluation_policy を参照して分析
 
-## 統合フォームスコア（integrated_score）の活用
+1. `star_rating.weights` で4軸重み付き総合評価を算出
+2. `training_type_criteria[type]` で training_type 別の良し悪し判定
+3. `summary_structure` のフォーマットで summary テキスト生成
+4. `next_run_target_variants[type]` で次回ターゲット算出
+5. `recommendations.format` + `recommendations.rules` で改善提案作成
+6. `plan_achievement.weights` + `plan_achievement.scale` でプラン達成度評価（planned_workout がある場合のみ）
 
-**CRITICAL**: 事前取得コンテキストの `form_scores.integrated_score` を総合評価に組み込むこと。
+### Step 3: JSON 生成 + バリデーション
 
-### 使用手順:
+```python
+analysis_data = {
+    "star_rating": "★★★★☆ 4.2/5.0",
+    "integrated_score": 78.5,           # null/未取得時は省略
+    "summary": "...",                   # 2-3文
+    "key_strengths": [...],            # 3-5項目
+    "improvement_areas": [...],        # 最大2件
+    "next_action": "...",              # 1件のみ、数値+成功条件
+    "next_run_target": {...},          # training_type別 dict
+    "recommendations": "...",          # 構造化マークダウン
+    "plan_achievement": {...}          # planned_workout 時のみ
+}
+validate_section_json("summary", analysis_data)
+# → valid=true なら Step 4 へ
+```
 
-1. **summaryテキストに含める:**
-   - 「統合フォームスコア: XX.X/100」を summary の冒頭〜中盤に自然に組み込む
-   - 例: 「フォーム効率は統合スコア78.5/100と良好で、...」
+### Step 4: 保存
 
-2. **類似ワークアウトとの比較:**
-   - `compare_similar_workouts()` の結果にスコアデータがあれば、推移をコメント
-   - 改善: key_strengths に「**フォームスコア向上**: 前回比+3.2pt（75.3→78.5/100）✅」
-   - 悪化: improvement_areas に「フォームスコア低下: 前回比-2.1pt（80.6→78.5/100）」
+```python
+Write(file_path="{temp_dir}/summary.json", content=json.dumps({
+    "activity_id": activity_id, "activity_date": activity_date,
+    "section_type": "summary", "analysis_data": analysis_data
+}, ensure_ascii=False, indent=2))
+```
 
-3. **analysis_data に `integrated_score` フィールドを出力:**
-   - `"integrated_score": 78.5` （float）
-   - integrated_score が null または事前取得コンテキストに含まれない場合はフィールドを省略
+## フォーム評価の使用
 
-### null ハンドリング:
-- `form_scores` が null、または `integrated_score` が null の場合:
-  - summary テキストにスコアを記載しない
-  - `integrated_score` フィールドを省略
-  - 他の分析は通常通り続行
+**CRITICAL**: improvement_areas では `get_form_evaluations()` の結果を優先する。
 
-## プラン達成度（plan_achievement）
+1. `get_form_evaluations(activity_id)` を呼び出す
+2. `needs_improvement=true` の指標のみを improvement_areas に含める
+3. `needs_improvement=false` の指標は key_strengths に含める
+4. 達成済み目標は improvement_areas に含めない
 
-**条件**: 事前取得コンテキストの `planned_workout` が not null の場合のみ出力。null（アドホックラン）の場合はフィールドごとスキップ。
+### プラン目標によるフィルタリング
 
-### 出力手順:
+`planned_workout` がある場合:
+- 実際のHRが `target_hr_low`〜`target_hr_high` 範囲内 → HR関連の improvement_areas に含めない
+- 実際のペースが `target_pace_low`〜`target_pace_high` 範囲内 → ペース関連の improvement_areas に含めない
+- プラン目標を超えた場合のみ改善提案を記載
 
-1. **目標値を取得:**
-   - `planned_workout.target_hr_low` / `target_hr_high` → HR目標範囲
-   - `planned_workout.target_pace_low` / `target_pace_high` → ペース目標範囲（秒/km）
-   - `planned_workout.workout_type` → ワークアウトタイプ（easy, tempo, interval等）
-   - いずれかが null の場合、該当する比較をスキップ
+## integrated_score の活用
 
-2. **実績値を取得:**
-   - `phase_structure.run.avg_hr` → メイン区間の平均HR
-   - `phase_structure.run.avg_pace_str` → メイン区間の平均ペース
+- summary テキストに「統合フォームスコア: XX.X/100」を自然に組み込む
+- `compare_similar_workouts()` で推移をコメント（改善→key_strengths、悪化→improvement_areas）
+- `integrated_score` が null の場合はフィールドごと省略
 
-3. **達成判定:**
-   - HR: 実績が `target_hr_low` ≤ avg_hr ≤ `target_hr_high` なら達成（✅）、範囲外なら未達（⚠️）
-   - ペース: 実績が `target_pace_low` ≤ avg_pace ≤ `target_pace_high` なら達成（✅）、範囲外なら未達（⚠️）
+## plan_achievement
 
-4. **analysis_data に `plan_achievement` dict を出力:**
+**条件**: `planned_workout` が not null の場合のみ出力。
 
 ```json
 "plan_achievement": {
@@ -171,297 +126,68 @@ key_strengths = [
 }
 ```
 
-### workout_type → description_ja マッピング:
-- `easy` → "イージーラン"
-- `recovery` → "リカバリーラン"
-- `long_run` → "ロングラン"
-- `tempo` → "テンポ走"
-- `threshold` → "閾値走"
-- `interval` → "インターバル"
-- `repetition` → "レペティション"
-- その他 → workout_type をそのまま使用
+### workout_type → description_ja マッピング
+- `easy` → "イージーラン", `recovery` → "リカバリーラン", `long_run` → "ロングラン"
+- `tempo` → "テンポ走", `threshold` → "閾値走", `interval` → "インターバル"
+- `repetition` → "レペティション", その他 → workout_type をそのまま使用
 
-### null ハンドリング:
+### null ハンドリング
 - `planned_workout` が null → `plan_achievement` フィールドを出力しない
-- `target_hr_low`/`target_hr_high` が null → `hr_achieved` を出力しない、targets.hr を省略
-- `target_pace_low`/`target_pace_high` が null → `pace_achieved` を出力しない、targets.pace を省略
-- 両方 null → `plan_achievement` フィールドを出力しない
+- `target_hr_*` が null → `hr_achieved` を省略
+- `target_pace_*` が null → `pace_achieved` を省略
+- 両方 null → `plan_achievement` を出力しない
 
-## 出力形式
+## next_run_target
 
-**section_type**: `"summary"`
+training_type に応じて contract の `next_run_target_variants` を参照し、以下の dict を算出:
 
-分析結果をJSONファイルとしてtempディレクトリに保存する例：
+**Easy/Recovery (HR基準):**
+- `recommended_type`, `target_hr_low`, `target_hr_high`, `reference_pace_*_formatted`
+- `success_criterion`, `adjustment_tip`, `summary_ja`
+- Easy run は HR 範囲が主、ペースは参考値
 
-```python
-Write(
-    file_path="{temp_dir}/summary.json",
-    content=json.dumps({
-    "activity_id": 20464005432,
-    "activity_date": "2025-10-07",
-    "section_type": "summary",
-    "analysis_data": {
-        "star_rating": "★★★★☆ 4.2/5.0",
-        "integrated_score": 78.5,
-        "summary": """
-今日のランは質の高い有酸素ベース走でした。フォーム効率は統合スコア78.5/100と良好です。平均心拍数146bpm、平均ペース6:45/km、平均パワー225Wという適切な中強度で、ペース変動係数0.017と非常に高い安定性を発揮しています。
-""",
-        "key_strengths": [
-            "ペース安定性: 変動係数0.017（目標<0.05を大幅クリア）",
-            "**パワー効率向上**: 前回比-5W（2.2%効率アップ）✅",
-            "フォーム効率: 全指標でペース補正後に優秀評価",
-            "類似ワークアウト比: 全指標が改善傾向"
-        ],
-        "improvement_areas": [
-            "ウォームアップ不足: 最初から心拍145bpmでスタート",
-            "上下動: 11.5cm（目標9cm未満を2.5cm上回る）"
-        ],
-        "next_action": "次のベース走では HR 130-145 bpm を維持し、最初の1kmはゆっくり入る（Zone 2 > 60% で成功）",
-        "next_run_target": {
-            "recommended_type": "easy",
-            "target_hr_low": 120,
-            "target_hr_high": 141,
-            "reference_pace_low_formatted": "6:50/km",
-            "reference_pace_high_formatted": "7:05/km",
-            "success_criterion": "Zone 2 比率 60% 以上で成功",
-            "adjustment_tip": "暑い日は +5bpm 許容、疲労時は上限を 5bpm 下げる",
-            "summary_ja": "次の Easy Run では HR 120-141 bpm を維持（参考ペース 6:50/km~7:05/km）。Zone 2 比率 60% 以上で成功"
-        },
-        "recommendations": """
-今回のベース走（有酸素ゾーン中心）を次回実施する際の改善点：
+**Tempo/Threshold (LTペース基準):**
+- `get_lactate_threshold_data()` から LT 速度取得
+- `recommended_type`, `target_pace_*_formatted`, `target_hr`
 
-### 1. ウォームアップの段階的導入 ⭐ 重要度: 高
+**Interval (vVO2max基準):**
+- `get_vo2_max_data()` から VO2max 取得
+- vVO2max (km/h) = VO2max / 3.5 → インターバルペース = 95-100% vVO2max
 
-**現状:**
-最初から心拍145bpmでスタート（ウォームアップ不足）
+**データ不足時:** `{"insufficient_data": true, "summary_ja": "...理由..."}`
 
-**推奨アクション:**
-- 最初の1kmはメインペースより30-60秒/km遅く入る
-- 心拍数が120bpm台から段階的に上がるのを確認
+## 類似ワークアウト比較
 
-**期待効果:**
-怪我リスクの低減、メイン区間でのパフォーマンス向上
-
----
-
-### 2. 接地時間の短縮 ⭐ 重要度: 中
-
-**現状:**
-平均262ms（目標250ms未満を12ms上回る）
-
-**推奨アクション:**
-- ケイデンス180spm以上を意識したリズム走を週1-2回実施
-- 重心直下での着地を意識したドリル練習（ハイニー、バットキック等）
-
-**期待効果:**
-接地時間が250ms未満に改善され、ランニングエコノミーが5-8%向上
-
----
-"""
-    }
-    }, ensure_ascii=False, indent=2)
-)
-```
-
-**フィールド要件:**
-
-1. **star_rating**: "★★★★☆ 4.2/5.0" 形式（星マーク + 数値/5.0）
-   - 評価基準: 5.0=完璧、4.5-4.9=非常に良好、4.0-4.4=良好、3.5-3.9=標準、3.0-3.4=要改善
-   - 観点: フォーム効率30%、ペース管理25%、心拍管理25%、トレーニング品質20%
-
-2. **integrated_score**: float (0-100) または省略
-   - 事前取得コンテキストの `form_scores.integrated_score` をそのまま出力
-   - null/未取得の場合はフィールドごと省略（`"integrated_score": null` は不可）
-
-3. **summary**: 2-3文のワークアウト要約（心拍/ペース/パワーの主要メトリクス + 統合フォームスコア）
-
-4. **key_strengths**: 優れている点のリスト（3-5項目、1行/項目）
-   - フォーマット: "指標名: 数値（評価コメント）"
-   - 重要項目は太字+✅で強調可能
-
-5. **improvement_areas**: 改善可能な点のリスト（**最大2件**、1行/項目）
-   - フォーマット: "課題: 具体的な状況（目標値や推奨値）"
-   - 最重要の2件のみに絞ること（3件以上は情報過多で実行されない）
-
-6. **next_action**: 次回の具体的アクション（**必須、1件のみ**）
-   - 必ず1件、数値付き、成功判定条件を明示
-   - Easy run の場合は HR 範囲で提示（ペースではなく）
-   - 例: `"次のEasy Runでは HR 135-140 bpm を維持（Zone 2 > 60% で成功）"`
-   - 例: `"次のテンポ走では 5:00-5:10/km を維持（CV < 0.02 で成功）"`
-
-7. **next_run_target**: 次のランの具体的目標（dict、**必須**）
-
-   トレーニングタイプに応じて以下のデータを算出し、dictとして出力する。
-
-   **Easy/Recovery/Aerobic Base の場合（HR基準）:**
-   - `get_heart_rate_zones_detail()` から Zone 2 の境界値を取得
-   - `get_splits_comprehensive(statistics_only=True)` から最近のペース-HR 相関を参考にする
-   - Easy run は HR 範囲が主、ペースは参考値として添える（analysis-standards.md 準拠）
-
-   ```json
-   "next_run_target": {
-     "recommended_type": "easy",
-     "target_hr_low": 120,
-     "target_hr_high": 141,
-     "reference_pace_low_formatted": "6:50/km",
-     "reference_pace_high_formatted": "7:10/km",
-     "success_criterion": "Zone 2 比率 60% 以上で成功",
-     "adjustment_tip": "暑い日は +5bpm 許容、疲労時は上限を 5bpm 下げる",
-     "summary_ja": "次の Easy Run では HR 120-141 bpm を維持（参考ペース 6:50/km~7:10/km）。Zone 2 比率 60% 以上で成功"
-   }
-   ```
-
-   **Tempo/Lactate Threshold の場合（LTペース基準）:**
-   - `get_lactate_threshold_data()` から LT 速度を取得
-   - テンポ範囲 = LTペース ±5%
-
-   ```json
-   "next_run_target": {
-     "recommended_type": "tempo",
-     "target_pace_low_formatted": "5:00/km",
-     "target_pace_high_formatted": "5:30/km",
-     "target_hr": 168,
-     "success_criterion": "ペース変動係数 (CV) < 0.03 かつ 5:00/km~5:30/km 維持で成功",
-     "adjustment_tip": "暑い日は 5-10秒/km 遅めを許容",
-     "summary_ja": "次のテンポ走では 5:00/km~5:30/km を維持（目標 HR ~168 bpm）。..."
-   }
-   ```
-
-   **Interval/VO2max の場合（vVO2max ペース基準）:**
-   - `get_vo2_max_data()` から VO2max を取得
-   - vVO2max (km/h) = VO2max / 3.5 → インターバルペース = 95-100% vVO2max
-
-   ```json
-   "next_run_target": {
-     "recommended_type": "interval",
-     "target_pace_low_formatted": "4:19/km",
-     "target_pace_high_formatted": "4:33/km",
-     "success_criterion": "Work 区間を 4:19/km~4:33/km で維持し、Recovery で HR が Zone 2 まで回復すれば成功",
-     "adjustment_tip": "疲労時は本数を減らして質を維持",
-     "summary_ja": "次のインターバルでは Work 区間を 4:19/km~4:33/km で実施。..."
-   }
-   ```
-
-   **データ不足時:** `"next_run_target": {"insufficient_data": true, "summary_ja": "...理由..."}`
-
-8. **recommendations**: 改善提案（構造化マークダウン、**最大2件**）
-
-   **MANDATORY FORMAT - 以下の構造を厳密に守ること:**
-
-   - 冒頭に文脈説明: 「今回の[トレーニングタイプ名]を次回実施する際の改善点：」
-   - 各提案は**必ず**以下の5要素を含むこと:
-     1. 見出し: `### N. タイトル ⭐ 重要度: 高/中/低`
-     2. 現状: `**現状:**` (コロンはアスタリスクの**内側**)
-     3. 推奨: `**推奨アクション:**` (コロンはアスタリスクの**内側**)
-     4. 効果: `**期待効果:**` (コロンはアスタリスクの**内側**)
-     5. 区切り: `---` (各提案の**後**に配置)
-
-   **重要**: `**現状:**` であり、`**現状**: テキスト` ではない（コロンの位置に注意）
-
-**key_strengths と improvement_areas の書き方:**
-- key_strengths: 「指標名: 数値（評価コメント）」形式、重要項目は太字で強調
-  - 例: "**パワー効率向上**: 前回比-5W（2.2%効率アップ）✅"
-  - 例: "ペース安定性: 変動係数0.017（目標<0.05を大幅クリア）"
-- improvement_areas: 「課題: 具体的な状況（目標値や推奨値）」形式
-  - 例: "ウォームアップ不足: 最初から心拍145bpmでスタート"
-  - 例: "Zone 2不足: 19.7%（長期的には60%以上が推奨）"
-
-## インサイト生成の要件（compare_similar_workouts活用）
-
-**CRITICAL**: key_strengths には必ず類似ワークアウトとの比較インサイトを含めること！
-
-### 類似ワークアウト比較の手順:
-
-1. **必ず `compare_similar_workouts()` を呼び出す:**
-   ```python
-   mcp__garmin-db__compare_similar_workouts(
-       activity_id=20625808856,
-       pace_tolerance=0.1,      # ±10%のペース範囲
-       distance_tolerance=0.1   # ±10%の距離範囲
-   )
-   ```
-
-2. **改善指標を抽出してkey_strengthsに追加:**
-   - **パワー効率の改善があれば**: "**パワー効率向上**: 前回比-5W（2.2%効率アップ）✅"
-   - **フォーム指標の改善があれば**: "**GCT改善**: 前回比-3ms（効率1.2%向上）"
-   - **全体的な改善傾向**: "類似ワークアウト比: 全指標が改善傾向"
-   - **心拍効率の改善**: "**心拍効率**: 同ペースで前回比-3bpm（有酸素能力向上）"
-
-**重要**:
-- 類似ワークアウトが見つからない場合でも、分析は続行する（インサイトなしでOK）
-- 改善が見られた指標のみをkey_strengthsに追加（悪化した指標はimprovement_areasへ）
-- 数値とパーセンテージの両方を記載すること
+1. `compare_similar_workouts()` を呼び出す
+2. 改善指標を key_strengths に追加（数値+%の両方を記載）
+3. 悪化指標は improvement_areas へ
+4. 類似ワークアウトが見つからない場合でもインサイトなしで分析続行
 
 ## HR Zone 評価ルール（矛盾防止）
 
-**CRITICAL**: HR zone の評価判断は efficiency-section-analyst の `evaluation` フィールドを権威的ソースとする。
+- ❌ `zone_percentages` を独自解釈して評価コメント生成しない
+- ❌ plan target met なのに training_type ベースで矛盾コメントを出さない
+- ✅ `zone_percentages` は事実の記述として使用可
+- ✅ `plan_achievement.hr_achieved` を HR 達成判断に使用
+- interval training の HR drift 15-25% は正常
 
-### 禁止事項:
-- ❌ `zone_percentages` を独自に解釈して「Zone 2 不足」「Zone 4 が多すぎる」等の評価コメントを生成しない
-- ❌ training_type ベースで zone 分布の良し悪しを独自判断しない（efficiency-section-analyst が担当）
-- ❌ plan target met なのに training_type ベースで「Zone 2 不足」と矛盾するコメントを出さない
+## Training Type 別評価
 
-### 許可事項:
-- ✅ `zone_percentages` を「事実の記述」として使用（例: 「Zone 2: 45%、Zone 3: 30%」）
-- ✅ `plan_achievement.hr_achieved` を HR 達成/未達成の判断に使用
-- ✅ efficiency-section-analyst の `evaluation` テキストを引用・要約して使用
+`get_hr_efficiency_analysis()` で training_type を取得し、タイプ別に評価:
 
-### interval training の HR drift:
-- interval training の HR drift 15-25% は正常（追い込むメニューのため）
-- split-analyst の HR drift 評価（<5% excellent）は interval には適用しない
+- **閾値/インターバル系**: メイン区間（run）のみ評価。HR drift/全体フォームばらつきは評価しない
+- **ベースラン**: Zone 2維持 + HR drift + ペース安定性
+- **テンポ走**: Zone 3-4比率 + ペース安定性 + HR drift（10-15%許容）
+- **リカバリーラン**: Zone 1-2のみ（>90%）、フォーム効率は評価不要
 
-## Training Type別評価基準
+## recommendations フォーマット
 
-**必須**: `get_hr_efficiency_analysis(activity_id)` で training_type を取得し、タイプ別に評価すること。
+contract の `recommendations.format` に従う。各提案は以下の5要素を**全て**含むこと:
 
-### 閾値/インターバル系 (lactate_threshold, vo2max, interval_training)
-**重要**: メイン区間（run）のみ評価！全体統計は使わない（ウォームアップ/クールダウン/Recovery混入のため）
-- ✅ `get_performance_trends(activity_id)` から `run_metrics` 取得
-- ✅ run区間のペース変動係数、Zone配分を評価
-- ❌ 心拍ドリフトは評価しない（追い込むメニューなので15-25%は正常）
-- ❌ 全体フォームばらつきは評価しない（フェーズ間で変わるのは当然）
+1. `### N. タイトル ⭐ 重要度: 高/中/低`
+2. `**現状:**` (改行後にテキスト、コロンは**内側**)
+3. `**推奨アクション:**` (改行後に箇条書き)
+4. `**期待効果:**` (改行後にテキスト)
+5. `---` (提案の最後)
 
-### ベースラン (aerobic_base)
-- Zone 2維持（>70%）、心拍ドリフト（<10%）、ペース安定性を評価
-
-### テンポ走 (tempo)
-- Zone 3-4時間比率（>60%）、ペース安定性、心拍ドリフト（10-15%許容）
-
-### リカバリーラン (recovery)
-- Zone 1-2のみ（>90%）、フォーム効率は評価不要
-
-## 分析ガイドライン
-
-**評価観点:**
-- フォーム効率（GCT/VO/VR）と心拍効率の統合評価
-- ペース安定性、心拍ドリフト、トレーニングタイプとの整合性
-
-**改善提案の構成:**
-1. 今回の課題指摘（データから見える具体的問題点）
-2. 改善のための技術的アドバイス（具体的な練習方法）
-3. 次のステップ提案（リカバリー時間、次回強度設定）
-
-## 重要事項
-
-- **データドリブン**: 数値データに基づいた具体的な改善提案（抽象的な提案は避ける）
-- **トークン効率**: `statistics_only=True` を活用、必要なsectionのみ取得
-
-## ❗ CRITICAL: recommendations フォーマット検証
-
-**生成前に必ず確認すること:**
-
-各改善提案は以下の5要素を**全て**含んでいるか？
-
-✅ `### 1. タイトル ⭐ 重要度: 高/中/低` (番号 + タイトル + 重要度)
-✅ `**現状:**` (改行後にテキスト、コロンは**内側**)
-✅ `**推奨アクション:**` (改行後に箇条書き、コロンは**内側**)
-✅ `**期待効果:**` (改行後にテキスト、コロンは**内側**)
-✅ `---` (提案の最後)
-
-**NG例:**
-❌ `**現状**: テキスト` → コロンが外側
-❌ `### タイトル` → 番号なし、重要度なし
-❌ パラグラフ形式のみ → 構造化されていない
-
-**OK例:**
-✅ Base Run (2025-10-08) の改善ポイントセクション参照
+冒頭に文脈説明を含める: 「今回の[トレーニングタイプ名]を次回実施する際の改善点：」

--- a/packages/garmin-mcp-server/src/garmin_mcp/validation/contracts.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/validation/contracts.py
@@ -431,54 +431,115 @@ _CONTRACTS: dict[str, dict[str, Any]] = {
             },
         },
         "evaluation_policy": {
-            "star_rating_scale": {
-                "5.0": "Exceptional",
-                "4.0-4.9": "Strong",
-                "3.0-3.9": "Adequate",
-                "2.0-2.9": "Below expectations",
-                "1.0-1.9": "Poor",
+            "star_rating": {
+                "weights": {
+                    "form_efficiency": 0.30,
+                    "pace_consistency": 0.25,
+                    "hr_management": 0.25,
+                    "execution_quality": 0.20,
+                },
+                "scale": [
+                    {"stars": "5.0", "min": 4.5, "description": "Exceptional"},
+                    {"stars": "4.0-4.9", "min": 3.5, "description": "Strong"},
+                    {"stars": "3.0-3.9", "min": 2.5, "description": "Adequate"},
+                    {
+                        "stars": "2.0-2.9",
+                        "min": 1.5,
+                        "description": "Below expectations",
+                    },
+                    {"stars": "1.0-1.9", "min": 0, "description": "Poor"},
+                ],
             },
             "next_run_target_variants": {
-                "easy_recovery": [
-                    "recommended_type",
-                    "target_hr_low",
-                    "target_hr_high",
-                    "reference_pace_low_formatted",
-                    "reference_pace_high_formatted",
-                    "success_criterion",
-                    "adjustment_tip",
-                    "summary_ja",
-                ],
-                "tempo_threshold": [
-                    "recommended_type",
-                    "target_pace_low_formatted",
-                    "target_pace_high_formatted",
-                    "target_hr",
-                    "success_criterion",
-                    "adjustment_tip",
-                    "summary_ja",
-                ],
-                "interval": [
-                    "recommended_type",
-                    "target_pace_low_formatted",
-                    "target_pace_high_formatted",
-                    "success_criterion",
-                    "adjustment_tip",
-                    "summary_ja",
-                ],
-                "data_insufficient": [
-                    "insufficient_data",
-                    "summary_ja",
+                "base_easy": {
+                    "distance": "±10%",
+                    "pace": "±5sec/km (reference only)",
+                    "hr_cap": "avg+5bpm, ≤Zone2 upper",
+                    "focus": "HR range primary, pace secondary",
+                },
+                "tempo": {
+                    "distance": "same or +1km",
+                    "pace": "-3sec/km (gradual improvement)",
+                    "hr_zone": "Zone 3-4 time +5%",
+                },
+                "interval": {
+                    "sets": "same or +1 rep",
+                    "pace": "±3sec/km",
+                    "recovery": "HR drops to Zone 2 before next set",
+                },
+                "long_run": {
+                    "distance": "+1-2km (≤30% weekly volume)",
+                    "pace": "Easy pace (HR Zone 1-2)",
+                    "nutrition": "Plan fueling if >60min",
+                },
+            },
+            "recommendations": {
+                "max_count": 2,
+                "format": {
+                    "heading": "### N. Title ⭐ 重要度: 高/中/低",
+                    "sections": [
+                        "**現状:**",
+                        "**推奨アクション:**",
+                        "**期待効果:**",
+                    ],
+                    "separator": "---",
+                },
+                "rules": [
+                    "Specific numbers required (no generic advice)",
+                    "Easy run suggestions use HR range, not pace",
+                    "Each recommendation must include measurable target",
                 ],
             },
-            "recommendations_max": 2,
+            "plan_achievement": {
+                "weights": {"pace": 0.40, "hr": 0.30, "distance": 0.30},
+                "scale": [
+                    {"stars": 5, "min_pct": 95},
+                    {"stars": 4, "min_pct": 85},
+                    {"stars": 3, "min_pct": 75},
+                    {"stars": 2, "min_pct": 60},
+                    {"stars": 1, "min_pct": 0},
+                ],
+            },
+            "training_type_criteria": {
+                "base": {
+                    "hr_zone_1_2": ">=80%",
+                    "pace_cv": "<3%",
+                },
+                "tempo": {
+                    "hr_zone_3_4": ">=60%",
+                    "pace_cv": "<5%",
+                    "hr_drift": "10-15% allowed",
+                },
+                "interval": {
+                    "work_recovery_contrast": "clear HR amplitude",
+                    "hr_drift": "N/A",
+                },
+                "recovery": {
+                    "hr_zone_1_2": ">=90%",
+                    "form_eval": "not required",
+                },
+                "race": {
+                    "pacing": "negative split or even",
+                    "hr_drift": "expected",
+                },
+            },
+            "summary_structure": {
+                "line_1": "training_type + distance + overall rating (1 sentence)",
+                "line_2": "Best aspect with specific number",
+                "line_3": "Improvement point with number (optional if none)",
+            },
             "next_action_count": 1,
         },
         "instructions": [
+            "Retrieve star_rating weights and training_type_criteria from this contract",
             "Exactly 1 next_action with numeric target and success condition",
-            "Maximum 2 recommendations with specific numbers",
+            "Maximum recommendations per recommendations.max_count",
+            "Follow recommendations.format for structured markdown",
             "Easy run suggestions use HR range, not pace",
             "Include plan_achievement only when planned_workout exists",
+            "Use plan_achievement.weights and scale for achievement scoring",
+            "Use summary_structure for summary text format",
+            "Use next_run_target_variants[type] for target calculation",
         ],
     },
 }

--- a/packages/garmin-mcp-server/tests/validation/test_contracts.py
+++ b/packages/garmin-mcp-server/tests/validation/test_contracts.py
@@ -185,10 +185,54 @@ def test_environment_contract_has_star_rating_weights():
 def test_get_contract_summary():
     contract = get_contract("summary")
     policy = contract["evaluation_policy"]
-    assert "star_rating_scale" in policy
+    assert "star_rating" in policy
     assert "next_run_target_variants" in policy
-    assert policy["recommendations_max"] == 2
+    assert policy["recommendations"]["max_count"] == 2
     assert policy["next_action_count"] == 1
+
+
+@pytest.mark.unit
+def test_summary_contract_has_star_rating_weights():
+    contract = get_contract("summary")
+    weights = contract["evaluation_policy"]["star_rating"]["weights"]
+    assert abs(sum(weights.values()) - 1.0) < 0.01
+    assert len(weights) == 4
+
+
+@pytest.mark.unit
+def test_summary_contract_has_next_run_variants():
+    contract = get_contract("summary")
+    variants = contract["evaluation_policy"]["next_run_target_variants"]
+    assert len(variants) == 4
+    for v in ["base_easy", "tempo", "interval", "long_run"]:
+        assert v in variants
+
+
+@pytest.mark.unit
+def test_summary_contract_has_recommendations_rules():
+    contract = get_contract("summary")
+    rec = contract["evaluation_policy"]["recommendations"]
+    assert rec["max_count"] == 2
+    assert "format" in rec
+    assert "rules" in rec
+
+
+@pytest.mark.unit
+def test_summary_contract_has_plan_achievement():
+    contract = get_contract("summary")
+    pa = contract["evaluation_policy"]["plan_achievement"]
+    weights = pa["weights"]
+    assert abs(sum(weights.values()) - 1.0) < 0.01
+    assert len(pa["scale"]) == 5
+
+
+@pytest.mark.unit
+def test_summary_contract_has_training_type_criteria():
+    contract = get_contract("summary")
+    criteria = contract["evaluation_policy"]["training_type_criteria"]
+    assert len(criteria) == 5
+    for t in ["base", "tempo", "interval", "recovery", "race"]:
+        assert t in criteria
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- Expanded `summary` evaluation_policy in `contracts.py` with structured star_rating weights (4-axis), next_run_target_variants (4 types), recommendations format/rules, plan_achievement weights/scale, training_type_criteria (5 types), and summary_structure
- Rewrote `summary-section-analyst.md` to contract+validate workflow (get_analysis_contract + validate_section_json), reducing from 467 to ~194 lines
- Added 5 new unit tests validating contract structure, updated existing test

Closes #147

## Test plan

- [x] 26/26 unit tests pass (`test_contracts.py`)
- [x] Pre-commit hooks pass (black, ruff, mypy)
- [ ] L3 E2E validation (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>