### PR TITLE
docs: clarify that Validation Level skip does not skip dev workflow

### DIFF
--- a/.claude/rules/dev/dev-reference.md
+++ b/.claude/rules/dev/dev-reference.md
@@ -49,8 +49,7 @@ Skip: Design セクションなし、Issue番号不明、dry-run時。
 
 - **Serena activate**: コード調査前に必ず `mcp__serena__activate_project()` 実行
 - **Stale recovery**: Serena → activate、garmin-db → `reload_server()`、それでもダメなら `/mcp`
-- **Code changes** (`packages/`, `tests/`): worktree MANDATORY
-- **Rules/docs** (`.claude/rules/`, `docs/`): PR required (branch protection)
+- **全変更**: Issue → Plan → Worktree → PR（branch protection により必須）
 - **Planning**: main branch (read-only)
 - **PR**: merge commit --no-ff、1 PR = 1 Sub-issue、title は Conventional Commits、body に `Closes #{issue}`
 - **Commit**: Conventional Commits + Co-Authored-By。単一の関心事のみ（"and" が必要なら分割）
@@ -59,6 +58,9 @@ Skip: Design セクションなし、Issue番号不明、dry-run時。
 ## 3. Validation
 
 ### Validation Level 判定
+
+> **Validation Level は PR マージ前の検証方法を決めるもの。
+> skip は「Validation Agent をスキップ」であり「ワークフロー(Issue/Plan/Worktree/PR)をスキップ」ではない。**
 
 変更対象の**全ファイル**を以下と照合し、最も高いレベルを採用:
 

--- a/.claude/rules/dev/implementation-workflow.md
+++ b/.claude/rules/dev/implementation-workflow.md
@@ -56,6 +56,7 @@ Risks セクション（任意）:
 | L1 | `uv run pytest {test_path} -m unit -v` | 0 failures |
 | L2 | L1 + `uv run pytest -m integration --tb=short -q` | 0 failures |
 | L3 | L2 + Validation Agent（foreground）で `reload_server` → `/analyze-activity` 実行 | analysis_data 非null + 必須フィールド存在 |
+| skip | Validation Agent スキップ。コードレビュー(Phase 2a)のみ | 2a チェック通過 |
 
 **CRITICAL**: テスト結果は自分のターンで確認する。サブエージェントの報告を信じない。
 
@@ -68,7 +69,7 @@ Risks セクション（任意）:
 - `/implement` の Step 5 が Phase 2 に相当する
 - developer agent 完了 → Validation Agent 起動（Step 5）→ Phase 3 (Ship)
 - Validation Agent は `/implement` が自動起動する（手動で別途起動する必要はない）
-- skip レベル（ルール/コマンド変更のみ）の場合は検証をスキップして Phase 3 へ
+- skip レベルの場合は Phase 2a（コードレビュー）のみ実施し Phase 3 へ（Validation Agent はスキップ）
 
 ## Phase 3: Ship (PR作成)
 

--- a/.claude/rules/dev/worktree-validation-protocol.md
+++ b/.claude/rules/dev/worktree-validation-protocol.md
@@ -115,7 +115,10 @@ manifest の `validation_level` に応じた手順を実行する。
 
 ## Skip 条件
 
-`validation_level` 未指定かつ変更が `.claude/rules/`, `docs/`, `CLAUDE.md` のみの場合、検証スキップ。
+`validation_level: skip` は Validation Agent の実行をスキップする。
+Issue → Plan → Worktree → PR のワークフローは変わらない。
+
+判定: `validation_level` 未指定かつ変更が `.claude/rules/`, `docs/`, `CLAUDE.md` のみの場合に該当。
 
 ## Manifest ディレクトリ
 


### PR DESCRIPTION
## Summary
- Separate "development workflow" (Issue/Plan/Worktree/PR — always required) from "Validation Level" (L1/L2/L3/skip — verification method only)
- Add explicit note in §3 Validation Level that skip ≠ workflow skip
- Add `skip` row to Phase 2b table in implementation-workflow.md
- Clarify Skip section in worktree-validation-protocol.md

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)