### PR TITLE
fix: correct L3 validation fixture and improve coverage

### DIFF
--- a/.claude/agents/validation-agent.md
+++ b/.claude/agents/validation-agent.md
@@ -29,7 +29,18 @@ Worktree で実装されたコード変更を検証するエージェント。
 4. 検証基準チェック:
    - **構造**: 全5セクションの `analysis_data` 非null、必須フィールド存在
    - **内容**: ペース/HR が fixture 範囲と整合、セクション間矛盾なし
-5. `reload_server()` で main 復帰
+   - Fixture: `dev-reference.md` §3 の L3 検証基準を参照
+5. (任意) DuckDB 挿入検証: `insert_section_analysis_dict` で各セクションを挿入し成功を確認
+6. (任意) レポート生成検証: Markdown レポートが生成され、5セクション分の内容を含むことを確認
+7. `reload_server()` で main 復帰
+
+## L3 Fixture
+
+- Activity: `20636804823` (2025-10-09, aerobic_base 5.66km, ~6:26/km, HR avg 144bpm)
+- Content check ranges:
+  - Pace: 6:00-6:45/km (360-405 sec/km)
+  - HR: 120-160 bpm
+- 詳細は `dev-reference.md` §3 を参照
 
 ## L3 実行手順
 
@@ -61,8 +72,21 @@ Agent tool で以下を並列起動:
 - 5ファイル存在: efficiency.json, environment.json, phase.json, split.json, summary.json
 - 各ファイルの `analysis_data` が非null
 - `activity_id`, `section_type` フィールドが存在
+- 内容チェック（WARNING レベル）:
+  - ペース値が 360-405 sec/km 範囲内
+  - HR 値が 120-160 bpm 範囲内
 
-### Step 5: 復帰・クリーンアップ
+### Step 5: DuckDB 挿入検証（任意）
+各セクションの JSON を `insert_section_analysis_dict` で DuckDB に挿入:
+- 5件全て成功すること
+- エラー発生時は WARNING（構造チェックとは別）
+
+### Step 6: レポート生成検証（任意）
+Markdown レポートの基本チェック:
+- ファイルが生成されること
+- 5セクション分の見出しが存在すること
+
+### Step 7: 復帰・クリーンアップ
 ```
 reload_server()  # main 復帰
 rm -rf /tmp/analysis_{activity_id}/

--- a/.claude/rules/dev/dev-reference.md
+++ b/.claude/rules/dev/dev-reference.md
@@ -83,7 +83,10 @@ Skip: Design セクションなし、Issue番号不明、dry-run時。
 
 - **構造 (FAIL=致命的)**: 全5セクションの `analysis_data` 非null、必須フィールド存在、Markdown生成
 - **内容 (WARNING)**: ペース/HR が fixture 範囲と整合、セクション間の矛盾なし
-- **Fixture**: Activity `12345678901` (2025-10-09, Easy run 7km, 5:15-5:45/km)
+- **Fixture**: Activity `20636804823` (2025-10-09, aerobic_base 5.66km, ~6:26/km, HR avg 144bpm)
+- **Content check ranges**:
+  - Pace: 6:00-6:45/km (360-405 sec/km)
+  - HR: 120-160 bpm
 
 ## 4. Testing
 

--- a/.claude/rules/dev/worktree-validation-protocol.md
+++ b/.claude/rules/dev/worktree-validation-protocol.md
@@ -48,7 +48,7 @@ Main Session (queue manager — 検証作業はしない)
      "change_category": "handler|reader|agent|reporting|ingest|schema|other",
      "changed_files": ["src/garmin_mcp/handlers/foo.py"],
      "test_results": {"unit": "pass", "integration": "pass"},
-     "verification_activity_id": 12345678901
+     "verification_activity_id": 20636804823
    }
    ```
 3. PR 作成 (draft)
@@ -103,9 +103,11 @@ manifest の `validation_level` に応じた手順を実行する。
 5. 検証基準チェック（`dev-reference.md` §3 の L3 検証基準）:
    - **構造チェック**: 5 セクションの `analysis_data` が非 null、必須フィールド存在
    - **内容チェック**: ペース・HR 値が fixture 範囲と整合、セクション間矛盾なし
-6. `mcp__garmin-db__reload_server()` で main 復帰
-7. pass/fail + 詳細を返却
-8. Manifest ファイルを削除
+6. (任意) DuckDB 挿入検証: `insert_section_analysis_dict` で各セクション挿入成功を確認
+7. (任意) レポート生成検証: Markdown レポート生成 + 5セクション見出し存在を確認
+8. `mcp__garmin-db__reload_server()` で main 復帰
+9. pass/fail + 詳細を返却
+10. Manifest ファイルを削除
 
 ### 判定基準
 


### PR DESCRIPTION
## Summary
- Fix L3 fixture from placeholder `12345678901` to real activity `20636804823` (2025-10-09)
- Add content check ranges (pace 6:00-6:45/km, HR 120-160 bpm) based on actual data
- Add optional DuckDB insertion + report generation verification steps to L3
- Unify fixture definitions across `dev-reference.md`, `validation-agent.md`, `worktree-validation-protocol.md`

Closes #164