### PR TITLE
feat(garmin-web): add trends dashboard with volume, physiology, form and efficiency

### DIFF
--- a/packages/garmin-web/frontend/package-lock.json
+++ b/packages/garmin-web/frontend/package-lock.json
@@ -8,8 +8,10 @@
       "name": "garmin-web-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "echarts": "^6.1.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-router-dom": "^7.17.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.0",
@@ -1665,6 +1667,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -1750,6 +1764,15 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/echarts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.1.0"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.372",
@@ -2231,6 +2254,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "dependencies": {
+        "react-router": "7.17.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -2325,6 +2384,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -2485,6 +2549,11 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -2810,6 +2879,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "node_modules/zrender": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
     }
   }
 }

--- a/packages/garmin-web/frontend/package.json
+++ b/packages/garmin-web/frontend/package.json
@@ -10,8 +10,10 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "echarts": "^6.1.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.17.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.0",

--- a/packages/garmin-web/frontend/src/App.tsx
+++ b/packages/garmin-web/frontend/src/App.tsx
@@ -1,5 +1,17 @@
+import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
 import ActivityList from "./pages/ActivityList";
+import TrendsDashboard from "./pages/TrendsDashboard";
 
 export default function App() {
-  return <ActivityList />;
+  return (
+    <BrowserRouter>
+      <nav>
+        <Link to="/">アクティビティ一覧</Link> | <Link to="/trends">トレンド</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<ActivityList />} />
+        <Route path="/trends" element={<TrendsDashboard />} />
+      </Routes>
+    </BrowserRouter>
+  );
 }

--- a/packages/garmin-web/frontend/src/api/trends.ts
+++ b/packages/garmin-web/frontend/src/api/trends.ts
@@ -1,0 +1,69 @@
+export type Granularity = "week" | "month";
+
+export interface VolumeTrendPoint {
+  bucket: string;
+  distance_km: number;
+  duration_seconds: number;
+  run_count: number;
+}
+
+export interface Vo2maxPoint {
+  date: string;
+  value: number | null;
+}
+
+export interface LactateThresholdPoint {
+  date: string;
+  heart_rate: number | null;
+  speed_mps: number | null;
+}
+
+export interface PhysiologyTrend {
+  vo2max: Vo2maxPoint[];
+  lactate_threshold: LactateThresholdPoint[];
+}
+
+export interface FormTrendPoint {
+  date: string;
+  overall_score: number | null;
+  gct_delta: number | null;
+  vo_delta: number | null;
+  vr_delta: number | null;
+}
+
+export interface EfficiencyTrendPoint {
+  date: string;
+  aerobic_efficiency: string | null;
+  primary_zone: string | null;
+  zone1_percentage: number | null;
+  zone2_percentage: number | null;
+  zone3_percentage: number | null;
+  zone4_percentage: number | null;
+  zone5_percentage: number | null;
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status}`);
+  }
+  return (await response.json()) as T;
+}
+
+export function fetchVolumeTrend(
+  granularity: Granularity,
+): Promise<VolumeTrendPoint[]> {
+  return fetchJson(`/api/trends/volume?granularity=${granularity}`);
+}
+
+export function fetchPhysiologyTrend(): Promise<PhysiologyTrend> {
+  return fetchJson("/api/trends/physiology");
+}
+
+export function fetchFormTrend(): Promise<FormTrendPoint[]> {
+  return fetchJson("/api/trends/form");
+}
+
+export function fetchEfficiencyTrend(): Promise<EfficiencyTrendPoint[]> {
+  return fetchJson("/api/trends/efficiency");
+}

--- a/packages/garmin-web/frontend/src/components/EChart.tsx
+++ b/packages/garmin-web/frontend/src/components/EChart.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+import * as echarts from "echarts";
+
+interface EChartProps {
+  option: echarts.EChartsOption;
+  ariaLabel: string;
+  height?: number;
+}
+
+/** Thin wrapper rendering an Apache ECharts chart into a div. */
+export default function EChart({ option, ariaLabel, height = 300 }: EChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const chart = echarts.init(container);
+    chart.setOption(option);
+    const handleResize = () => chart.resize();
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      chart.dispose();
+    };
+  }, [option]);
+
+  return (
+    <div
+      ref={containerRef}
+      role="img"
+      aria-label={ariaLabel}
+      style={{ width: "100%", height }}
+    />
+  );
+}

--- a/packages/garmin-web/frontend/src/pages/TrendsDashboard.test.tsx
+++ b/packages/garmin-web/frontend/src/pages/TrendsDashboard.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import TrendsDashboard from "./TrendsDashboard";
+
+// echarts requires a real canvas; mock it out for jsdom
+vi.mock("echarts", () => ({
+  init: () => ({
+    setOption: vi.fn(),
+    resize: vi.fn(),
+    dispose: vi.fn(),
+  }),
+}));
+
+const VOLUME = [
+  { bucket: "2025-W41", distance_km: 15.0, duration_seconds: 5400, run_count: 2 },
+  { bucket: "2025-W42", distance_km: 8.0, duration_seconds: 2400, run_count: 1 },
+];
+
+const PHYSIOLOGY = {
+  vo2max: [
+    { date: "2025-10-06", value: 49.6 },
+    { date: "2025-10-13", value: 50.1 },
+  ],
+  lactate_threshold: [{ date: "2025-10-13", heart_rate: 168, speed_mps: 3.2 }],
+};
+
+const FORM = [
+  {
+    date: "2025-10-06",
+    overall_score: 4.2,
+    gct_delta: 2.5,
+    vo_delta: 0.4,
+    vr_delta: 0.3,
+  },
+];
+
+const EFFICIENCY = [
+  {
+    date: "2025-10-06",
+    aerobic_efficiency: "good",
+    primary_zone: "Zone 2",
+    zone1_percentage: 10.0,
+    zone2_percentage: 60.0,
+    zone3_percentage: 20.0,
+    zone4_percentage: 8.0,
+    zone5_percentage: 2.0,
+  },
+];
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("TrendsDashboard", () => {
+  it("renders all four trend blocks from API data", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((url: string) => {
+        if (url.startsWith("/api/trends/volume")) {
+          return Promise.resolve(jsonResponse(VOLUME));
+        }
+        if (url.startsWith("/api/trends/physiology")) {
+          return Promise.resolve(jsonResponse(PHYSIOLOGY));
+        }
+        if (url.startsWith("/api/trends/form")) {
+          return Promise.resolve(jsonResponse(FORM));
+        }
+        if (url.startsWith("/api/trends/efficiency")) {
+          return Promise.resolve(jsonResponse(EFFICIENCY));
+        }
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }),
+    );
+
+    render(<TrendsDashboard />);
+
+    // All four block headings appear once data is loaded
+    expect(
+      await screen.findByRole("heading", { level: 2, name: "走行量" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 2, name: "生理指標 (VO2max / 乳酸閾値)" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 2, name: "フォームスコア推移" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 2, name: "効率推移 (HRゾーン分布)" }),
+    ).toBeInTheDocument();
+
+    // Volume block summary is rendered from the mocked API data
+    expect(screen.getByText(/2025-W42/)).toBeInTheDocument();
+    expect(screen.getByText(/8\.0 km/)).toBeInTheDocument();
+
+    // Physiology block shows the latest VO2max from the mocked API data
+    expect(screen.getByText(/最新VO2max: 50\.1/)).toBeInTheDocument();
+  });
+});

--- a/packages/garmin-web/frontend/src/pages/TrendsDashboard.tsx
+++ b/packages/garmin-web/frontend/src/pages/TrendsDashboard.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import {
+  fetchEfficiencyTrend,
+  fetchFormTrend,
+  fetchPhysiologyTrend,
+  fetchVolumeTrend,
+} from "../api/trends";
+import type {
+  EfficiencyTrendPoint,
+  FormTrendPoint,
+  Granularity,
+  PhysiologyTrend,
+  VolumeTrendPoint,
+} from "../api/trends";
+import VolumeBlock from "./trends/VolumeBlock";
+import PhysiologyBlock from "./trends/PhysiologyBlock";
+import FormBlock from "./trends/FormBlock";
+import EfficiencyBlock from "./trends/EfficiencyBlock";
+
+export default function TrendsDashboard() {
+  const [granularity, setGranularity] = useState<Granularity>("week");
+  const [volume, setVolume] = useState<VolumeTrendPoint[] | null>(null);
+  const [physiology, setPhysiology] = useState<PhysiologyTrend | null>(null);
+  const [form, setForm] = useState<FormTrendPoint[] | null>(null);
+  const [efficiency, setEfficiency] = useState<EfficiencyTrendPoint[] | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchVolumeTrend(granularity)
+      .then((data) => {
+        if (!cancelled) setVolume(data);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [granularity]);
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.all([fetchPhysiologyTrend(), fetchFormTrend(), fetchEfficiencyTrend()])
+      .then(([physiologyData, formData, efficiencyData]) => {
+        if (!cancelled) {
+          setPhysiology(physiologyData);
+          setForm(formData);
+          setEfficiency(efficiencyData);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (error) {
+    return <p role="alert">エラー: {error}</p>;
+  }
+
+  const loading =
+    volume == null || physiology == null || form == null || efficiency == null;
+  if (loading) {
+    return <p>読み込み中...</p>;
+  }
+
+  return (
+    <div>
+      <h1>トレンドダッシュボード</h1>
+      <VolumeBlock
+        data={volume}
+        granularity={granularity}
+        onGranularityChange={setGranularity}
+      />
+      <PhysiologyBlock data={physiology} />
+      <FormBlock data={form} />
+      <EfficiencyBlock data={efficiency} />
+    </div>
+  );
+}

--- a/packages/garmin-web/frontend/src/pages/trends/EfficiencyBlock.tsx
+++ b/packages/garmin-web/frontend/src/pages/trends/EfficiencyBlock.tsx
@@ -1,0 +1,44 @@
+import { useMemo } from "react";
+import EChart from "../../components/EChart";
+import type { EfficiencyTrendPoint } from "../../api/trends";
+
+interface EfficiencyBlockProps {
+  data: EfficiencyTrendPoint[];
+}
+
+const ZONE_KEYS = [
+  "zone1_percentage",
+  "zone2_percentage",
+  "zone3_percentage",
+  "zone4_percentage",
+  "zone5_percentage",
+] as const;
+
+export default function EfficiencyBlock({ data }: EfficiencyBlockProps) {
+  const option = useMemo(
+    () => ({
+      tooltip: { trigger: "axis" as const },
+      legend: { data: ZONE_KEYS.map((_, i) => `Zone ${i + 1}`) },
+      xAxis: { type: "category" as const, data: data.map((p) => p.date) },
+      yAxis: { type: "value" as const, name: "%", max: 100 },
+      series: ZONE_KEYS.map((key, i) => ({
+        name: `Zone ${i + 1}`,
+        type: "bar" as const,
+        stack: "zones",
+        data: data.map((p) => p[key]),
+      })),
+    }),
+    [data],
+  );
+
+  return (
+    <section aria-label="効率">
+      <h2>効率推移 (HRゾーン分布)</h2>
+      {data.length === 0 ? (
+        <p>データがありません</p>
+      ) : (
+        <EChart option={option} ariaLabel="HRゾーン分布の積み上げ棒グラフ" />
+      )}
+    </section>
+  );
+}

--- a/packages/garmin-web/frontend/src/pages/trends/FormBlock.tsx
+++ b/packages/garmin-web/frontend/src/pages/trends/FormBlock.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from "react";
+import EChart from "../../components/EChart";
+import type { FormTrendPoint } from "../../api/trends";
+
+interface FormBlockProps {
+  data: FormTrendPoint[];
+}
+
+export default function FormBlock({ data }: FormBlockProps) {
+  const option = useMemo(
+    () => ({
+      tooltip: { trigger: "axis" as const },
+      legend: { data: ["総合スコア", "GCT Δ%", "VO Δcm", "VR Δ%"] },
+      xAxis: { type: "category" as const, data: data.map((p) => p.date) },
+      yAxis: { type: "value" as const, scale: true },
+      series: [
+        {
+          name: "総合スコア",
+          type: "line" as const,
+          data: data.map((p) => p.overall_score),
+        },
+        {
+          name: "GCT Δ%",
+          type: "line" as const,
+          data: data.map((p) => p.gct_delta),
+        },
+        {
+          name: "VO Δcm",
+          type: "line" as const,
+          data: data.map((p) => p.vo_delta),
+        },
+        {
+          name: "VR Δ%",
+          type: "line" as const,
+          data: data.map((p) => p.vr_delta),
+        },
+      ],
+    }),
+    [data],
+  );
+
+  return (
+    <section aria-label="フォーム">
+      <h2>フォームスコア推移</h2>
+      {data.length === 0 ? (
+        <p>データがありません</p>
+      ) : (
+        <EChart option={option} ariaLabel="フォーム評価の折れ線グラフ" />
+      )}
+    </section>
+  );
+}

--- a/packages/garmin-web/frontend/src/pages/trends/PhysiologyBlock.tsx
+++ b/packages/garmin-web/frontend/src/pages/trends/PhysiologyBlock.tsx
@@ -1,0 +1,57 @@
+import { useMemo } from "react";
+import EChart from "../../components/EChart";
+import type { PhysiologyTrend } from "../../api/trends";
+
+interface PhysiologyBlockProps {
+  data: PhysiologyTrend;
+}
+
+export default function PhysiologyBlock({ data }: PhysiologyBlockProps) {
+  const option = useMemo(
+    () => ({
+      tooltip: { trigger: "axis" as const },
+      legend: { data: ["VO2max", "LT心拍"] },
+      xAxis: { type: "category" as const, data: data.vo2max.map((p) => p.date) },
+      yAxis: [
+        { type: "value" as const, name: "VO2max", scale: true },
+        { type: "value" as const, name: "LT心拍 (bpm)", scale: true },
+      ],
+      series: [
+        {
+          name: "VO2max",
+          type: "line" as const,
+          data: data.vo2max.map((p) => p.value),
+        },
+        {
+          name: "LT心拍",
+          type: "line" as const,
+          yAxisIndex: 1,
+          data: data.lactate_threshold.map((p) => [p.date, p.heart_rate]),
+        },
+      ],
+    }),
+    [data],
+  );
+
+  const latestVo2max = data.vo2max.at(-1);
+  const isEmpty =
+    data.vo2max.length === 0 && data.lactate_threshold.length === 0;
+
+  return (
+    <section aria-label="生理指標">
+      <h2>生理指標 (VO2max / 乳酸閾値)</h2>
+      {isEmpty ? (
+        <p>データがありません</p>
+      ) : (
+        <>
+          {latestVo2max?.value != null && (
+            <p>
+              最新VO2max: {latestVo2max.value.toFixed(1)} ({latestVo2max.date})
+            </p>
+          )}
+          <EChart option={option} ariaLabel="VO2maxと乳酸閾値の折れ線グラフ" />
+        </>
+      )}
+    </section>
+  );
+}

--- a/packages/garmin-web/frontend/src/pages/trends/VolumeBlock.tsx
+++ b/packages/garmin-web/frontend/src/pages/trends/VolumeBlock.tsx
@@ -1,0 +1,65 @@
+import { useMemo } from "react";
+import EChart from "../../components/EChart";
+import type { Granularity, VolumeTrendPoint } from "../../api/trends";
+
+interface VolumeBlockProps {
+  data: VolumeTrendPoint[];
+  granularity: Granularity;
+  onGranularityChange: (granularity: Granularity) => void;
+}
+
+export default function VolumeBlock({
+  data,
+  granularity,
+  onGranularityChange,
+}: VolumeBlockProps) {
+  const option = useMemo(
+    () => ({
+      tooltip: { trigger: "axis" as const },
+      xAxis: { type: "category" as const, data: data.map((p) => p.bucket) },
+      yAxis: { type: "value" as const, name: "km" },
+      series: [
+        {
+          name: "距離 (km)",
+          type: "bar" as const,
+          data: data.map((p) => p.distance_km),
+        },
+      ],
+    }),
+    [data],
+  );
+
+  return (
+    <section aria-label="走行量">
+      <h2>走行量</h2>
+      <div role="group" aria-label="集計単位">
+        <button
+          type="button"
+          aria-pressed={granularity === "week"}
+          onClick={() => onGranularityChange("week")}
+        >
+          週
+        </button>
+        <button
+          type="button"
+          aria-pressed={granularity === "month"}
+          onClick={() => onGranularityChange("month")}
+        >
+          月
+        </button>
+      </div>
+      {data.length === 0 ? (
+        <p>データがありません</p>
+      ) : (
+        <>
+          <p>
+            直近{granularity === "week" ? "週" : "月"} ({data[data.length - 1].bucket}
+            ): {data[data.length - 1].distance_km.toFixed(1)} km /{" "}
+            {data[data.length - 1].run_count} 回
+          </p>
+          <EChart option={option} ariaLabel="走行量の棒グラフ" />
+        </>
+      )}
+    </section>
+  );
+}

--- a/packages/garmin-web/src/garmin_web/api/trends.py
+++ b/packages/garmin-web/src/garmin_web/api/trends.py
@@ -1,0 +1,48 @@
+"""Trends API router."""
+
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Query, Request
+from garmin_mcp.database.connection import get_connection
+
+from garmin_web.queries import trends as trends_queries
+
+router = APIRouter(prefix="/api/trends")
+
+
+def _db_path(request: Request):
+    return getattr(request.app.state, "db_path", None)
+
+
+@router.get("/volume")
+def get_volume(
+    request: Request,
+    granularity: Annotated[Literal["week", "month"], Query()] = "week",
+) -> list[dict]:
+    """Running volume aggregated per ISO week or calendar month.
+
+    Invalid granularity values are rejected with 422 by FastAPI validation.
+    """
+    with get_connection(_db_path(request)) as conn:
+        return trends_queries.get_volume_trend(conn, granularity=granularity)
+
+
+@router.get("/physiology")
+def get_physiology(request: Request) -> dict:
+    """VO2max and lactate threshold time series."""
+    with get_connection(_db_path(request)) as conn:
+        return trends_queries.get_physiology_trend(conn)
+
+
+@router.get("/form")
+def get_form(request: Request) -> list[dict]:
+    """Form evaluation score trend."""
+    with get_connection(_db_path(request)) as conn:
+        return trends_queries.get_form_trend(conn)
+
+
+@router.get("/efficiency")
+def get_efficiency(request: Request) -> list[dict]:
+    """HR efficiency trend with zone distribution."""
+    with get_connection(_db_path(request)) as conn:
+        return trends_queries.get_efficiency_trend(conn)

--- a/packages/garmin-web/src/garmin_web/app.py
+++ b/packages/garmin-web/src/garmin_web/app.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from garmin_web.api.activities import router as activities_router
+from garmin_web.api.trends import router as trends_router
 
 VITE_DEV_ORIGIN = "http://localhost:5173"
 
@@ -30,4 +31,5 @@ def create_app(db_path: str | Path | None = None) -> FastAPI:
         allow_headers=["*"],
     )
     app.include_router(activities_router)
+    app.include_router(trends_router)
     return app

--- a/packages/garmin-web/src/garmin_web/queries/trends.py
+++ b/packages/garmin-web/src/garmin_web/queries/trends.py
@@ -1,0 +1,134 @@
+"""Read-only trend queries aggregating across activities."""
+
+import duckdb
+
+_VALID_GRANULARITIES = ("week", "month")
+
+_BUCKET_EXPRESSIONS = {
+    # ISO week, e.g. "2025-W41" (isoyear/weekofyear are ISO-8601 in DuckDB)
+    "week": "printf('%d-W%02d', isoyear(activity_date), weekofyear(activity_date))",
+    # Calendar month, e.g. "2025-10"
+    "month": "strftime(activity_date, '%Y-%m')",
+}
+
+
+def _rows_to_dicts(result: duckdb.DuckDBPyConnection) -> list[dict]:
+    """Convert a DuckDB result to a list of dicts keyed by column name."""
+    columns = [desc[0] for desc in result.description]
+    return [dict(zip(columns, row, strict=True)) for row in result.fetchall()]
+
+
+def get_volume_trend(
+    conn: duckdb.DuckDBPyConnection, granularity: str = "week"
+) -> list[dict]:
+    """Aggregate running volume per ISO week or calendar month.
+
+    Args:
+        conn: Open DuckDB connection (read-only is sufficient).
+        granularity: "week" (ISO week, e.g. "2025-W41") or
+            "month" (e.g. "2025-10").
+
+    Returns:
+        List of dicts sorted by bucket ascending, each with keys:
+        bucket (str), distance_km (float), duration_seconds (int),
+        run_count (int).
+
+    Raises:
+        ValueError: If granularity is not "week" or "month".
+    """
+    if granularity not in _VALID_GRANULARITIES:
+        raise ValueError(
+            f"granularity must be one of {_VALID_GRANULARITIES}, got {granularity!r}"
+        )
+    bucket_expr = _BUCKET_EXPRESSIONS[granularity]
+    result = conn.execute(f"""
+        SELECT
+            {bucket_expr} AS bucket,
+            COALESCE(SUM(total_distance_km), 0.0) AS distance_km,
+            CAST(COALESCE(SUM(total_time_seconds), 0) AS INTEGER)
+                AS duration_seconds,
+            COUNT(*) AS run_count
+        FROM activities
+        GROUP BY bucket
+        ORDER BY bucket
+    """)
+    return _rows_to_dicts(result)
+
+
+def get_physiology_trend(conn: duckdb.DuckDBPyConnection) -> dict:
+    """Time series of VO2max and lactate threshold measurements.
+
+    Returns:
+        Dict with keys:
+        - "vo2max": list of {"date": str, "value": float}, date ascending.
+        - "lactate_threshold": list of
+          {"date": str, "heart_rate": int, "speed_mps": float},
+          date ascending.
+    """
+    # NOTE: conn.execute() returns the connection itself, so each result
+    # must be fully consumed before the next query is executed.
+    vo2max = _rows_to_dicts(conn.execute("""
+            SELECT
+                CAST(date AS VARCHAR) AS date,
+                COALESCE(precise_value, value) AS value
+            FROM vo2_max
+            WHERE date IS NOT NULL
+            ORDER BY date
+        """))
+    lactate = _rows_to_dicts(conn.execute("""
+            SELECT
+                CAST(CAST(date_hr AS DATE) AS VARCHAR) AS date,
+                heart_rate,
+                speed_mps
+            FROM lactate_threshold
+            WHERE date_hr IS NOT NULL
+            ORDER BY date_hr
+        """))
+    return {"vo2max": vo2max, "lactate_threshold": lactate}
+
+
+def get_form_trend(conn: duckdb.DuckDBPyConnection) -> list[dict]:
+    """Form evaluation scores joined with activity dates.
+
+    Returns:
+        List of dicts sorted by date ascending, each with keys:
+        date (str), overall_score (float), gct_delta (float, %),
+        vo_delta (float, cm), vr_delta (float, %).
+    """
+    result = conn.execute("""
+        SELECT
+            CAST(a.activity_date AS VARCHAR) AS date,
+            f.overall_score,
+            f.gct_delta_pct AS gct_delta,
+            f.vo_delta_cm AS vo_delta,
+            f.vr_delta_pct AS vr_delta
+        FROM form_evaluations f
+        JOIN activities a USING (activity_id)
+        ORDER BY a.activity_date
+    """)
+    return _rows_to_dicts(result)
+
+
+def get_efficiency_trend(conn: duckdb.DuckDBPyConnection) -> list[dict]:
+    """HR efficiency metrics joined with activity dates.
+
+    Returns:
+        List of dicts sorted by date ascending, each with keys:
+        date (str), aerobic_efficiency (str rating), primary_zone (str),
+        zone1_percentage .. zone5_percentage (float).
+    """
+    result = conn.execute("""
+        SELECT
+            CAST(a.activity_date AS VARCHAR) AS date,
+            h.aerobic_efficiency,
+            h.primary_zone,
+            h.zone1_percentage,
+            h.zone2_percentage,
+            h.zone3_percentage,
+            h.zone4_percentage,
+            h.zone5_percentage
+        FROM hr_efficiency h
+        JOIN activities a USING (activity_id)
+        ORDER BY a.activity_date
+    """)
+    return _rows_to_dicts(result)

--- a/packages/garmin-web/tests/conftest.py
+++ b/packages/garmin-web/tests/conftest.py
@@ -54,3 +54,135 @@ def empty_db_path(tmp_path: Path) -> Path:
     finally:
         conn.close()
     return db_path
+
+
+# --- Trends fixtures (Issue #201) -------------------------------------------
+# Column names mirror the production schema in
+# garmin_mcp/database/db_writer.py (only columns used by trend queries).
+
+_CREATE_VO2_MAX = """
+    CREATE TABLE vo2_max (
+        activity_id BIGINT PRIMARY KEY,
+        precise_value DOUBLE,
+        value DOUBLE,
+        date DATE,
+        category INTEGER
+    )
+"""
+
+_CREATE_LACTATE_THRESHOLD = """
+    CREATE TABLE lactate_threshold (
+        activity_id BIGINT PRIMARY KEY,
+        heart_rate INTEGER,
+        speed_mps DOUBLE,
+        date_hr TIMESTAMP
+    )
+"""
+
+_CREATE_FORM_EVALUATIONS = """
+    CREATE TABLE form_evaluations (
+        eval_id INTEGER PRIMARY KEY,
+        activity_id BIGINT UNIQUE,
+        gct_delta_pct FLOAT,
+        vo_delta_cm FLOAT,
+        vr_delta_pct FLOAT,
+        overall_score FLOAT
+    )
+"""
+
+_CREATE_HR_EFFICIENCY = """
+    CREATE TABLE hr_efficiency (
+        activity_id BIGINT PRIMARY KEY,
+        primary_zone VARCHAR,
+        aerobic_efficiency VARCHAR,
+        zone1_percentage DOUBLE,
+        zone2_percentage DOUBLE,
+        zone3_percentage DOUBLE,
+        zone4_percentage DOUBLE,
+        zone5_percentage DOUBLE
+    )
+"""
+
+_TRENDS_TABLE_DDLS = [
+    _CREATE_ACTIVITIES,
+    _CREATE_VO2_MAX,
+    _CREATE_LACTATE_THRESHOLD,
+    _CREATE_FORM_EVALUATIONS,
+    _CREATE_HR_EFFICIENCY,
+]
+
+
+def _create_trends_tables(conn: duckdb.DuckDBPyConnection) -> None:
+    for ddl in _TRENDS_TABLE_DDLS:
+        conn.execute(ddl)
+
+
+@pytest.fixture
+def trends_conn():
+    """In-memory DuckDB with activities + 4 trend tables, no rows.
+
+    Unit tests insert their own rows (activity_id band: 9000001xxx).
+    """
+    conn = duckdb.connect(":memory:")
+    _create_trends_tables(conn)
+    yield conn
+    conn.close()
+
+
+# (activity_id, date, name, distance_km, time_s, pace_s_per_km, avg_hr)
+_TRENDS_ACTIVITY_ROWS = [
+    (9000001001, "2025-10-06", "Run A", 10.0, 3600, 360.0, 140),
+    (9000001002, "2025-10-09", "Run B", 5.0, 1800, 360.0, 145),
+    (9000001003, "2025-10-13", "Run C", 8.0, 2400, 300.0, 150),
+    (9000001004, "2025-11-03", "Run D", 7.0, 2100, 300.0, 148),
+]
+
+
+@pytest.fixture
+def trends_db_path(tmp_path: Path) -> Path:
+    """File DuckDB with activities + trend tables populated (9000001xxx)."""
+    db_path = tmp_path / "test_garmin_web_trends.duckdb"
+    conn = duckdb.connect(str(db_path))
+    try:
+        _create_trends_tables(conn)
+        conn.executemany(
+            "INSERT INTO activities VALUES (?, ?, ?, ?, ?, ?, ?)",
+            _TRENDS_ACTIVITY_ROWS,
+        )
+        conn.executemany(
+            "INSERT INTO vo2_max VALUES (?, ?, ?, ?, ?)",
+            [
+                (9000001001, 49.6, 50.0, "2025-10-06", 5),
+                (9000001003, 50.1, 50.0, "2025-10-13", 5),
+            ],
+        )
+        conn.execute(
+            "INSERT INTO lactate_threshold VALUES (?, ?, ?, ?)",
+            (9000001003, 168, 3.2, "2025-10-13 06:30:00"),
+        )
+        conn.executemany(
+            "INSERT INTO form_evaluations VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                (1, 9000001001, 2.5, 0.4, 0.3, 4.2),
+                (2, 9000001003, 1.8, 0.2, 0.1, 4.5),
+            ],
+        )
+        conn.execute(
+            "INSERT INTO hr_efficiency VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (9000001001, "Zone 2", "good", 10.0, 60.0, 20.0, 8.0, 2.0),
+        )
+    finally:
+        conn.close()
+    return db_path
+
+
+@pytest.fixture
+def empty_trends_db_path(tmp_path: Path) -> Path:
+    """File DuckDB with activities + trend tables, all empty."""
+    db_path = tmp_path / "test_garmin_web_trends_empty.duckdb"
+    conn = duckdb.connect(str(db_path))
+    try:
+        _create_trends_tables(conn)
+    finally:
+        conn.close()
+    return db_path

--- a/packages/garmin-web/tests/test_api_trends.py
+++ b/packages/garmin-web/tests/test_api_trends.py
@@ -1,0 +1,38 @@
+"""API tests for GET /api/trends/*."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from garmin_web.app import create_app
+
+_ENDPOINTS = (
+    "/api/trends/volume",
+    "/api/trends/physiology",
+    "/api/trends/form",
+    "/api/trends/efficiency",
+)
+
+
+@pytest.mark.integration
+def test_api_trends_all_endpoints_200(trends_db_path, empty_trends_db_path):
+    client = TestClient(create_app(db_path=trends_db_path))
+    for endpoint in _ENDPOINTS:
+        response = client.get(endpoint)
+        assert response.status_code == 200, endpoint
+
+    volume = client.get("/api/trends/volume", params={"granularity": "month"})
+    assert volume.status_code == 200
+    assert [bucket["bucket"] for bucket in volume.json()] == ["2025-10", "2025-11"]
+
+    # Invalid granularity is rejected by FastAPI validation
+    invalid = client.get("/api/trends/volume", params={"granularity": "day"})
+    assert invalid.status_code == 422
+
+    # Empty DB returns 200 with empty payloads
+    empty_client = TestClient(create_app(db_path=empty_trends_db_path))
+    assert empty_client.get("/api/trends/volume").json() == []
+    assert empty_client.get("/api/trends/form").json() == []
+    assert empty_client.get("/api/trends/efficiency").json() == []
+    physiology = empty_client.get("/api/trends/physiology")
+    assert physiology.status_code == 200
+    assert physiology.json() == {"vo2max": [], "lactate_threshold": []}

--- a/packages/garmin-web/tests/test_queries_trends.py
+++ b/packages/garmin-web/tests/test_queries_trends.py
@@ -1,0 +1,137 @@
+"""Unit tests for garmin_web.queries.trends."""
+
+import pytest
+
+from garmin_web.queries.trends import (
+    get_efficiency_trend,
+    get_form_trend,
+    get_physiology_trend,
+    get_volume_trend,
+)
+
+_INSERT_ACTIVITY = "INSERT INTO activities VALUES (?, ?, ?, ?, ?, ?, ?)"
+
+
+@pytest.mark.unit
+def test_volume_weekly_buckets(trends_conn):
+    """2025-10-06 (Mon) and 10-09 share ISO week W41; 10-13 starts W42."""
+    trends_conn.executemany(
+        _INSERT_ACTIVITY,
+        [
+            (9000001101, "2025-10-06", "Run A", 10.0, 3600, 360.0, 140),
+            (9000001102, "2025-10-09", "Run B", 5.0, 1800, 360.0, 145),
+            (9000001103, "2025-10-13", "Run C", 8.0, 2400, 300.0, 150),
+        ],
+    )
+
+    result = get_volume_trend(trends_conn, granularity="week")
+
+    assert [bucket["bucket"] for bucket in result] == ["2025-W41", "2025-W42"]
+    w41 = result[0]
+    assert w41["distance_km"] == pytest.approx(15.0)
+    assert w41["duration_seconds"] == 5400
+    assert w41["run_count"] == 2
+    w42 = result[1]
+    assert w42["distance_km"] == pytest.approx(8.0)
+    assert w42["run_count"] == 1
+
+
+@pytest.mark.unit
+def test_volume_monthly_buckets(trends_conn):
+    trends_conn.executemany(
+        _INSERT_ACTIVITY,
+        [
+            (9000001111, "2025-10-06", "Run A", 10.0, 3600, 360.0, 140),
+            (9000001112, "2025-10-20", "Run B", 5.0, 1800, 360.0, 145),
+            (9000001113, "2025-11-03", "Run C", 8.0, 2400, 300.0, 150),
+        ],
+    )
+
+    result = get_volume_trend(trends_conn, granularity="month")
+
+    assert [bucket["bucket"] for bucket in result] == ["2025-10", "2025-11"]
+    assert result[0]["distance_km"] == pytest.approx(15.0)
+    assert result[0]["run_count"] == 2
+    assert result[1]["run_count"] == 1
+
+
+@pytest.mark.unit
+def test_volume_invalid_granularity_raises(trends_conn):
+    with pytest.raises(ValueError, match="granularity"):
+        get_volume_trend(trends_conn, granularity="day")
+
+
+@pytest.mark.unit
+def test_physiology_series_sorted(trends_conn):
+    """vo2_max rows inserted in reverse date order come back date-ascending."""
+    trends_conn.executemany(
+        "INSERT INTO vo2_max VALUES (?, ?, ?, ?, ?)",
+        [
+            (9000001121, 50.2, 50.0, "2025-10-15", 5),
+            (9000001122, 49.8, 50.0, "2025-10-10", 5),
+            (9000001123, 49.1, 49.0, "2025-10-05", 5),
+        ],
+    )
+    trends_conn.execute(
+        "INSERT INTO lactate_threshold VALUES (?, ?, ?, ?)",
+        (9000001121, 168, 3.2, "2025-10-15 06:30:00"),
+    )
+
+    result = get_physiology_trend(trends_conn)
+
+    dates = [point["date"] for point in result["vo2max"]]
+    assert dates == ["2025-10-05", "2025-10-10", "2025-10-15"]
+    assert all(isinstance(date, str) for date in dates)
+    assert result["vo2max"][0]["value"] == pytest.approx(49.1)
+    lt = result["lactate_threshold"]
+    assert lt == [{"date": "2025-10-15", "heart_rate": 168, "speed_mps": 3.2}]
+
+
+@pytest.mark.unit
+def test_form_trend_joins_dates(trends_conn):
+    trends_conn.executemany(
+        _INSERT_ACTIVITY,
+        [
+            (9000001131, "2025-10-06", "Run A", 10.0, 3600, 360.0, 140),
+            (9000001132, "2025-10-09", "Run B", 5.0, 1800, 360.0, 145),
+        ],
+    )
+    trends_conn.executemany(
+        "INSERT INTO form_evaluations VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            (1, 9000001131, 2.5, 0.4, 0.3, 4.2),
+            (2, 9000001132, 1.8, 0.2, 0.1, 4.5),
+        ],
+    )
+
+    result = get_form_trend(trends_conn)
+
+    assert [(point["date"], point["overall_score"]) for point in result] == [
+        ("2025-10-06", pytest.approx(4.2)),
+        ("2025-10-09", pytest.approx(4.5)),
+    ]
+    first = result[0]
+    assert first["gct_delta"] == pytest.approx(2.5)
+    assert first["vo_delta"] == pytest.approx(0.4)
+    assert first["vr_delta"] == pytest.approx(0.3)
+
+
+@pytest.mark.unit
+def test_efficiency_trend_zone_percentages(trends_conn):
+    trends_conn.execute(
+        _INSERT_ACTIVITY,
+        (9000001141, "2025-10-06", "Run A", 10.0, 3600, 360.0, 140),
+    )
+    trends_conn.execute(
+        "INSERT INTO hr_efficiency VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (9000001141, "Zone 2", "good", 10.0, 60.0, 20.0, 8.0, 2.0),
+    )
+
+    result = get_efficiency_trend(trends_conn)
+
+    assert len(result) == 1
+    point = result[0]
+    assert point["date"] == "2025-10-06"
+    assert point["zone2_percentage"] == pytest.approx(60.0)
+    assert point["primary_zone"] == "Zone 2"
+    assert point["aerobic_efficiency"] == "good"


### PR DESCRIPTION
Closes #201

Part of Epic #196 の P4。複数アクティビティ横断のトレンドダッシュボード（4ブロック）を実装。

## 変更内容

- **Backend**: `queries/trends.py`（volume/physiology/form/efficiency の4関数）+ `api/trends.py`（`GET /api/trends/{volume|physiology|form|efficiency}`）。`app.py` への変更は import + include_router の2行のみ
- **Frontend**: `/trends` ルート + TrendsDashboard（走行量棒グラフ 週/月トグル、VO2max・LT折れ線、フォームスコア推移、ゾーン分布積み上げ棒）。echarts + react-router-dom を追加
- ISO週バケットは `isoyear()`+`weekofyear()` で実装（2025-10-06/09 → W41、10-13 → W42 をテストで検証）

## 検証（L2 相当 — オーケストレーターが独立実行で確認済み）

| チェック | 結果 |
|---|---|
| `pytest -m unit` | 10 passed（trends 6本 + 既存4本） |
| `pytest -m integration` | 2 passed |
| `ruff check src/ tests/` | clean |
| `vitest run` | 2 passed |
| `tsc + vite build` | pass（echarts 由来の chunk size warning は informational） |

## 設計からの逸脱（理由付き）

- `aerobic_efficiency` は str で返却 — 実テーブルが VARCHAR（"good" 等の rating）のため。効率ブロックはゾーン分布積み上げ棒を主体に変更
- `date IS NULL` / `date_hr IS NULL` 行は時系列から除外（プロット不能のため。ingest 汚染のマスクではなく表示要件）
- 実装中に発見したバグ: DuckDB `conn.execute()` の結果は次の execute で上書きされるため、`get_physiology_trend` は各クエリを即時 fetch する形にした

## Note

P2 (#199) が並行開発中。共有ファイル（`app.py`/`App.tsx`/`package.json`）は追加最小限。後からマージする側が rebase でコンフリクト解消する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)