### PR TITLE
chore: sync pre-commit black/ruff rev with uv.lock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,13 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
       - id: black
         language_version: python3.12
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.1
+    rev: v0.15.17
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]


### PR DESCRIPTION
## Summary

Epic #183 のフォローアップ。`.pre-commit-config.yaml` の `rev` ピンを uv.lock に揃えた。

- black `26.1.0` → `26.5.1`
- ruff `v0.15.1` → `v0.15.17`

`pre-commit-hooks` (v5.0.0) は uv.lock 管理外のため据え置き。

## Verification（worktree で実行）
- `pre-commit run --all-files`: 全フック **Passed**（black/ruff 新 rev で再フォーマット差分なし、mypy も pass）

Closes #194