### PR TITLE
fix: add explicit no-mkdir instruction to validation-agent and analysis-standards

### DIFF
--- a/.claude/agents/validation-agent.md
+++ b/.claude/agents/validation-agent.md
@@ -63,6 +63,7 @@ ANALYSIS_TEMP_DIR=/tmp/analysis_{activity_id}_{unix_timestamp}
 ```
 unix_timestamp は現在時刻の秒数（例: 1709312345）。
 これにより再分析時に前回の JSON が残っていても Write tool の既存ファイル制約を回避できる。
+**事前の mkdir は不要**。Write tool がファイル書き込み時に親ディレクトリを自動作成する。`mkdir -p` や `Bash` でのディレクトリ作成は行わないこと。
 
 ### Step 3: 5 Analyst Agents 並列実行
 

--- a/.claude/rules/analysis/analysis-standards.md
+++ b/.claude/rules/analysis/analysis-standards.md
@@ -14,7 +14,7 @@ Consolidated reference for all analysis rules.
 
 - **独立動作**: 他セクション分析を参照しない。全データを MCP tools から直接取得
 - **事前コンテキスト**: orchestrator 提供の JSON を信頼し、不足時のみ追加 MCP 呼び出し
-- **出力**: 日本語テキスト + English key names。`{ANALYSIS_TEMP_DIR}/{section_type}.json` に出力（ANALYSIS_TEMP_DIR は orchestrator が timestamp 付きユニークパスとして提供）
+- **出力**: 日本語テキスト + English key names。`{ANALYSIS_TEMP_DIR}/{section_type}.json` に出力（ANALYSIS_TEMP_DIR は orchestrator が timestamp 付きユニークパスとして提供）。**事前の mkdir は不要**（Write tool が親ディレクトリを自動作成する）
 - **JSON構造**: `{"activity_id": <int>, "activity_date": "<YYYY-MM-DD>", "section_type": "<type>", "analysis_data": {...}}`
 - **星評価**: `(★★★★☆ N.N/5.0)`
 - **HR zones**: Garmin native zones のみ (計算式禁止)


### PR DESCRIPTION
## Summary

- Add explicit "no mkdir needed" instruction to `validation-agent.md` Step 2.5
- Add same note to `analysis-standards.md` Agent Rules output line
- Fixes: validation agent attempting `mkdir -p` via Bash (requiring user permission) when Write tool auto-creates directories

Supplements #170

## Test plan

- [x] L3 validation: validation agent executes without `mkdir -p` Bash calls — PASS
- [x] All 5 analyst agents write JSON to timestamp-based temp dir successfully — PASS (5/5)

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)