### PR TITLE
chore(deps): upgrade garminconnect to 0.3.5

### DIFF
--- a/packages/garmin-mcp-server/pyproject.toml
+++ b/packages/garmin-mcp-server/pyproject.toml
@@ -5,7 +5,7 @@ description = "Garmin running performance analysis MCP server with DuckDB backen
 readme = "../../README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "garminconnect>=0.2.0",
+    "garminconnect>=0.3.0",
     "duckdb>=1.1.1",
     "pandas>=3.0.0",
     "polars>=1.9.0",

--- a/packages/garmin-mcp-server/src/garmin_mcp/ingest/api_client.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/ingest/api_client.py
@@ -70,8 +70,11 @@ def get_garmin_client() -> Garmin:
             client.login()
             logger.info("Garmin credential authentication successful")
 
-        # Always save tokens (captures refreshed OAuth2 tokens too)
-        client.garth.dump(tokenstore_path)
+        # Always save tokens (captures refreshed OAuth2 tokens too).
+        # garminconnect 0.3.x exposes the underlying auth client as
+        # ``Garmin.client`` (curl-cffi based); the legacy ``.garth`` attribute
+        # was removed. ``client.dump(path)`` persists the OAuth tokens.
+        client.client.dump(tokenstore_path)
         logger.info(f"Garmin tokens saved to {tokenstore_path}")
 
         _client = client

--- a/packages/garmin-mcp-server/src/garmin_mcp/training_plan/garmin_uploader.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/training_plan/garmin_uploader.py
@@ -153,7 +153,10 @@ class GarminWorkoutUploader:
         try:
             url = f"/workout-service/schedule/{garmin_workout_id}"
             payload = {"date": scheduled_date}
-            client.garth.post("connectapi", url, json=payload, api=True)
+            # garminconnect 0.3.x removed the ``.garth`` attribute; the
+            # underlying auth client (``Garmin.client``) exposes the same
+            # ``post(domain, path, json=..., api=...)`` helper.
+            client.client.post("connectapi", url, json=payload, api=True)
             logger.info(f"Scheduled workout {garmin_workout_id} on {scheduled_date}")
             return True
         except Exception as e:
@@ -396,11 +399,14 @@ class GarminWorkoutUploader:
                 "reason": f"Garmin workout kept ({shared_count} other references)",
             }
 
-        # Last reference - delete from Garmin
+        # Last reference - delete from Garmin.
+        # garminconnect 0.3.x: ``Garmin.connectapi`` only performs GET requests
+        # (passing ``method=`` collides with its internal call). Use the
+        # underlying client's ``delete(domain, path)`` helper for DELETE.
         try:
             client = self._get_garmin_client()
-            client.connectapi(
-                f"/workout-service/workout/{garmin_workout_id}", method="DELETE"
+            client.client.delete(
+                "connectapi", f"/workout-service/workout/{garmin_workout_id}"
             )
 
             with get_write_connection(db_path) as update_conn:

--- a/packages/garmin-mcp-server/tests/ingest/test_api_client.py
+++ b/packages/garmin-mcp-server/tests/ingest/test_api_client.py
@@ -48,7 +48,8 @@ class TestGetGarminClient:
         # Token login is called with a path argument
         args, _ = mock_instance.login.call_args
         assert len(args) == 1  # tokenstore_path passed
-        mock_instance.garth.dump.assert_called_once()
+        # garminconnect 0.3.x: token dump moved from ``.garth`` to ``.client``
+        mock_instance.client.dump.assert_called_once()
 
     def test_token_login_failure_falls_back_to_credential(
         self, mocker: MockerFixture
@@ -78,7 +79,8 @@ class TestGetGarminClient:
         # Second call: credential login without path
         second_call_args, _ = mock_instance.login.call_args_list[1]
         assert len(second_call_args) == 0
-        mock_instance.garth.dump.assert_called_once()
+        # garminconnect 0.3.x: token dump moved from ``.garth`` to ``.client``
+        mock_instance.client.dump.assert_called_once()
 
     def test_singleton_returns_same_instance(self, mocker: MockerFixture) -> None:
         """Calling get_garmin_client() twice returns the same object."""

--- a/packages/garmin-mcp-server/tests/training_plan/test_garmin_uploader.py
+++ b/packages/garmin-mcp-server/tests/training_plan/test_garmin_uploader.py
@@ -68,7 +68,7 @@ class TestGarminWorkoutUploader:
     def test_schedule_workout_success(self, mocker):
         """Should schedule workout on Garmin Connect calendar."""
         mock_client = mocker.MagicMock()
-        mock_client.garth.post.return_value = None  # Success
+        mock_client.client.post.return_value = None  # Success
 
         uploader = GarminWorkoutUploader.__new__(GarminWorkoutUploader)
         uploader._db_path = ":memory:"
@@ -77,7 +77,8 @@ class TestGarminWorkoutUploader:
         result = uploader._schedule_workout(mock_client, 12345, "2026-03-15")
 
         assert result is True
-        mock_client.garth.post.assert_called_once_with(
+        # garminconnect 0.3.x: scheduling POST moved from ``.garth`` to ``.client``
+        mock_client.client.post.assert_called_once_with(
             "connectapi",
             "/workout-service/schedule/12345",
             json={"date": "2026-03-15"},
@@ -87,7 +88,7 @@ class TestGarminWorkoutUploader:
     def test_schedule_workout_failure(self, mocker):
         """Should return False and log warning on schedule failure."""
         mock_client = mocker.MagicMock()
-        mock_client.garth.post.side_effect = Exception("API error")
+        mock_client.client.post.side_effect = Exception("API error")
 
         uploader = GarminWorkoutUploader.__new__(GarminWorkoutUploader)
         uploader._db_path = ":memory:"
@@ -165,7 +166,7 @@ class TestGarminWorkoutUploader:
         # Mock client
         mock_client = mocker.MagicMock()
         mock_client.upload_workout.return_value = {"workoutId": 99999}
-        mock_client.garth.post.return_value = None
+        mock_client.client.post.return_value = None
 
         # Mock duckdb for update
         mock_duckdb_conn = mocker.MagicMock()
@@ -287,7 +288,7 @@ class TestGarminWorkoutUploader:
         mock_conn.execute.side_effect = [mock_cursor1, mock_cursor2]
 
         mock_client = mocker.MagicMock()
-        mock_client.connectapi.return_value = None
+        mock_client.client.delete.return_value = None
 
         mock_duckdb_conn = mocker.MagicMock()
         mocker.patch("duckdb.connect", return_value=mock_duckdb_conn)
@@ -306,8 +307,9 @@ class TestGarminWorkoutUploader:
         assert result["success"] is True
         assert result["deleted"] is True
         assert result["garmin_workout_id"] == 99999
-        mock_client.connectapi.assert_called_once_with(
-            "/workout-service/workout/99999", method="DELETE"
+        # garminconnect 0.3.x: DELETE moved from connectapi(method=) to client.delete
+        mock_client.client.delete.assert_called_once_with(
+            "connectapi", "/workout-service/workout/99999"
         )
         mock_duckdb_conn.execute.assert_called_once()
         mock_duckdb_conn.close.assert_called_once()
@@ -601,7 +603,7 @@ class TestDeleteWorkoutSafeSharing:
         mock_conn.execute.side_effect = [mock_cursor1, mock_cursor2]
 
         mock_client = mocker.MagicMock()
-        mock_client.connectapi.return_value = None
+        mock_client.client.delete.return_value = None
 
         mock_duckdb_conn = mocker.MagicMock()
         mocker.patch("duckdb.connect", return_value=mock_duckdb_conn)
@@ -619,6 +621,7 @@ class TestDeleteWorkoutSafeSharing:
 
         assert result["success"] is True
         assert result["deleted"] is True
-        mock_client.connectapi.assert_called_once_with(
-            "/workout-service/workout/99999", method="DELETE"
+        # garminconnect 0.3.x: DELETE moved from connectapi(method=) to client.delete
+        mock_client.client.delete.assert_called_once_with(
+            "connectapi", "/workout-service/workout/99999"
         )

--- a/uv.lock
+++ b/uv.lock
@@ -370,6 +370,39 @@ wheels = [
 ]
 
 [[package]]
+name = "curl-cffi"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "cffi" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/5b/89fcfebd3e5e85134147ac99e9f2b2271165fd4d71984fc65da5f17819b7/curl_cffi-0.15.0.tar.gz", hash = "sha256:ea0c67652bf6893d34ee0f82c944f37e488f6147e9421bef1771cc6545b02ded", size = 196437, upload-time = "2026-04-03T11:12:31.525Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/42/54ddd442c795f30ce5dd4e49f87ce77505958d3777cd96a91567a3975d2a/curl_cffi-0.15.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:bda66404010e9ed743b1b83c20c86f24fe21a9a6873e17479d6e67e29d8ded28", size = 2795267, upload-time = "2026-04-03T11:11:46.48Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2d/3915e238579b3c5a92cead5c79130c3b8d20caaba7616cc4d894650e1d6b/curl_cffi-0.15.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a25620d9bf989c9c029a7d1642999c4c265abb0bad811deb2f77b0b5b2b12e5b", size = 2573544, upload-time = "2026-04-03T11:11:47.951Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/b3/9d2f1057749a1b07ba1989db3c1503ce8bed998310bae9aea2c43aa64f20/curl_cffi-0.15.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:582e570aa2586b96ed47cf4a17586b9a3c462cbe43f780487c3dc245c6ef1527", size = 10515369, upload-time = "2026-04-03T11:11:50.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1d/6d10dded5ce3fd8157e558ebd97d09e551b77a62cdc1c31e93d0a633cee5/curl_cffi-0.15.0-cp310-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:838e48212447d9c81364b04707a5c861daf08f8320f9ecb3406a8919d1d5c3b3", size = 10160045, upload-time = "2026-04-03T11:11:52.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc", size = 11090433, upload-time = "2026-04-03T11:11:55.049Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/0d/78edcc4f71934225db99df68197a107386d59080742fc7bf6bb4d007924f/curl_cffi-0.15.0-cp310-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e5e69eee735f659287e2c84444319d68a1fa68dd37abf228943a4074864283a", size = 10479178, upload-time = "2026-04-03T11:11:57.685Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/84/1e101c1acb1ea2f0b4992f5c3024f596d8e21db0d53540b9d583f673c4e7/curl_cffi-0.15.0-cp310-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa1323950224db24f4c510d010b3affa02196ca853fb424191fa917a513d3f4b", size = 10317051, upload-time = "2026-04-03T11:12:00.295Z" },
+    { url = "https://files.pythonhosted.org/packages/28/42/8ef236b22a6c23d096c85a1dc507efe37bfdfc7a2f8a4b34efb590197369/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:41f80170ba844009273b2660da1964ec31e99e5719d16b3422ada87177e32e13", size = 11299660, upload-time = "2026-04-03T11:12:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/56aeb055d962da87a1be0d74c6c644e251c7e88129b5471dc44ac724e678/curl_cffi-0.15.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1977e1e12cfb5c11352cbb74acef1bed24eb7d226dab61ca57c168c21acd4d61", size = 11945049, upload-time = "2026-04-03T11:12:05.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/8c/2abf99a38d6340d66cf0557e0c750ef3f8883dfc5d450087e01c85861343/curl_cffi-0.15.0-cp310-abi3-win_amd64.whl", hash = "sha256:5a0c1896a0d5a5ac1eb89cd24b008d2b718dd1df6fd2f75451b59ca66e49e572", size = 1661649, upload-time = "2026-04-03T11:12:07.948Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/39/dfd54f2240d3a9b96d77bacc62b97813b35e2aa8ecf5cd5013c683f1ba96/curl_cffi-0.15.0-cp310-abi3-win_arm64.whl", hash = "sha256:a6d57f8389273a3a1f94370473c74897467bcc36af0a17336989780c507fa43d", size = 1410741, upload-time = "2026-04-03T11:12:10.073Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/c24df8a4fc22fa84070dcd94abeba43c15e08cc09e35869565c0bad196fd/curl_cffi-0.15.0-cp313-abi3-android_24_arm64_v8a.whl", hash = "sha256:4682dc38d4336e0eb0b185374db90a760efde63cbea994b4e63f3521d44c4c92", size = 7190427, upload-time = "2026-04-03T11:12:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/11/56/132225cb3491d07cc6adcce5fe395e059bde87c68cff1ef87a31c88c7819/curl_cffi-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:967ad7355bd8e9586f8c2d02eaa99953747549e7ea4a9b25cd53353e6b67fe6d", size = 2795723, upload-time = "2026-04-03T11:12:13.668Z" },
+    { url = "https://files.pythonhosted.org/packages/07/8f/f4f83cd303bef7e8f1749512e5dd157e7e5d08b0a36c8211f9640a2757bf/curl_cffi-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7e63539d0d839d0a8c5eacf86229bc68c57803547f35e0db7ee0986328b478c3", size = 2573739, upload-time = "2026-04-03T11:12:15.08Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/643d65c7fc9acd742876aa55c2d7823c438cb7665810acd2e66c9976c4d9/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08c799b89740b9bc49c09fbc3d5907f13ac1f845ca52620507ef9466d4639dd5", size = 10521046, upload-time = "2026-04-03T11:12:17.034Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0b/9b8037113c93f4c5323096163471fa7c35c7676c3f608eeaf1287cd99d58/curl_cffi-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b7a92767a888ee90147e18964b396d8435ff42737030d6fb00824ffd6094805", size = 11096115, upload-time = "2026-04-03T11:12:19.694Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/96/fff2fcbd924ef4042e0d67379f751a8a4e3186a91e75e35a4cf218b306ee/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:829cc357061ecb99cc2d406301f609a039e05665322f5c025ec67c38b0dc49ce", size = 11305346, upload-time = "2026-04-03T11:12:22.151Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/304b253a45ab28691c8c5e8cca1e6cbb9cf8e46dfceae4648dd536f75e73/curl_cffi-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:408d6f14e346841cd889c2e0962832bb235ba3b6749ebf609f347f747da5e60f", size = 11949834, upload-time = "2026-04-03T11:12:24.986Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/4723d92f08259c707a974aba27a08d0a822b9555e35ca581bf18d055a364/curl_cffi-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b624c7ce087bfda967a013ed0a64702a525444e5b6e97d23534d567ccc6525aa", size = 1702771, upload-time = "2026-04-03T11:12:28.201Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/36bbe06d66fa2b765e4a07199f643a59a9cd1a754207a96335402a9520f4/curl_cffi-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0b6c0543b993996670e9e4b78e305a2d60809d5681903ffb5568e21a387434d3", size = 1466312, upload-time = "2026-04-03T11:12:30.054Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -473,7 +506,7 @@ dev = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=26.0.0" },
     { name = "duckdb", specifier = ">=1.1.1" },
-    { name = "garminconnect", specifier = ">=0.2.0" },
+    { name = "garminconnect", specifier = ">=0.3.0" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
@@ -541,28 +574,16 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "garminconnect"
-version = "0.2.38"
+version = "0.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "garth" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/b5/c2d3c7fb53c98f74ef208b44b686e48f01cb6434d091f66593e29fd4d2ed/garminconnect-0.2.38.tar.gz", hash = "sha256:53f0d73e821dfa9e93731a6a1c81c34e689ce157c2751edd22dd462d4e4f9e04", size = 37502, upload-time = "2026-01-04T12:08:57.563Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/dc/9e0b1eee113fedfefd6577de45205e33505fcdc1520d4d28ee4c339e9862/garminconnect-0.2.38-py3-none-any.whl", hash = "sha256:801f64834d8d2ff41f10679e4111fc157312550980b0e29b0c2f263fd628a604", size = 32733, upload-time = "2026-01-04T12:08:55.45Z" },
-]
-
-[[package]]
-name = "garth"
-version = "0.5.21"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
+    { name = "curl-cffi" },
     { name = "requests" },
-    { name = "requests-oauthlib" },
+    { name = "ua-generator" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/1a/e559feb5efd53e9a5d15c28007a714e240a51363c79a306727977fe1999b/garth-0.5.21.tar.gz", hash = "sha256:8d979595d1d4ea23a1b466ab4a60955d139b71f886f46490be140fcee584dab4", size = 1840358, upload-time = "2026-01-07T23:12:33.828Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/d8/df118bbbf9a4634bf335cba7baf66f0618babbbf6982c7c43560f9d96d32/garminconnect-0.3.5.tar.gz", hash = "sha256:b4de13fa5e6c581348cbd8110afb9095dc68273d6cfb1284ed13cae7df0f6b02", size = 61692, upload-time = "2026-06-04T11:09:16.641Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/14/b7c77f363ff04cc0c57991277b8c3564df5210b0879894e2033f90f55ff5/garth-0.5.21-py3-none-any.whl", hash = "sha256:24b8c517ef24ef030bca14cf4e8d7ad7a191d9bc60ece6077fec6ea743a5d039", size = 33265, upload-time = "2026-01-07T23:12:32.069Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/c35ed445156311b9408aa2a10b6c9199392ea1fa26144de947d544c5601a/garminconnect-0.3.5-py3-none-any.whl", hash = "sha256:7a34c408ab4b94a69f67baeda96e8c8aef674447389bbb39beea0e5e49c2a29d", size = 57331, upload-time = "2026-06-04T11:09:15.203Z" },
 ]
 
 [[package]]
@@ -974,15 +995,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
     { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
     { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
-]
-
-[[package]]
-name = "oauthlib"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
 ]
 
 [[package]]
@@ -1515,19 +1527,6 @@ wheels = [
 ]
 
 [[package]]
-name = "requests-oauthlib"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "oauthlib" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
-]
-
-[[package]]
 name = "rich"
 version = "14.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1839,6 +1838,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "ua-generator"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/4a/46aa28f8eb83969ef8e1e8ae521147de966916de85ae6729d2d97480be15/ua_generator-2.1.1.tar.gz", hash = "sha256:c01984c1055da4900c8a1f4c419f229fa454caf42d8642267aec1904110d1c8d", size = 29642, upload-time = "2026-05-24T09:48:47.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/8c/a9f0161f2a34752987199425fec7f0068b012a02c98551615a9b82cbd70a/ua_generator-2.1.1-py3-none-any.whl", hash = "sha256:d8fd6e39e44dc057dd232d5f808fe0f61dab4a3163903cfe24446777ecdd2ec4", size = 32769, upload-time = "2026-05-24T09:48:45.44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Epic #183 Stage 2。garminconnect 0.2.38 → 0.3.5。0.3.x で `.garth` 属性が削除された（curl-cffi ベースの `Garmin.client` に統合）破壊的変更があり、3 箇所を修正。

### 破壊的変更への対応（0.3.5 を実地 introspect して確認・修正）
- `ingest/api_client.py`: `client.garth.dump(path)` → `client.client.dump(path)`
- `training_plan/garmin_uploader.py` (`_schedule_workout`): `client.garth.post(...)` → `client.client.post(...)`
- `training_plan/garmin_uploader.py` (`delete_workout`): `client.connectapi(path, method="DELETE")`（0.3.x で `connectapi` は GET 専用になり TypeError）→ `client.client.delete("connectapi", path)`
- 対応するテスト（`test_api_client.py`, `test_garmin_uploader.py`）のモック/アサーションを `.client` 経路に更新

オーケストレーターが 0.3.5 の `Client.dump/post/delete` シグネチャを再 introspect し、修正内容と一致することを確認済み。`garmin_api` テストは CI スキップのため、互換性は introspection で担保。

### 互換性確認した API（11件）
`Garmin()` 構築 / `login` / `get_activity` / `get_activity_details(maxchart=)` / `get_max_metrics` / `get_lactate_threshold(latest=)` / `get_daily_weigh_ins` / `get_activities_fordate` / `upload_workout` は変更なし。`.garth` 系 3 件のみ修正。

### lock diff
garminconnect 0.2.38→0.3.5。追加: curl-cffi, ua-generator。削除: garth, oauthlib, requests-oauthlib。pyproject: `garminconnect>=0.3.0`。

## Verification（オーケストレーターが worktree で再実行）
- full suite: **1738 passed**, 0 failed, 1 skipped
- ruff: clean / pre-commit: pass
- 0.3.5 実 API introspection と修正の整合確認: OK

Closes #185