### PR TITLE
docs: add worktree command rules to avoid compound commands

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -46,8 +46,8 @@ mcp__serena__activate_project("/home/yamakii/workspace/garmin-performance-analys
 ### Step 4: テスト & Lint
 
 ```bash
-uv run pytest {test_path} -m unit -v
-uv run ruff check {changed_files}
+uv run --directory {worktree_path} pytest {test_path} -m unit -v
+uv run --directory {worktree_path} ruff check {changed_files}
 ```
 
 失敗があれば修正して再実行。
@@ -55,8 +55,8 @@ uv run ruff check {changed_files}
 ### Step 5: Commit
 
 ```bash
-git add {changed_files}
-git commit -m "{conventional commit message}
+git -C {worktree_path} add {changed_files}
+git -C {worktree_path} commit -m "{conventional commit message}
 
 Closes #{issue_number}
 

--- a/.claude/rules/dev/worktree-commands.md
+++ b/.claude/rules/dev/worktree-commands.md
@@ -1,0 +1,27 @@
+# Worktree Commands
+
+## `cd <path> && ...` を使わない
+
+worktree 内でコマンドを実行する際、`cd <path> && <cmd>` は compound コマンドとして Claude Code が毎回承認を求める。各ツールのディレクトリ指定オプションを使う。
+
+### git 操作 — `git -C <path>`
+
+| 用途 | コマンド |
+|------|---------|
+| ステージ | `git -C <path> add file1 file2` |
+| コミット | `git -C <path> commit -m "msg"` |
+| 状態確認 | `git -C <path> status` |
+| 差分 | `git -C <path> diff` |
+| ログ | `git -C <path> log --oneline -5` |
+| プッシュ | `git -C <path> push -u origin branch` |
+| ブランチ作成 | `git -C <path> checkout -b branch` |
+| stash | `git -C <path> stash` |
+| fetch | `git -C <path> fetch origin` |
+
+### uv / pytest / ruff / pre-commit — `--directory`
+
+| 用途 | コマンド |
+|------|---------|
+| テスト | `uv run --directory <path> pytest -m unit -v` |
+| lint | `uv run --directory <path> ruff check src/` |
+| pre-commit | `uv run --directory <path> pre-commit run --all-files` |


### PR DESCRIPTION
## Summary
- `cd <path> && <cmd>` が compound コマンドとして毎回承認を求める問題を回避するルールを追加
- `.claude/rules/dev/worktree-commands.md` に `git -C` / `uv run --directory` のパターンを記載
- `developer.md` の Step 4, 5 コマンド例を更新

Closes #158