### PR TITLE
fix: add unix timestamp to analysis temp dir for Write tool compatibility

### DIFF
--- a/.claude/agents/validation-agent.md
+++ b/.claude/agents/validation-agent.md
@@ -44,6 +44,15 @@ get_server_info()  # server_dir 確認
 prefetch_activity_context(activity_id)
 ```
 
+### Step 2.5: ANALYSIS_TEMP_DIR 生成
+
+現在時刻の unix timestamp を取得し、timestamp 付きユニークパスを生成:
+```
+ANALYSIS_TEMP_DIR=/tmp/analysis_{activity_id}_{unix_timestamp}
+```
+unix_timestamp は現在時刻の秒数（例: 1709312345）。
+これにより再分析時に前回の JSON が残っていても Write tool の既存ファイル制約を回避できる。
+
 ### Step 3: 5 Analyst Agents 並列実行
 
 Agent tool で以下を並列起動:
@@ -53,11 +62,11 @@ Agent tool で以下を並列起動:
 - split-section-analyst
 - summary-section-analyst
 
-各エージェントに activity_id, date, prefetch context, temp_dir を渡す。
+各エージェントに activity_id, date, prefetch context, `ANALYSIS_TEMP_DIR` を渡す。
 
 ### Step 4: 結果検証
 
-`/tmp/analysis_{activity_id}/` 内の JSON ファイルを Read で確認:
+`{ANALYSIS_TEMP_DIR}/` 内の JSON ファイルを Read で確認:
 - 5ファイル存在: efficiency.json, environment.json, phase.json, split.json, summary.json
 - 各ファイルの `analysis_data` が非null
 - `activity_id`, `section_type` フィールドが存在
@@ -65,7 +74,7 @@ Agent tool で以下を並列起動:
 ### Step 5: 復帰・クリーンアップ
 ```
 reload_server()  # main 復帰
-rm -rf /tmp/analysis_{activity_id}/
+rm -rf {ANALYSIS_TEMP_DIR}/
 ```
 
 ## 判定基準

--- a/.claude/commands/analyze-activity.md
+++ b/.claude/commands/analyze-activity.md
@@ -22,8 +22,8 @@ mcp__garmin-db__ingest_activity(date="{{arg1}}")
 
 返却された `activity_id` と `date` を取得してください。
 
-tempフォルダパスは `ANALYSIS_TEMP_DIR=/tmp/analysis_{activity_id}` として以降使用。
-（ディレクトリはエージェントの Write tool が自動作成します）
+tempフォルダパスは `ANALYSIS_TEMP_DIR=/tmp/analysis_{activity_id}_{unix_timestamp}` として以降使用。unix_timestamp は現在時刻の秒数（例: 1709312345）。
+ディレクトリは Write tool がファイル書き込み時に自動作成するため、事前の mkdir は不要。
 
 ### Step 1.5: コンテキスト事前取得（MCP ツール）
 
@@ -80,7 +80,7 @@ prompt: "Activity ID {activity_id} ({date}) のアクティビティタイプ判
 エラーハンドリング通過後、1コマンドで一括登録：
 
 ```bash
-uv run python -m garmin_mcp.scripts.merge_section_analyses /tmp/analysis_{activity_id}
+uv run python -m garmin_mcp.scripts.merge_section_analyses {ANALYSIS_TEMP_DIR}
 ```
 
 - 全 `.json` を読み込み→DuckDBに一括挿入→成功時にtempフォルダ自動削除

--- a/.claude/rules/analysis/analysis-standards.md
+++ b/.claude/rules/analysis/analysis-standards.md
@@ -14,7 +14,7 @@ Consolidated reference for all analysis rules.
 
 - **独立動作**: 他セクション分析を参照しない。全データを MCP tools から直接取得
 - **事前コンテキスト**: orchestrator 提供の JSON を信頼し、不足時のみ追加 MCP 呼び出し
-- **出力**: 日本語テキスト + English key names。`{temp_dir}/{section_type}.json` に出力
+- **出力**: 日本語テキスト + English key names。`{ANALYSIS_TEMP_DIR}/{section_type}.json` に出力（ANALYSIS_TEMP_DIR は orchestrator が timestamp 付きユニークパスとして提供）
 - **JSON構造**: `{"activity_id": <int>, "activity_date": "<YYYY-MM-DD>", "section_type": "<type>", "analysis_data": {...}}`
 - **星評価**: `(★★★★☆ N.N/5.0)`
 - **HR zones**: Garmin native zones のみ (計算式禁止)

--- a/.claude/rules/dev/worktree-validation-protocol.md
+++ b/.claude/rules/dev/worktree-validation-protocol.md
@@ -99,6 +99,7 @@ manifest の `validation_level` に応じた手順を実行する。
 
 1-3. L1 と同じ（reload_server + health check）
 4. `/analyze-activity {fixture_date}` を実行（analyze-activity.md が Single Source of Truth）
+   - temp ディレクトリパスは analyze-activity.md の ANALYSIS_TEMP_DIR 定義に従う（timestamp 付きユニークパス）
    - Fixture: `dev-reference.md` §3 の L3 検証基準を参照
 5. 検証基準チェック（`dev-reference.md` §3 の L3 検証基準）:
    - **構造チェック**: 5 セクションの `analysis_data` が非 null、必須フィールド存在


### PR DESCRIPTION
## Summary

- Analysis temp dir path now includes unix timestamp: `/tmp/analysis_{id}_{timestamp}` instead of `/tmp/analysis_{id}`
- Prevents Write tool "File has not been read yet" error when re-analyzing the same activity
- Updated all 4 files that reference temp dir path (analyze-activity.md, validation-agent.md, worktree-validation-protocol.md, analysis-standards.md)

## Test plan

- [ ] Run `/analyze-activity 2025-10-09` → all 5 JSON files generated + merge + report succeeds
- [ ] Re-run same activity → uses different temp dir, both succeed
- [ ] Verify L3 pipeline works end-to-end

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)