### PR TITLE
fix: update stale parameter-error tests to structured error contract

### DIFF
--- a/packages/garmin-mcp-server/tests/integration/test_rag_interval_tools_mcp.py
+++ b/packages/garmin-mcp-server/tests/integration/test_rag_interval_tools_mcp.py
@@ -419,20 +419,24 @@ class TestRagIntervalToolsMcp:
 
     @pytest.mark.asyncio
     async def test_call_interval_analysis_missing_activity_id_error(self):
-        """Test that missing activity_id raises KeyError."""
-        with pytest.raises(KeyError):
-            await call_tool(name="get_interval_analysis", arguments={})
+        """Missing activity_id returns a structured parameter error."""
+        result = await call_tool(name="get_interval_analysis", arguments={})
+        response = json.loads(result[0].text)
+        assert "Invalid parameter" in response["error"]
+        assert "activity_id" in response["error"]
 
     @pytest.mark.asyncio
     async def test_call_split_time_series_missing_split_number_error(
         self, fixture_activity_id: int
     ):
-        """Test that missing split_number raises KeyError."""
-        with pytest.raises(KeyError):
-            await call_tool(
-                name="get_split_time_series_detail",
-                arguments={"activity_id": fixture_activity_id},
-            )
+        """Missing split_number returns a structured parameter error."""
+        result = await call_tool(
+            name="get_split_time_series_detail",
+            arguments={"activity_id": fixture_activity_id},
+        )
+        response = json.loads(result[0].text)
+        assert "Invalid parameter" in response["error"]
+        assert "split_number" in response["error"]
 
     @pytest.mark.asyncio
     async def test_list_tools_includes_phase3_rag_tools(self):


### PR DESCRIPTION
## Summary

`safe_tool_handler`（`src/garmin_mcp/utils/error_handling.py`）は `KeyError`/`ValueError`/`TypeError` を捕捉して構造化エラー（`{"error": "Invalid parameter: ...", ...}`）を返す設計だが、2 テストが古い `pytest.raises(KeyError)` の期待のまま残り baseline で失敗していた。テストを現行仕様に追従させた（実装コードは変更なし）。

- `test_call_interval_analysis_missing_activity_id_error`
- `test_call_split_time_series_missing_split_number_error`

## Verification

- 対象ファイル integration: 20 passed（オーケストレーターが worktree で再実行し確認）
- ruff check: clean

Closes #188