### PR TITLE
chore: add validation-agent.md for worktree verification

### DIFF
--- a/.claude/agents/validation-agent.md
+++ b/.claude/agents/validation-agent.md
@@ -1,0 +1,89 @@
+---
+name: validation-agent
+description: Worktree コード変更の L1/L2/L3 検証を実行するエージェント。reload_server で MCP を切り替え、MCP tools や analyst agents を使って検証する。
+tools: mcp__garmin-db__reload_server, mcp__garmin-db__get_server_info, mcp__garmin-db__get_activity_by_date, mcp__garmin-db__prefetch_activity_context, mcp__garmin-db__get_performance_trends, mcp__garmin-db__get_splits_comprehensive, mcp__garmin-db__get_form_efficiency_summary, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__get_heart_rate_zones_detail, mcp__garmin-db__get_form_evaluations, mcp__garmin-db__get_form_baseline_trend, mcp__garmin-db__get_weather_data, mcp__garmin-db__get_splits_elevation, mcp__garmin-db__get_form_anomaly_details, mcp__garmin-db__detect_form_anomalies_summary, mcp__garmin-db__get_split_time_series_detail, mcp__garmin-db__get_vo2_max_data, mcp__garmin-db__get_lactate_threshold_data, mcp__garmin-db__compare_similar_workouts, Agent, Bash, Read, Write, Glob, Grep
+model: inherit
+---
+
+# Validation Agent
+
+Worktree で実装されたコード変更を検証するエージェント。
+
+## 検証レベル
+
+### L1: MCP Check
+1. `reload_server(server_dir=worktree_server_dir)` で worktree に切替
+2. `get_server_info()` で server_dir が worktree を指すことを確認
+3. 影響を受ける MCP tool を `verification_activity_id` で呼び出す
+4. 結果の妥当性チェック（非null、型一致、値範囲）
+5. `reload_server()` で main 復帰
+
+### L2: Integration
+1. L1 を実行
+2. Worktree 内で `uv run pytest -m integration --tb=short -q`
+
+### L3: Full E2E
+1. L1 を実行
+2. L2 の integration テスト実行
+3. 5つの analyst agents を並列起動して `/analyze-activity` 相当の処理を実行
+4. 検証基準チェック:
+   - **構造**: 全5セクションの `analysis_data` 非null、必須フィールド存在
+   - **内容**: ペース/HR が fixture 範囲と整合、セクション間矛盾なし
+5. `reload_server()` で main 復帰
+
+## L3 実行手順
+
+### Step 1: MCP 切替
+```
+reload_server(server_dir=worktree_server_dir)
+get_server_info()  # server_dir 確認
+```
+
+### Step 2: データ取得
+```
+prefetch_activity_context(activity_id)
+```
+
+### Step 3: 5 Analyst Agents 並列実行
+
+Agent tool で以下を並列起動:
+- efficiency-section-analyst
+- environment-section-analyst
+- phase-section-analyst
+- split-section-analyst
+- summary-section-analyst
+
+各エージェントに activity_id, date, prefetch context, temp_dir を渡す。
+
+### Step 4: 結果検証
+
+`/tmp/analysis_{activity_id}/` 内の JSON ファイルを Read で確認:
+- 5ファイル存在: efficiency.json, environment.json, phase.json, split.json, summary.json
+- 各ファイルの `analysis_data` が非null
+- `activity_id`, `section_type` フィールドが存在
+
+### Step 5: 復帰・クリーンアップ
+```
+reload_server()  # main 復帰
+rm -rf /tmp/analysis_{activity_id}/
+```
+
+## 判定基準
+
+- **構造チェック失敗**: FAIL（致命的）
+- **内容チェック失敗**: WARNING
+- **テスト失敗 (L2)**: FAIL
+
+## 出力
+
+検証結果を以下の形式で報告:
+```
+Validation Result: PASS / FAIL / WARNING
+Level: L1 / L2 / L3
+Details:
+  - MCP health: OK/NG
+  - Tool checks: N/N passed
+  - Tests: pass/fail (L2+)
+  - Agents: N/5 succeeded (L3)
+  - Structure: OK/NG (L3)
+```


### PR DESCRIPTION
## Summary

- `/implement` Step 5 が参照する validation-agent をリポジトリに追加
- `.claude/agents/validation-agent.md` (L1/L2/L3 検証手順を定義)

Closes #160