### PR TITLE
feat: add FIFO manifest handoff between developer and validation agents

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -63,6 +63,30 @@ Closes #{issue_number}
 Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
 ```
 
+### Step 5.5: Validation Manifest 書き出し
+
+commit 完了後、Validation Agent 用の manifest を書き出す。
+
+1. Validation Level 判定（`dev-reference.md` §3 の判定表で changed_files の最高レベルを採用）
+2. Write tool で JSON manifest を書き出し:
+   - パス: `/tmp/validation_queue/{branch_name}.json`
+   - Write tool が親ディレクトリを自動作成するため `mkdir -p` 不要
+3. Manifest スキーマ（`worktree-validation-protocol.md` §Implementation Agent の責務 に準拠）:
+   ```json
+   {
+     "branch": "feature/xxx",
+     "worktree_path": "/absolute/path/to/worktree",
+     "server_dir": "/absolute/path/to/worktree/packages/garmin-mcp-server",
+     "pr_number": null,
+     "issue_number": 72,
+     "validation_level": "L1|L2|L3|skip",
+     "change_category": "handler|reader|agent|reporting|ingest|schema|other",
+     "changed_files": ["src/garmin_mcp/handlers/foo.py"],
+     "test_results": {"unit": "pass", "integration": "pass"},
+     "verification_activity_id": 20636804823
+   }
+   ```
+
 ## 禁止事項
 
 - `git push` — push はオーケストレーターの責務
@@ -84,4 +108,5 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
 - [ ] 全テストが pass
 - [ ] ruff check が clean
 - [ ] commit 完了（push はしない）
+- [ ] Manifest 書き出し完了
 - [ ] 変更ファイル一覧と commit hash を報告

--- a/.claude/agents/validation-agent.md
+++ b/.claude/agents/validation-agent.md
@@ -9,6 +9,13 @@ model: inherit
 
 Worktree で実装されたコード変更を検証するエージェント。
 
+## Step 0: Manifest 読み込み
+
+1. `/tmp/validation_queue/{branch}.json` を Read で取得
+2. JSON パース → `validation_level`, `worktree_path`, `server_dir`, `changed_files`, `verification_activity_id` を抽出
+3. `validation_level` が `skip` → 即座に manifest 削除して PASS を返却して終了
+4. L1/L2/L3 → 対応する検証セクションへ進む
+
 ## 検証レベル
 
 ### L1: MCP Check
@@ -100,6 +107,7 @@ Markdown レポートの基本チェック:
 ```
 reload_server()  # main 復帰
 rm -rf {ANALYSIS_TEMP_DIR}/
+rm /tmp/validation_queue/{branch}.json
 ```
 
 ## 判定基準

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -81,16 +81,16 @@ Agent(subagent_type="developer", isolation="worktree", prompt="""
 
 各 developer agent 完了後、Validation Level に応じて検証を実行:
 
-1. **Manifest 確認**: `/tmp/validation_queue/<branch>.json` を読み込む
-   - developer agent が manifest を書いていない場合:
-     worktree_path と changed_files から Validation Level を自動判定（`dev-reference.md` §3 の判定表を使用）
-   - skip レベルの場合 → 検証をスキップし Step 6 へ
+1. **Manifest 読み込み**: `/tmp/validation_queue/<branch>.json` を Read で読み込む
+   - Manifest が存在する場合: `validation_level` を使用
+   - Manifest が存在しない場合（fallback）: worktree の changed_files から `dev-reference.md` §3 の判定表で Validation Level を自動判定
+   - `skip` レベルの場合 → 検証をスキップし Step 6 へ
 
 2. **Validation Agent 起動**: foreground で1つずつ起動（FIFO 順）
    ```
    Agent(subagent_type="validation-agent", prompt="""
      Manifest: /tmp/validation_queue/<branch>.json
-     （または worktree_path, changed_files, validation_level を直接指定）
+     （manifest がない場合は worktree_path, changed_files, validation_level を直接指定）
    """)
    ```
 

--- a/.claude/rules/dev/implementation-workflow.md
+++ b/.claude/rules/dev/implementation-workflow.md
@@ -38,6 +38,7 @@ Risks セクション（任意）:
 - lint 実行指示: `uv run ruff check {changed_files}`
 - commit 指示: ブランチ名、コミットメッセージ形式
 - **push しない**指示
+- **Manifest 書き出し指示**: commit 後に `/tmp/validation_queue/{branch}.json` へ manifest を書き出すこと（developer.md Step 5.5 参照）
 
 ## Phase 2: Verify (独立検証)
 


### PR DESCRIPTION
## Summary
- developer agent に Step 5.5 (Validation Manifest 書き出し) を追加
- validation-agent に Step 0 (Manifest 読み込み) + Step 7 に manifest 削除を追加
- implementation-workflow.md の Phase 1 に manifest 書き出し指示を追記
- implement.md の Step 5 を manifest-first に整理（fallback 維持）

Closes #175

## Test plan
- [x] Validation Level: skip (`.claude/` ファイルのみ変更)
- [ ] 手動 E2E 検証は Epic #174 の別 sub-issue で実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)