### PR TITLE
docs: reinforce that Validation Level skip does not bypass dev workflow

### DIFF
--- a/.claude/rules/dev/dev-reference.md
+++ b/.claude/rules/dev/dev-reference.md
@@ -120,6 +120,7 @@ Skip: Design セクションなし、Issue番号不明、dry-run時。
 - ルールを CLAUDE.md に直接記述 (`.claude/rules/` を使う)
 - 本番データ依存テスト
 - 複数の無関係な変更を1コミットに混在
+- Validation Level: skip を理由に Issue/Plan/Worktree/PR をスキップ
 
 ## 8. LLM Round-Trip Optimization
 

--- a/.claude/rules/dev/workflow-orchestration.md
+++ b/.claude/rules/dev/workflow-orchestration.md
@@ -8,6 +8,7 @@
 ## Implementation
 - プラン承認後は `implementation-workflow.md` に従って実行する
 - 委任・検証・Ship の手順はすべてそちらに定義
+- **全変更で Worktree → PR が必須**。Validation Level: skip は検証方法の指定であり、ワークフロー省略の許可ではない
 
 ## Self-Improvement Loop
 - After ANY user correction: append to `.claude/tasks/lessons.md`


### PR DESCRIPTION
## Summary
- Add "Validation Level: skip を理由に Issue/Plan/Worktree/PR をスキップ" to §7 Prohibited list in `dev-reference.md`
- Add explicit note in `workflow-orchestration.md` Implementation section that all changes require Worktree → PR regardless of Validation Level

Redundant placement in high-visibility locations prevents LLMs from misinterpreting "skip" as workflow bypass permission.

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)