### PR TITLE
feat(garmin-web): add activity detail page with time-series, splits and section cards

### DIFF
--- a/packages/garmin-web/frontend/package-lock.json
+++ b/packages/garmin-web/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "echarts": "^6.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-markdown": "^10.0.0",
         "react-router-dom": "^7.17.0"
       },
       "devDependencies": {
@@ -1354,6 +1355,14 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1363,14 +1372,41 @@
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
-      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1383,6 +1419,16 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1562,6 +1608,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.36",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.36.tgz",
@@ -1636,6 +1691,15 @@
         }
       ]
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -1652,6 +1716,42 @@
         "node": ">=18"
       }
     },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -1659,6 +1759,15 @@
       "dev": true,
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/convert-source-map": {
@@ -1701,8 +1810,7 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -1721,7 +1829,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1740,6 +1847,18 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1753,9 +1872,20 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -1848,6 +1978,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1865,6 +2004,11 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1906,6 +2050,44 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -1916,6 +2098,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -1963,6 +2154,62 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -2040,6 +2287,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2074,6 +2330,572 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -2086,8 +2908,7 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -2121,6 +2942,29 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
       "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
       "dev": true
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -2210,6 +3054,15 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2244,6 +3097,32 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -2301,6 +3180,37 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rollup": {
@@ -2405,6 +3315,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -2416,6 +3335,19 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -2446,6 +3378,22 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
@@ -2550,6 +3498,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
@@ -2566,6 +3532,87 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -2596,6 +3643,32 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -2886,6 +3959,15 @@
       "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
       "dependencies": {
         "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/packages/garmin-web/frontend/package.json
+++ b/packages/garmin-web/frontend/package.json
@@ -13,6 +13,7 @@
     "echarts": "^6.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-markdown": "^10.0.0",
     "react-router-dom": "^7.17.0"
   },
   "devDependencies": {

--- a/packages/garmin-web/frontend/src/App.tsx
+++ b/packages/garmin-web/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
+import ActivityDetail from "./pages/ActivityDetail";
 import ActivityList from "./pages/ActivityList";
 import TrendsDashboard from "./pages/TrendsDashboard";
 
@@ -10,6 +11,7 @@ export default function App() {
       </nav>
       <Routes>
         <Route path="/" element={<ActivityList />} />
+        <Route path="/activities/:id" element={<ActivityDetail />} />
         <Route path="/trends" element={<TrendsDashboard />} />
       </Routes>
     </BrowserRouter>

--- a/packages/garmin-web/frontend/src/api/client.ts
+++ b/packages/garmin-web/frontend/src/api/client.ts
@@ -1,4 +1,9 @@
-import type { ActivitySummary } from "../types";
+import type {
+  ActivityDetailResponse,
+  ActivitySummary,
+  SectionsResponse,
+  TimeSeriesResponse,
+} from "../types";
 
 export async function fetchActivities(params?: {
   from?: string;
@@ -13,4 +18,42 @@ export async function fetchActivities(params?: {
     throw new Error(`Failed to fetch activities: ${response.status}`);
   }
   return (await response.json()) as ActivitySummary[];
+}
+
+export async function fetchActivityDetail(
+  activityId: string | number,
+): Promise<ActivityDetailResponse> {
+  const response = await fetch(`/api/activities/${activityId}`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch activity detail: ${response.status}`);
+  }
+  return (await response.json()) as ActivityDetailResponse;
+}
+
+export async function fetchTimeSeries(
+  activityId: string | number,
+  metrics: string[],
+  maxPoints = 500,
+): Promise<TimeSeriesResponse> {
+  const query = new URLSearchParams({
+    metrics: metrics.join(","),
+    max_points: String(maxPoints),
+  });
+  const response = await fetch(
+    `/api/activities/${activityId}/time-series?${query.toString()}`,
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to fetch time series: ${response.status}`);
+  }
+  return (await response.json()) as TimeSeriesResponse;
+}
+
+export async function fetchSections(
+  activityId: string | number,
+): Promise<SectionsResponse> {
+  const response = await fetch(`/api/activities/${activityId}/sections`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch sections: ${response.status}`);
+  }
+  return (await response.json()) as SectionsResponse;
 }

--- a/packages/garmin-web/frontend/src/components/TimeSeriesChart.tsx
+++ b/packages/garmin-web/frontend/src/components/TimeSeriesChart.tsx
@@ -1,0 +1,135 @@
+import * as echarts from "echarts";
+import { useEffect, useRef } from "react";
+import type { TimeSeriesResponse } from "../types";
+
+const GRID_HEIGHT = 140;
+const GRID_GAP = 50;
+const GRID_TOP = 40;
+
+export function formatElapsed(totalSeconds: number): string {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = Math.floor(totalSeconds % 60);
+  const mmss = `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  return hours > 0 ? `${hours}:${mmss}` : mmss;
+}
+
+export function formatPaceLabel(secondsPerKm: number): string {
+  const minutes = Math.floor(secondsPerKm / 60);
+  const seconds = Math.round(secondsPerKm % 60);
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+/** speed (m/s) -> pace (sec/km); null for non-positive speeds. */
+function speedToPace(value: number | null): number | null {
+  if (value == null || value <= 0) {
+    return null;
+  }
+  return Math.round(1000 / value);
+}
+
+/**
+ * Stacked line charts (one grid per metric) with a shared x axis:
+ * dataZoom and axisPointer are linked across all grids.
+ * The "speed" metric is displayed as pace (min/km, inverted axis).
+ */
+export default function TimeSeriesChart({
+  data,
+  metricLabels,
+}: {
+  data: TimeSeriesResponse;
+  metricLabels: Record<string, string>;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<echarts.ECharts | null>(null);
+
+  const metricNames = Object.keys(data.metrics);
+  const height = GRID_TOP + metricNames.length * (GRID_HEIGHT + GRID_GAP) + 60;
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || metricNames.length === 0) {
+      return;
+    }
+    chartRef.current ??= echarts.init(container);
+
+    const base = data.timestamps[0] ?? 0;
+    const elapsedLabels = data.timestamps.map((t) => formatElapsed(t - base));
+    const lastIndex = metricNames.length - 1;
+    const allXAxisIndices = metricNames.map((_, i) => i);
+
+    const option: echarts.EChartsOption = {
+      animation: false,
+      axisPointer: { link: [{ xAxisIndex: "all" }] },
+      tooltip: { trigger: "axis" },
+      grid: metricNames.map((_, i) => ({
+        left: 80,
+        right: 30,
+        top: GRID_TOP + i * (GRID_HEIGHT + GRID_GAP),
+        height: GRID_HEIGHT,
+      })),
+      xAxis: metricNames.map((_, i) => ({
+        type: "category",
+        gridIndex: i,
+        data: elapsedLabels,
+        axisLabel: { show: i === lastIndex },
+        axisPointer: { show: true },
+      })),
+      yAxis: metricNames.map((name, i) => {
+        const isPace = name === "speed";
+        return {
+          type: "value",
+          gridIndex: i,
+          name: metricLabels[name] ?? name,
+          scale: true,
+          inverse: isPace,
+          axisLabel: isPace
+            ? { formatter: (value: number) => formatPaceLabel(value) }
+            : {},
+        };
+      }),
+      series: metricNames.map((name, i) => {
+        const isPace = name === "speed";
+        const values = isPace
+          ? data.metrics[name].map(speedToPace)
+          : data.metrics[name];
+        return {
+          name: metricLabels[name] ?? name,
+          type: "line" as const,
+          xAxisIndex: i,
+          yAxisIndex: i,
+          data: values,
+          showSymbol: false,
+          connectNulls: false,
+          tooltip: isPace
+            ? {
+                valueFormatter: (value) =>
+                  typeof value === "number"
+                    ? `${formatPaceLabel(value)}/km`
+                    : "-",
+              }
+            : {},
+        };
+      }),
+      dataZoom: [
+        { type: "inside", xAxisIndex: allXAxisIndices },
+        { type: "slider", xAxisIndex: allXAxisIndices, bottom: 10 },
+      ],
+    };
+    chartRef.current.setOption(option, true);
+    chartRef.current.resize({ height });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, metricLabels, height]);
+
+  useEffect(() => {
+    const handleResize = () => chartRef.current?.resize();
+    window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      chartRef.current?.dispose();
+      chartRef.current = null;
+    };
+  }, []);
+
+  return <div ref={containerRef} style={{ width: "100%", height }} />;
+}

--- a/packages/garmin-web/frontend/src/components/sections/EfficiencySectionCard.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/EfficiencySectionCard.tsx
@@ -1,0 +1,36 @@
+import type { EfficiencySectionData } from "../../types";
+import KeyValueList from "./KeyValueList";
+import MarkdownText from "./MarkdownText";
+
+const FIELDS: { key: keyof EfficiencySectionData & string; label: string }[] = [
+  { key: "efficiency", label: "フォーム効率" },
+  { key: "evaluation", label: "心拍効率評価" },
+  { key: "form_trend", label: "フォームトレンド" },
+];
+
+const KNOWN_KEYS = ["metadata", ...FIELDS.map((field) => field.key)];
+
+export default function EfficiencySectionCard({
+  data,
+}: {
+  data: EfficiencySectionData;
+}) {
+  return (
+    <section className="section-card">
+      <h3>効率分析</h3>
+      {FIELDS.map(({ key, label }) => {
+        const text = data[key];
+        if (typeof text !== "string") {
+          return null;
+        }
+        return (
+          <div key={key}>
+            <h4>{label}</h4>
+            <MarkdownText text={text} />
+          </div>
+        );
+      })}
+      <KeyValueList data={data} exclude={KNOWN_KEYS} />
+    </section>
+  );
+}

--- a/packages/garmin-web/frontend/src/components/sections/EnvironmentSectionCard.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/EnvironmentSectionCard.tsx
@@ -1,0 +1,21 @@
+import type { EnvironmentSectionData } from "../../types";
+import KeyValueList from "./KeyValueList";
+import MarkdownText from "./MarkdownText";
+
+const KNOWN_KEYS = ["metadata", "environmental"];
+
+export default function EnvironmentSectionCard({
+  data,
+}: {
+  data: EnvironmentSectionData;
+}) {
+  return (
+    <section className="section-card">
+      <h3>環境影響</h3>
+      {typeof data.environmental === "string" && (
+        <MarkdownText text={data.environmental} />
+      )}
+      <KeyValueList data={data} exclude={KNOWN_KEYS} />
+    </section>
+  );
+}

--- a/packages/garmin-web/frontend/src/components/sections/FallbackCard.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/FallbackCard.tsx
@@ -1,0 +1,19 @@
+import KeyValueList from "./KeyValueList";
+
+/** Generic card rendering all fields as key-value pairs. */
+export default function FallbackCard({
+  title,
+  data,
+  exclude = [],
+}: {
+  title: string;
+  data: Record<string, unknown>;
+  exclude?: string[];
+}) {
+  return (
+    <section className="section-card">
+      <h3>{title}</h3>
+      <KeyValueList data={data} exclude={exclude} />
+    </section>
+  );
+}

--- a/packages/garmin-web/frontend/src/components/sections/KeyValueList.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/KeyValueList.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+import MarkdownText from "./MarkdownText";
+
+export function renderValue(value: unknown): ReactNode {
+  if (value == null) {
+    return "-";
+  }
+  if (typeof value === "string") {
+    return <MarkdownText text={value} />;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return (
+      <ul>
+        {value.map((item, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <li key={index}>{renderValue(item)}</li>
+        ))}
+      </ul>
+    );
+  }
+  if (typeof value === "object") {
+    return <KeyValueList data={value as Record<string, unknown>} />;
+  }
+  return String(value);
+}
+
+/**
+ * Generic key-value renderer for unknown / fallback section fields.
+ * String values are rendered as Markdown; arrays and nested objects
+ * are rendered recursively.
+ */
+export default function KeyValueList({
+  data,
+  exclude = [],
+}: {
+  data: Record<string, unknown>;
+  exclude?: string[];
+}) {
+  const entries = Object.entries(data).filter(([key]) => !exclude.includes(key));
+  if (entries.length === 0) {
+    return null;
+  }
+  return (
+    <dl className="key-value-list">
+      {entries.map(([key, value]) => (
+        <div key={key} className="key-value-item">
+          <dt>{key}</dt>
+          <dd>{renderValue(value)}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/packages/garmin-web/frontend/src/components/sections/MarkdownText.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/MarkdownText.tsx
@@ -1,0 +1,6 @@
+import ReactMarkdown from "react-markdown";
+
+/** Renders Markdown-style Japanese analysis text from section JSON. */
+export default function MarkdownText({ text }: { text: string }) {
+  return <ReactMarkdown>{text}</ReactMarkdown>;
+}

--- a/packages/garmin-web/frontend/src/components/sections/PhaseSectionCard.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/PhaseSectionCard.tsx
@@ -1,0 +1,34 @@
+import type { PhaseSectionData } from "../../types";
+import KeyValueList from "./KeyValueList";
+import MarkdownText from "./MarkdownText";
+
+const PHASE_FIELDS: { key: keyof PhaseSectionData & string; label: string }[] = [
+  { key: "warmup_evaluation", label: "ウォームアップ" },
+  { key: "run_evaluation", label: "メインラン" },
+  { key: "recovery_evaluation", label: "リカバリー" }, // interval training only
+  { key: "cooldown_evaluation", label: "クールダウン" },
+  { key: "evaluation_criteria", label: "評価基準" },
+];
+
+const KNOWN_KEYS = ["metadata", ...PHASE_FIELDS.map((field) => field.key)];
+
+export default function PhaseSectionCard({ data }: { data: PhaseSectionData }) {
+  return (
+    <section className="section-card">
+      <h3>フェーズ評価</h3>
+      {PHASE_FIELDS.map(({ key, label }) => {
+        const text = data[key];
+        if (typeof text !== "string") {
+          return null;
+        }
+        return (
+          <div key={key}>
+            <h4>{label}</h4>
+            <MarkdownText text={text} />
+          </div>
+        );
+      })}
+      <KeyValueList data={data} exclude={KNOWN_KEYS} />
+    </section>
+  );
+}

--- a/packages/garmin-web/frontend/src/components/sections/SectionCard.test.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/SectionCard.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import SectionCard from "./SectionCard";
+
+describe("SectionCard", () => {
+  it("falls back to key-value for unknown fields", () => {
+    const section = {
+      data: {
+        metadata: {
+          activity_id: "9000000101",
+          date: "2025-10-09",
+          analyst: "summary-section-analyst",
+          version: "1.0",
+          timestamp: "2025-10-09T12:00:00+09:00",
+        },
+        // Known fields -> dedicated rendering
+        star_rating: "★★★★☆ 4.3/5.0",
+        summary: "有酸素ベースの安定したランでした。",
+        key_strengths: ["心拍の安定", "ケイデンス維持"],
+        // Unknown fields (added without version bump) -> key-value fallback
+        next_action: "次回はHR 135-145でイージーランを実施",
+        integrated_score: 4.1,
+      },
+      parse_error: false,
+      raw: null,
+    };
+
+    render(<SectionCard sectionType="summary" section={section} />);
+
+    // Known fields are rendered by the dedicated card UI
+    expect(
+      screen.getByRole("heading", { level: 3, name: /★★★★☆ 4.3\/5.0/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("有酸素ベースの安定したランでした。"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 4, name: "強み" }))
+      .toBeInTheDocument();
+    expect(screen.getByText("心拍の安定")).toBeInTheDocument();
+
+    // Unknown fields fall back to key-value rendering
+    expect(screen.getByText("next_action")).toBeInTheDocument();
+    expect(
+      screen.getByText("次回はHR 135-145でイージーランを実施"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("integrated_score")).toBeInTheDocument();
+    expect(screen.getByText("4.1")).toBeInTheDocument();
+
+    // metadata is a known boilerplate field and is not dumped as key-value
+    expect(screen.queryByText("metadata")).not.toBeInTheDocument();
+  });
+
+  it("renders unknown structure without crashing via fallback", () => {
+    const section = {
+      data: { metadata: { activity_id: "99999999" }, test: "テストデータ" },
+      parse_error: false,
+      raw: null,
+    };
+
+    render(<SectionCard sectionType="mystery" section={section} />);
+
+    expect(screen.getByText("test")).toBeInTheDocument();
+    expect(screen.getByText("テストデータ")).toBeInTheDocument();
+  });
+
+  it("shows raw text when JSON parsing failed", () => {
+    const section = {
+      data: null,
+      parse_error: true,
+      raw: '{"metadata": broken',
+    };
+
+    render(<SectionCard sectionType="environment" section={section} />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText('{"metadata": broken')).toBeInTheDocument();
+  });
+});

--- a/packages/garmin-web/frontend/src/components/sections/SectionCard.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/SectionCard.tsx
@@ -1,0 +1,70 @@
+import type { SectionResult } from "../../types";
+import EfficiencySectionCard from "./EfficiencySectionCard";
+import EnvironmentSectionCard from "./EnvironmentSectionCard";
+import FallbackCard from "./FallbackCard";
+import PhaseSectionCard from "./PhaseSectionCard";
+import SplitSectionCard from "./SplitSectionCard";
+import SummarySectionCard from "./SummarySectionCard";
+
+export const SECTION_TITLES: Record<string, string> = {
+  summary: "総合評価",
+  split: "スプリット分析",
+  phase: "フェーズ評価",
+  efficiency: "効率分析",
+  environment: "環境影響",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Dispatches a section analysis to its dedicated card.
+ * - Known section types get dedicated rendering; unknown fields inside
+ *   them fall back to key-value rendering automatically.
+ * - Unknown section types or non-object data fall back to FallbackCard.
+ * - Parse errors render the raw string for inspection.
+ */
+export default function SectionCard({
+  sectionType,
+  section,
+}: {
+  sectionType: string;
+  section: SectionResult;
+}) {
+  const title = SECTION_TITLES[sectionType] ?? sectionType;
+
+  if (section.parse_error) {
+    return (
+      <section className="section-card">
+        <h3>{title}</h3>
+        <p role="alert">分析データのJSON解析に失敗しました。</p>
+        {section.raw != null && <pre>{section.raw}</pre>}
+      </section>
+    );
+  }
+
+  if (!isRecord(section.data)) {
+    return (
+      <section className="section-card">
+        <h3>{title}</h3>
+        <p>分析データがありません。</p>
+      </section>
+    );
+  }
+
+  switch (sectionType) {
+    case "summary":
+      return <SummarySectionCard data={section.data} />;
+    case "split":
+      return <SplitSectionCard data={section.data} />;
+    case "phase":
+      return <PhaseSectionCard data={section.data} />;
+    case "efficiency":
+      return <EfficiencySectionCard data={section.data} />;
+    case "environment":
+      return <EnvironmentSectionCard data={section.data} />;
+    default:
+      return <FallbackCard title={title} data={section.data} />;
+  }
+}

--- a/packages/garmin-web/frontend/src/components/sections/SplitSectionCard.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/SplitSectionCard.tsx
@@ -1,0 +1,48 @@
+import type { SplitSectionData } from "../../types";
+import KeyValueList from "./KeyValueList";
+import MarkdownText from "./MarkdownText";
+
+const KNOWN_KEYS = ["metadata", "highlights", "analyses"];
+
+function splitNumber(key: string): number {
+  const match = /^split_(\d+)$/.exec(key);
+  return match ? Number(match[1]) : Number.MAX_SAFE_INTEGER;
+}
+
+export default function SplitSectionCard({ data }: { data: SplitSectionData }) {
+  const analyses =
+    data.analyses && typeof data.analyses === "object" ? data.analyses : null;
+  const analysisEntries = analyses
+    ? Object.entries(analyses).sort(
+        ([a], [b]) => splitNumber(a) - splitNumber(b),
+      )
+    : [];
+
+  return (
+    <section className="section-card">
+      <h3>スプリット分析</h3>
+      {typeof data.highlights === "string" && (
+        <>
+          <h4>ハイライト</h4>
+          <MarkdownText text={data.highlights} />
+        </>
+      )}
+      {analysisEntries.length > 0 && (
+        <>
+          <h4>スプリット別分析</h4>
+          {analysisEntries.map(([key, text]) => (
+            <div key={key} className="split-analysis">
+              <h5>{key.replace("split_", "")} km</h5>
+              {typeof text === "string" ? (
+                <MarkdownText text={text} />
+              ) : (
+                String(text)
+              )}
+            </div>
+          ))}
+        </>
+      )}
+      <KeyValueList data={data} exclude={KNOWN_KEYS} />
+    </section>
+  );
+}

--- a/packages/garmin-web/frontend/src/components/sections/SummarySectionCard.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/SummarySectionCard.tsx
@@ -1,0 +1,62 @@
+import type { SummarySectionData } from "../../types";
+import KeyValueList from "./KeyValueList";
+import MarkdownText from "./MarkdownText";
+
+const KNOWN_KEYS = [
+  "metadata",
+  "star_rating",
+  "summary",
+  "key_strengths",
+  "improvement_areas",
+  "recommendations",
+];
+
+export default function SummarySectionCard({
+  data,
+}: {
+  data: SummarySectionData;
+}) {
+  return (
+    <section className="section-card">
+      <h3>
+        総合評価
+        {typeof data.star_rating === "string" ? ` ${data.star_rating}` : ""}
+      </h3>
+      {typeof data.summary === "string" && <MarkdownText text={data.summary} />}
+      {Array.isArray(data.key_strengths) && data.key_strengths.length > 0 && (
+        <>
+          <h4>強み</h4>
+          <ul>
+            {data.key_strengths.map((item) => (
+              <li key={String(item)}>
+                <MarkdownText text={String(item)} />
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+      {Array.isArray(data.improvement_areas) &&
+        data.improvement_areas.length > 0 && (
+          <>
+            <h4>改善ポイント</h4>
+            <ul>
+              {data.improvement_areas.map((item) => (
+                <li key={String(item)}>
+                  <MarkdownText text={String(item)} />
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      {typeof data.recommendations === "string" && (
+        <>
+          <h4>推奨事項</h4>
+          <MarkdownText text={data.recommendations} />
+        </>
+      )}
+      {/* Fields added without a version bump (integrated_score, next_action,
+          next_run_target, plan_achievement, ...) fall back to key-value. */}
+      <KeyValueList data={data} exclude={KNOWN_KEYS} />
+    </section>
+  );
+}

--- a/packages/garmin-web/frontend/src/pages/ActivityDetail.tsx
+++ b/packages/garmin-web/frontend/src/pages/ActivityDetail.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  fetchActivityDetail,
+  fetchSections,
+  fetchTimeSeries,
+} from "../api/client";
+import SectionCard from "../components/sections/SectionCard";
+import TimeSeriesChart from "../components/TimeSeriesChart";
+import type {
+  ActivityDetailResponse,
+  SectionsResponse,
+  TimeSeriesResponse,
+} from "../types";
+import { formatDistance, formatPace } from "./ActivityList";
+
+const AVAILABLE_METRICS: { key: string; label: string }[] = [
+  { key: "heart_rate", label: "心拍数" },
+  { key: "speed", label: "ペース" },
+  { key: "cadence", label: "ケイデンス" },
+  { key: "power", label: "パワー" },
+  { key: "elevation", label: "高度" },
+  { key: "ground_contact_time", label: "接地時間" },
+  { key: "vertical_oscillation", label: "上下動" },
+  { key: "vertical_ratio", label: "上下動比" },
+];
+
+const METRIC_LABELS: Record<string, string> = Object.fromEntries(
+  AVAILABLE_METRICS.map(({ key, label }) => [key, label]),
+);
+
+const DEFAULT_METRICS = ["heart_rate", "speed"];
+
+const SECTION_ORDER = ["summary", "split", "phase", "efficiency", "environment"];
+
+export function formatDuration(totalSeconds: number | null): string {
+  if (totalSeconds == null || totalSeconds < 0) {
+    return "-";
+  }
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = Math.floor(totalSeconds % 60);
+  const mmss = `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  return hours > 0 ? `${hours}:${mmss}` : mmss;
+}
+
+function orderedSectionTypes(sections: SectionsResponse): string[] {
+  const known = SECTION_ORDER.filter((type) => type in sections);
+  const unknown = Object.keys(sections).filter(
+    (type) => !SECTION_ORDER.includes(type),
+  );
+  return [...known, ...unknown];
+}
+
+export default function ActivityDetail() {
+  const { id } = useParams<{ id: string }>();
+  const [detail, setDetail] = useState<ActivityDetailResponse | null>(null);
+  const [sections, setSections] = useState<SectionsResponse | null>(null);
+  const [timeSeries, setTimeSeries] = useState<TimeSeriesResponse | null>(null);
+  const [selectedMetrics, setSelectedMetrics] =
+    useState<string[]>(DEFAULT_METRICS);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!id) {
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    Promise.all([fetchActivityDetail(id), fetchSections(id)])
+      .then(([detailData, sectionsData]) => {
+        if (!cancelled) {
+          setDetail(detailData);
+          setSections(sectionsData);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  useEffect(() => {
+    if (!id || selectedMetrics.length === 0) {
+      setTimeSeries(null);
+      return;
+    }
+    let cancelled = false;
+    fetchTimeSeries(id, selectedMetrics)
+      .then((data) => {
+        if (!cancelled) {
+          setTimeSeries(data);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setTimeSeries(null);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, selectedMetrics]);
+
+  const toggleMetric = (key: string) => {
+    setSelectedMetrics((current) =>
+      current.includes(key)
+        ? current.filter((metric) => metric !== key)
+        : [
+            ...AVAILABLE_METRICS.map((metric) => metric.key).filter(
+              (metric) => current.includes(metric) || metric === key,
+            ),
+          ],
+    );
+  };
+
+  if (loading) {
+    return <p>読み込み中...</p>;
+  }
+  if (error) {
+    return <p role="alert">エラー: {error}</p>;
+  }
+  if (!detail) {
+    return <p>アクティビティが見つかりません</p>;
+  }
+
+  const { activity, splits } = detail;
+
+  return (
+    <div>
+      <p>
+        <Link to="/">← アクティビティ一覧</Link>
+      </p>
+      <h1>
+        {activity.activity_name ?? "アクティビティ"} ({activity.activity_date})
+      </h1>
+
+      {/* KPI header */}
+      <dl className="kpi-header">
+        <div>
+          <dt>距離</dt>
+          <dd>{formatDistance(activity.total_distance_km)}</dd>
+        </div>
+        <div>
+          <dt>時間</dt>
+          <dd>{formatDuration(activity.total_time_seconds)}</dd>
+        </div>
+        <div>
+          <dt>平均ペース</dt>
+          <dd>{formatPace(activity.avg_pace_seconds_per_km)}</dd>
+        </div>
+        <div>
+          <dt>平均心拍</dt>
+          <dd>{activity.avg_heart_rate ?? "-"} bpm</dd>
+        </div>
+      </dl>
+
+      {/* Time series chart with metric toggles */}
+      <section>
+        <h2>タイムシリーズ</h2>
+        <div className="metric-toggles">
+          {AVAILABLE_METRICS.map(({ key, label }) => (
+            <label key={key} style={{ marginRight: "1em" }}>
+              <input
+                type="checkbox"
+                checked={selectedMetrics.includes(key)}
+                onChange={() => toggleMetric(key)}
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+        {timeSeries && Object.keys(timeSeries.metrics).length > 0 ? (
+          <TimeSeriesChart data={timeSeries} metricLabels={METRIC_LABELS} />
+        ) : (
+          <p>表示する指標を選択してください</p>
+        )}
+      </section>
+
+      {/* Splits table */}
+      {splits.length > 0 && (
+        <section>
+          <h2>スプリット</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>#</th>
+                <th>距離</th>
+                <th>ペース</th>
+                <th>心拍</th>
+                <th>ケイデンス</th>
+                <th>パワー</th>
+              </tr>
+            </thead>
+            <tbody>
+              {splits.map((split) => (
+                <tr key={split.split_index}>
+                  <td>{split.split_index}</td>
+                  <td>{formatDistance(split.distance)}</td>
+                  <td>{formatPace(split.pace_seconds_per_km)}</td>
+                  <td>{split.heart_rate ?? "-"}</td>
+                  <td>{split.cadence ?? "-"}</td>
+                  <td>{split.power ?? "-"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      )}
+
+      {/* Section analysis cards */}
+      {sections && Object.keys(sections).length > 0 && (
+        <section>
+          <h2>分析</h2>
+          {orderedSectionTypes(sections).map((sectionType) => (
+            <SectionCard
+              key={sectionType}
+              sectionType={sectionType}
+              section={sections[sectionType]}
+            />
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/packages/garmin-web/frontend/src/pages/ActivityList.test.tsx
+++ b/packages/garmin-web/frontend/src/pages/ActivityList.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import ActivityList from "./ActivityList";
 
@@ -39,7 +40,11 @@ describe("ActivityList", () => {
       ),
     );
 
-    render(<ActivityList />);
+    render(
+      <MemoryRouter>
+        <ActivityList />
+      </MemoryRouter>,
+    );
 
     // Wait for the data rows to appear
     expect(await screen.findByText("2025-10-09")).toBeInTheDocument();

--- a/packages/garmin-web/frontend/src/pages/ActivityList.tsx
+++ b/packages/garmin-web/frontend/src/pages/ActivityList.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { fetchActivities } from "../api/client";
 import type { ActivitySummary } from "../types";
 
@@ -39,6 +40,7 @@ function groupByMonth(
 }
 
 export default function ActivityList() {
+  const navigate = useNavigate();
   const [activities, setActivities] = useState<ActivitySummary[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -93,7 +95,11 @@ export default function ActivityList() {
             </thead>
             <tbody>
               {monthActivities.map((activity) => (
-                <tr key={activity.activity_id}>
+                <tr
+                  key={activity.activity_id}
+                  onClick={() => navigate(`/activities/${activity.activity_id}`)}
+                  style={{ cursor: "pointer" }}
+                >
                   <td>{activity.activity_date}</td>
                   <td>{activity.activity_name ?? "-"}</td>
                   <td>{formatDistance(activity.total_distance_km)}</td>

--- a/packages/garmin-web/frontend/src/types.ts
+++ b/packages/garmin-web/frontend/src/types.ts
@@ -7,3 +7,107 @@ export interface ActivitySummary {
   avg_pace_seconds_per_km: number | null;
   avg_heart_rate: number | null;
 }
+
+// --- Activity detail (Issue #199) ---
+
+export interface SplitRow {
+  activity_id: number;
+  split_index: number;
+  distance: number | null;
+  duration_seconds: number | null;
+  pace_seconds_per_km: number | null;
+  heart_rate: number | null;
+  cadence: number | null;
+  power: number | null;
+  [key: string]: unknown;
+}
+
+export interface HrZoneRow {
+  activity_id: number;
+  zone_number: number;
+  zone_low_boundary: number | null;
+  zone_high_boundary: number | null;
+  time_in_zone_seconds: number | null;
+  zone_percentage: number | null;
+}
+
+export interface ActivityDetailResponse {
+  activity: ActivitySummary & Record<string, unknown>;
+  splits: SplitRow[];
+  form_efficiency: Record<string, unknown> | null;
+  hr_zones: HrZoneRow[];
+  performance_trends: Record<string, unknown> | null;
+  form_evaluations: Record<string, unknown> | null;
+}
+
+export interface TimeSeriesResponse {
+  timestamps: number[];
+  metrics: Record<string, (number | null)[]>;
+}
+
+export interface SectionResult {
+  data: Record<string, unknown> | null;
+  parse_error: boolean;
+  raw: string | null;
+}
+
+export type SectionsResponse = Record<string, SectionResult>;
+
+// --- Section analysis data types (from Spike #198) ---
+
+export interface SectionMetadata {
+  activity_id: string; // NOTE: string inside JSON (DB column is BIGINT)
+  date: string; // "YYYY-MM-DD"
+  analyst: string; // e.g. "summary-section-analyst"
+  version: string; // currently always "1.0"
+  timestamp: string; // ISO 8601
+}
+
+/** Markdown-style Japanese analysis text */
+export type AnalysisText = string;
+
+export interface SplitSectionData {
+  metadata?: SectionMetadata;
+  highlights?: AnalysisText;
+  analyses?: Record<string, AnalysisText>; // keys "split_1".."split_N" (distance-dependent)
+  [key: string]: unknown;
+}
+
+export interface PhaseSectionData {
+  metadata?: SectionMetadata;
+  warmup_evaluation?: AnalysisText;
+  run_evaluation?: AnalysisText;
+  cooldown_evaluation?: AnalysisText;
+  evaluation_criteria?: AnalysisText;
+  recovery_evaluation?: AnalysisText; // interval training only
+  [key: string]: unknown;
+}
+
+export interface EfficiencySectionData {
+  metadata?: SectionMetadata;
+  efficiency?: AnalysisText;
+  evaluation?: AnalysisText;
+  form_trend?: AnalysisText;
+  [key: string]: unknown;
+}
+
+export interface EnvironmentSectionData {
+  metadata?: SectionMetadata;
+  environmental?: AnalysisText;
+  [key: string]: unknown;
+}
+
+export interface SummarySectionData {
+  metadata?: SectionMetadata;
+  star_rating?: string; // "★★★★☆ 4.3/5.0" format
+  summary?: AnalysisText;
+  key_strengths?: string[];
+  improvement_areas?: string[];
+  recommendations?: AnalysisText;
+  // Fields added after 2026-02 without a version bump — render by key presence
+  integrated_score?: number;
+  next_action?: string;
+  next_run_target?: Record<string, unknown>;
+  plan_achievement?: Record<string, unknown>;
+  [key: string]: unknown;
+}

--- a/packages/garmin-web/src/garmin_web/api/activity_detail.py
+++ b/packages/garmin-web/src/garmin_web/api/activity_detail.py
@@ -1,0 +1,54 @@
+"""Activity detail API router (detail, time-series, sections)."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from garmin_mcp.database.connection import get_connection
+
+from garmin_web.queries.detail import get_activity_detail
+from garmin_web.queries.sections import get_sections
+from garmin_web.queries.time_series import get_time_series
+
+router = APIRouter(prefix="/api")
+
+
+@router.get("/activities/{activity_id}")
+def get_detail(request: Request, activity_id: int) -> dict:
+    """Return aggregated detail for one activity, or 404 if unknown."""
+    db_path = getattr(request.app.state, "db_path", None)
+    with get_connection(db_path) as conn:
+        detail = get_activity_detail(conn, activity_id)
+    if detail is None:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    return detail
+
+
+@router.get("/activities/{activity_id}/time-series")
+def get_activity_time_series(
+    request: Request,
+    activity_id: int,
+    metrics: Annotated[str, Query(min_length=1)],
+    max_points: Annotated[int, Query(ge=2, le=5000)] = 500,
+) -> dict:
+    """Return downsampled time series for the requested metrics.
+
+    `metrics` is a required comma-separated list of metric column names.
+    Unknown metric names are rejected with 422.
+    """
+    metric_names = [name.strip() for name in metrics.split(",") if name.strip()]
+    db_path = getattr(request.app.state, "db_path", None)
+    try:
+        with get_connection(db_path) as conn:
+            return get_time_series(
+                conn, activity_id, metric_names, max_points=max_points
+            )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.get("/activities/{activity_id}/sections")
+def get_activity_sections(request: Request, activity_id: int) -> dict:
+    """Return section analyses keyed by section_type."""
+    db_path = getattr(request.app.state, "db_path", None)
+    with get_connection(db_path) as conn:
+        return get_sections(conn, activity_id)

--- a/packages/garmin-web/src/garmin_web/app.py
+++ b/packages/garmin-web/src/garmin_web/app.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from garmin_web.api.activities import router as activities_router
+from garmin_web.api.activity_detail import router as activity_detail_router
 from garmin_web.api.trends import router as trends_router
 
 VITE_DEV_ORIGIN = "http://localhost:5173"
@@ -31,5 +32,6 @@ def create_app(db_path: str | Path | None = None) -> FastAPI:
         allow_headers=["*"],
     )
     app.include_router(activities_router)
+    app.include_router(activity_detail_router)
     app.include_router(trends_router)
     return app

--- a/packages/garmin-web/src/garmin_web/queries/detail.py
+++ b/packages/garmin-web/src/garmin_web/queries/detail.py
@@ -1,0 +1,85 @@
+"""Read-only queries aggregating per-activity detail data."""
+
+import datetime
+from typing import Any
+
+import duckdb
+
+
+def _to_jsonable(value: Any) -> Any:
+    """Convert DuckDB date/datetime values to str for JSON serialization."""
+    if isinstance(value, datetime.date | datetime.datetime):
+        return str(value)
+    return value
+
+
+def _row_to_dict(columns: list[str], row: tuple) -> dict:
+    return {col: _to_jsonable(val) for col, val in zip(columns, row, strict=True)}
+
+
+def _fetch_one(conn: duckdb.DuckDBPyConnection, sql: str, params: list) -> dict | None:
+    result = conn.execute(sql, params)
+    columns = [desc[0] for desc in result.description]
+    row = result.fetchone()
+    return _row_to_dict(columns, row) if row is not None else None
+
+
+def _fetch_all(conn: duckdb.DuckDBPyConnection, sql: str, params: list) -> list[dict]:
+    result = conn.execute(sql, params)
+    columns = [desc[0] for desc in result.description]
+    return [_row_to_dict(columns, row) for row in result.fetchall()]
+
+
+def get_activity_detail(
+    conn: duckdb.DuckDBPyConnection, activity_id: int
+) -> dict | None:
+    """Aggregate activity detail data into a single dict.
+
+    Combines activities, splits, form_efficiency, heart_rate_zones,
+    performance_trends and form_evaluations. Splits are ordered by
+    split_index ascending; HR zones by zone_number ascending.
+
+    Args:
+        conn: Open DuckDB connection (read-only is sufficient).
+        activity_id: Target activity ID.
+
+    Returns:
+        Dict with keys: activity, splits, form_efficiency, hr_zones,
+        performance_trends, form_evaluations. Single-row tables that have
+        no row for the activity are None; list tables are empty lists.
+        Returns None if the activity itself does not exist.
+    """
+    activity = _fetch_one(
+        conn, "SELECT * FROM activities WHERE activity_id = ?", [activity_id]
+    )
+    if activity is None:
+        return None
+    return {
+        "activity": activity,
+        "splits": _fetch_all(
+            conn,
+            "SELECT * FROM splits WHERE activity_id = ? ORDER BY split_index",
+            [activity_id],
+        ),
+        "form_efficiency": _fetch_one(
+            conn,
+            "SELECT * FROM form_efficiency WHERE activity_id = ?",
+            [activity_id],
+        ),
+        "hr_zones": _fetch_all(
+            conn,
+            "SELECT * FROM heart_rate_zones WHERE activity_id = ?"
+            " ORDER BY zone_number",
+            [activity_id],
+        ),
+        "performance_trends": _fetch_one(
+            conn,
+            "SELECT * FROM performance_trends WHERE activity_id = ?",
+            [activity_id],
+        ),
+        "form_evaluations": _fetch_one(
+            conn,
+            "SELECT * FROM form_evaluations WHERE activity_id = ?",
+            [activity_id],
+        ),
+    }

--- a/packages/garmin-web/src/garmin_web/queries/sections.py
+++ b/packages/garmin-web/src/garmin_web/queries/sections.py
@@ -1,0 +1,42 @@
+"""Read-only queries for the section_analyses table with JSON parsing."""
+
+import json
+
+import duckdb
+
+
+def get_sections(conn: duckdb.DuckDBPyConnection, activity_id: int) -> dict[str, dict]:
+    """Fetch section analyses keyed by section_type.
+
+    When multiple rows exist for the same section_type, the most recently
+    created row wins. analysis_data is parsed as JSON; on parse failure
+    the raw string is preserved for fallback rendering.
+
+    Args:
+        conn: Open DuckDB connection (read-only is sufficient).
+        activity_id: Target activity ID.
+
+    Returns:
+        {section_type: {"data": parsed_json | None,
+                        "parse_error": bool,
+                        "raw": str | None}}.
+        raw is populated only when parsing failed.
+    """
+    rows = conn.execute(
+        "SELECT section_type, analysis_data FROM section_analyses"
+        " WHERE activity_id = ? ORDER BY created_at",
+        [activity_id],
+    ).fetchall()
+
+    sections: dict[str, dict] = {}
+    for section_type, raw in rows:
+        if raw is None:
+            sections[section_type] = {"data": None, "parse_error": True, "raw": None}
+            continue
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            sections[section_type] = {"data": None, "parse_error": True, "raw": raw}
+        else:
+            sections[section_type] = {"data": data, "parse_error": False, "raw": None}
+    return sections

--- a/packages/garmin-web/src/garmin_web/queries/time_series.py
+++ b/packages/garmin-web/src/garmin_web/queries/time_series.py
@@ -1,0 +1,93 @@
+"""Read-only queries for the time_series_metrics table with downsampling."""
+
+import duckdb
+
+# Metric columns of time_series_metrics (everything except the key columns
+# activity_id / seq_no / timestamp_s). Source of truth:
+# garmin_mcp/database/db_writer.py CREATE TABLE time_series_metrics.
+ALLOWED_METRICS: frozenset[str] = frozenset(
+    {
+        "sum_moving_duration",
+        "sum_duration",
+        "sum_elapsed_duration",
+        "sum_distance",
+        "sum_accumulated_power",
+        "heart_rate",
+        "speed",
+        "grade_adjusted_speed",
+        "cadence",
+        "cadence_single_foot",
+        "cadence_total",
+        "power",
+        "ground_contact_time",
+        "vertical_oscillation",
+        "vertical_ratio",
+        "stride_length",
+        "vertical_speed",
+        "elevation",
+        "air_temperature",
+        "latitude",
+        "longitude",
+        "available_stamina",
+        "potential_stamina",
+        "body_battery",
+        "performance_condition",
+    }
+)
+
+
+def get_time_series(
+    conn: duckdb.DuckDBPyConnection,
+    activity_id: int,
+    metrics: list[str],
+    max_points: int = 500,
+) -> dict:
+    """Fetch time series metrics, downsampled to at most max_points.
+
+    Rows are ordered by seq_no. When the row count exceeds max_points,
+    rows are picked at equal intervals; the first and last rows are
+    always kept.
+
+    Args:
+        conn: Open DuckDB connection (read-only is sufficient).
+        activity_id: Target activity ID.
+        metrics: Metric column names; each must be in ALLOWED_METRICS.
+        max_points: Maximum number of points per series (>= 2).
+
+    Returns:
+        {"timestamps": [...], "metrics": {name: [...]}}.
+
+    Raises:
+        ValueError: If metrics is empty, contains an unknown metric,
+            or max_points < 2.
+    """
+    if not metrics:
+        raise ValueError("At least one metric is required")
+    unknown = sorted(set(metrics) - ALLOWED_METRICS)
+    if unknown:
+        raise ValueError(f"Unknown metrics: {', '.join(unknown)}")
+    if max_points < 2:
+        raise ValueError("max_points must be >= 2")
+
+    # Deduplicate while preserving order
+    metric_names = list(dict.fromkeys(metrics))
+
+    # Safe to interpolate: validated against ALLOWED_METRICS above.
+    columns = ", ".join(metric_names)
+    rows = conn.execute(
+        f"SELECT timestamp_s, {columns} FROM time_series_metrics"
+        " WHERE activity_id = ? ORDER BY seq_no",
+        [activity_id],
+    ).fetchall()
+
+    n = len(rows)
+    if n > max_points:
+        indices = [round(i * (n - 1) / (max_points - 1)) for i in range(max_points)]
+        rows = [rows[i] for i in indices]
+
+    return {
+        "timestamps": [row[0] for row in rows],
+        "metrics": {
+            name: [row[i + 1] for row in rows] for i, name in enumerate(metric_names)
+        },
+    }

--- a/packages/garmin-web/tests/conftest.py
+++ b/packages/garmin-web/tests/conftest.py
@@ -5,6 +5,7 @@ this is the documented exception to the get_connection()-only rule,
 required because fixture creation needs write access to a new file.
 """
 
+import json
 from pathlib import Path
 
 import duckdb
@@ -59,6 +60,9 @@ def empty_db_path(tmp_path: Path) -> Path:
 # --- Trends fixtures (Issue #201) -------------------------------------------
 # Column names mirror the production schema in
 # garmin_mcp/database/db_writer.py (only columns used by trend queries).
+# NOTE: form_evaluations DDL differs from the detail fixtures below because
+# each fixture set creates its own database file with only the columns its
+# queries touch.
 
 _CREATE_VO2_MAX = """
     CREATE TABLE vo2_max (
@@ -79,7 +83,7 @@ _CREATE_LACTATE_THRESHOLD = """
     )
 """
 
-_CREATE_FORM_EVALUATIONS = """
+_CREATE_FORM_EVALUATIONS_TRENDS = """
     CREATE TABLE form_evaluations (
         eval_id INTEGER PRIMARY KEY,
         activity_id BIGINT UNIQUE,
@@ -107,7 +111,7 @@ _TRENDS_TABLE_DDLS = [
     _CREATE_ACTIVITIES,
     _CREATE_VO2_MAX,
     _CREATE_LACTATE_THRESHOLD,
-    _CREATE_FORM_EVALUATIONS,
+    _CREATE_FORM_EVALUATIONS_TRENDS,
     _CREATE_HR_EFFICIENCY,
 ]
 
@@ -183,6 +187,340 @@ def empty_trends_db_path(tmp_path: Path) -> Path:
     conn = duckdb.connect(str(db_path))
     try:
         _create_trends_tables(conn)
+    finally:
+        conn.close()
+    return db_path
+
+
+# --- Detail page fixtures (Issue #199) ---------------------------------
+# Reduced-column versions of the production schemas: queries use SELECT *
+# and ORDER BY key columns only, so only representative columns are needed.
+
+_CREATE_SPLITS = """
+    CREATE TABLE splits (
+        activity_id BIGINT,
+        split_index INTEGER,
+        distance DOUBLE,
+        duration_seconds DOUBLE,
+        pace_seconds_per_km DOUBLE,
+        heart_rate INTEGER,
+        cadence DOUBLE,
+        power DOUBLE,
+        ground_contact_time DOUBLE,
+        vertical_oscillation DOUBLE,
+        vertical_ratio DOUBLE,
+        elevation_gain DOUBLE,
+        elevation_loss DOUBLE,
+        PRIMARY KEY (activity_id, split_index)
+    )
+"""
+
+_CREATE_FORM_EFFICIENCY = """
+    CREATE TABLE form_efficiency (
+        activity_id BIGINT PRIMARY KEY,
+        gct_average DOUBLE,
+        vo_average DOUBLE,
+        vr_average DOUBLE,
+        gct_rating VARCHAR,
+        vo_rating VARCHAR,
+        vr_rating VARCHAR
+    )
+"""
+
+_CREATE_HEART_RATE_ZONES = """
+    CREATE TABLE heart_rate_zones (
+        activity_id BIGINT,
+        zone_number INTEGER,
+        zone_low_boundary INTEGER,
+        zone_high_boundary INTEGER,
+        time_in_zone_seconds DOUBLE,
+        zone_percentage DOUBLE,
+        PRIMARY KEY (activity_id, zone_number)
+    )
+"""
+
+_CREATE_PERFORMANCE_TRENDS = """
+    CREATE TABLE performance_trends (
+        activity_id BIGINT PRIMARY KEY,
+        pace_consistency DOUBLE,
+        hr_drift_percentage DOUBLE,
+        fatigue_pattern VARCHAR
+    )
+"""
+
+_CREATE_FORM_EVALUATIONS_DETAIL = """
+    CREATE TABLE form_evaluations (
+        eval_id INTEGER PRIMARY KEY,
+        activity_id BIGINT UNIQUE,
+        overall_score FLOAT,
+        overall_star_rating VARCHAR,
+        evaluated_at TIMESTAMP
+    )
+"""
+
+_CREATE_TIME_SERIES_METRICS = """
+    CREATE TABLE time_series_metrics (
+        activity_id BIGINT NOT NULL,
+        seq_no INTEGER NOT NULL,
+        timestamp_s INTEGER NOT NULL,
+        heart_rate DOUBLE,
+        speed DOUBLE,
+        cadence DOUBLE,
+        PRIMARY KEY (activity_id, seq_no)
+    )
+"""
+
+_CREATE_SECTION_ANALYSES = """
+    CREATE TABLE section_analyses (
+        analysis_id INTEGER PRIMARY KEY,
+        activity_id BIGINT NOT NULL,
+        activity_date DATE NOT NULL,
+        section_type VARCHAR NOT NULL,
+        analysis_data VARCHAR,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        agent_name VARCHAR,
+        agent_version VARCHAR
+    )
+"""
+
+# Activity 9000000101: full data (5 splits, form_efficiency, 5 HR zones,
+# performance_trends, form_evaluations, 2000 time-series rows, 5 sections).
+# Activity 9000000102: partial data (2 splits, NO form_efficiency,
+# 300 time-series rows, 5 sections — environment has broken JSON).
+FULL_ACTIVITY_ID = 9000000101
+PARTIAL_ACTIVITY_ID = 9000000102
+
+_DETAIL_ACTIVITIES = [
+    (FULL_ACTIVITY_ID, "2025-10-09", "Detail Run", 5.66, 2186, 386.0, 144),
+    (PARTIAL_ACTIVITY_ID, "2025-10-07", "Partial Run", 2.0, 760, 380.0, 140),
+]
+
+# Inserted out of order on purpose: ORDER BY split_index must sort them.
+_DETAIL_SPLITS = [
+    (
+        FULL_ACTIVITY_ID,
+        3,
+        1.0,
+        385.0,
+        385.0,
+        146,
+        172.0,
+        250.0,
+        248.0,
+        7.8,
+        8.1,
+        4.0,
+        3.0,
+    ),
+    (
+        FULL_ACTIVITY_ID,
+        1,
+        1.0,
+        390.0,
+        390.0,
+        138,
+        170.0,
+        245.0,
+        250.0,
+        7.9,
+        8.2,
+        5.0,
+        2.0,
+    ),
+    (
+        FULL_ACTIVITY_ID,
+        5,
+        0.66,
+        250.0,
+        379.0,
+        150,
+        173.0,
+        255.0,
+        246.0,
+        7.7,
+        8.0,
+        1.0,
+        1.0,
+    ),
+    (
+        FULL_ACTIVITY_ID,
+        2,
+        1.0,
+        388.0,
+        388.0,
+        142,
+        171.0,
+        248.0,
+        249.0,
+        7.8,
+        8.1,
+        3.0,
+        4.0,
+    ),
+    (
+        FULL_ACTIVITY_ID,
+        4,
+        1.0,
+        382.0,
+        382.0,
+        148,
+        172.0,
+        252.0,
+        247.0,
+        7.7,
+        8.0,
+        2.0,
+        2.0,
+    ),
+    (
+        PARTIAL_ACTIVITY_ID,
+        1,
+        1.0,
+        380.0,
+        380.0,
+        138,
+        168.0,
+        240.0,
+        252.0,
+        8.0,
+        8.3,
+        2.0,
+        2.0,
+    ),
+    (
+        PARTIAL_ACTIVITY_ID,
+        2,
+        1.0,
+        379.0,
+        379.0,
+        141,
+        169.0,
+        242.0,
+        251.0,
+        7.9,
+        8.2,
+        1.0,
+        1.0,
+    ),
+]
+
+_DETAIL_HR_ZONES = [
+    (FULL_ACTIVITY_ID, zone, 80 + zone * 20, 100 + zone * 20, 400.0, 20.0)
+    for zone in range(1, 6)
+]
+
+_SECTION_TYPES = ["split", "phase", "efficiency", "environment", "summary"]
+
+
+def _section_json(activity_id: int, section_type: str) -> str:
+    return json.dumps(
+        {
+            "metadata": {
+                "activity_id": str(activity_id),
+                "date": "2025-10-09",
+                "analyst": f"{section_type}-section-analyst",
+                "version": "1.0",
+                "timestamp": "2025-10-09T12:00:00+09:00",
+            },
+            "summary": f"{section_type} の分析テキスト",
+        },
+        ensure_ascii=False,
+    )
+
+
+@pytest.fixture
+def detail_db_path(tmp_path: Path) -> Path:
+    """DuckDB with all tables needed by the activity detail page."""
+    db_path = tmp_path / "test_garmin_web_detail.duckdb"
+    conn = duckdb.connect(str(db_path))
+    try:
+        conn.execute(_CREATE_ACTIVITIES)
+        conn.execute(_CREATE_SPLITS)
+        conn.execute(_CREATE_FORM_EFFICIENCY)
+        conn.execute(_CREATE_HEART_RATE_ZONES)
+        conn.execute(_CREATE_PERFORMANCE_TRENDS)
+        conn.execute(_CREATE_FORM_EVALUATIONS_DETAIL)
+        conn.execute(_CREATE_TIME_SERIES_METRICS)
+        conn.execute(_CREATE_SECTION_ANALYSES)
+
+        conn.executemany(
+            "INSERT INTO activities VALUES (?, ?, ?, ?, ?, ?, ?)",
+            _DETAIL_ACTIVITIES,
+        )
+        conn.executemany(
+            "INSERT INTO splits VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            _DETAIL_SPLITS,
+        )
+        conn.execute(
+            "INSERT INTO form_efficiency VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [FULL_ACTIVITY_ID, 248.0, 7.8, 8.1, "good", "good", "average"],
+        )
+        conn.executemany(
+            "INSERT INTO heart_rate_zones VALUES (?, ?, ?, ?, ?, ?)",
+            _DETAIL_HR_ZONES,
+        )
+        conn.execute(
+            "INSERT INTO performance_trends VALUES (?, ?, ?, ?)",
+            [FULL_ACTIVITY_ID, 4.2, 3.1, "stable"],
+        )
+        conn.execute(
+            "INSERT INTO form_evaluations VALUES (?, ?, ?, ?, ?)",
+            [1, FULL_ACTIVITY_ID, 4.1, "★★★★☆", "2025-10-09 12:00:00"],
+        )
+
+        # Time series: 2000 rows (full) / 300 rows (partial)
+        conn.execute(
+            "INSERT INTO time_series_metrics"
+            f" SELECT {FULL_ACTIVITY_ID}, i, i, 140 + i % 20, 2.8, 170.0"
+            " FROM range(2000) AS t(i)"
+        )
+        conn.execute(
+            "INSERT INTO time_series_metrics"
+            f" SELECT {PARTIAL_ACTIVITY_ID}, i, i, 135 + i % 10, 2.6, 168.0"
+            " FROM range(300) AS t(i)"
+        )
+
+        # Sections: 5 valid for FULL; 4 valid + 1 broken (environment) for PARTIAL
+        analysis_id = 1
+        for section_type in _SECTION_TYPES:
+            conn.execute(
+                "INSERT INTO section_analyses"
+                " (analysis_id, activity_id, activity_date, section_type,"
+                "  analysis_data, agent_name, agent_version)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                [
+                    analysis_id,
+                    FULL_ACTIVITY_ID,
+                    "2025-10-09",
+                    section_type,
+                    _section_json(FULL_ACTIVITY_ID, section_type),
+                    f"{section_type}-section-analyst",
+                    "1.0",
+                ],
+            )
+            analysis_id += 1
+        for section_type in _SECTION_TYPES:
+            analysis_data = (
+                '{"metadata": broken'
+                if section_type == "environment"
+                else _section_json(PARTIAL_ACTIVITY_ID, section_type)
+            )
+            conn.execute(
+                "INSERT INTO section_analyses"
+                " (analysis_id, activity_id, activity_date, section_type,"
+                "  analysis_data, agent_name, agent_version)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                [
+                    analysis_id,
+                    PARTIAL_ACTIVITY_ID,
+                    "2025-10-07",
+                    section_type,
+                    analysis_data,
+                    f"{section_type}-section-analyst",
+                    "1.0",
+                ],
+            )
+            analysis_id += 1
     finally:
         conn.close()
     return db_path

--- a/packages/garmin-web/tests/test_api_detail.py
+++ b/packages/garmin-web/tests/test_api_detail.py
@@ -1,0 +1,64 @@
+"""API tests for activity detail endpoints."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from garmin_web.app import create_app
+
+FULL_ACTIVITY_ID = 9000000101
+
+
+@pytest.mark.integration
+def test_api_detail_endpoints_200(detail_db_path):
+    client = TestClient(create_app(db_path=detail_db_path))
+
+    # Detail endpoint
+    response = client.get(f"/api/activities/{FULL_ACTIVITY_ID}")
+    assert response.status_code == 200
+    detail = response.json()
+    assert detail["activity"]["activity_id"] == FULL_ACTIVITY_ID
+    assert len(detail["splits"]) == 5
+    assert detail["form_efficiency"] is not None
+    assert len(detail["hr_zones"]) == 5
+
+    # Time-series endpoint (metrics required)
+    response = client.get(
+        f"/api/activities/{FULL_ACTIVITY_ID}/time-series",
+        params={"metrics": "heart_rate,speed", "max_points": 500},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload["timestamps"]) <= 500
+    assert set(payload["metrics"].keys()) == {"heart_rate", "speed"}
+
+    # Time-series without metrics -> 422
+    response = client.get(f"/api/activities/{FULL_ACTIVITY_ID}/time-series")
+    assert response.status_code == 422
+
+    # Time-series with unknown metric -> 422
+    response = client.get(
+        f"/api/activities/{FULL_ACTIVITY_ID}/time-series",
+        params={"metrics": "bogus"},
+    )
+    assert response.status_code == 422
+
+    # Sections endpoint
+    response = client.get(f"/api/activities/{FULL_ACTIVITY_ID}/sections")
+    assert response.status_code == 200
+    sections = response.json()
+    assert set(sections.keys()) == {
+        "split",
+        "phase",
+        "efficiency",
+        "environment",
+        "summary",
+    }
+    assert all(s["parse_error"] is False for s in sections.values())
+
+
+@pytest.mark.integration
+def test_api_detail_404(detail_db_path):
+    client = TestClient(create_app(db_path=detail_db_path))
+    response = client.get("/api/activities/999999")
+
+    assert response.status_code == 404

--- a/packages/garmin-web/tests/test_queries_detail.py
+++ b/packages/garmin-web/tests/test_queries_detail.py
@@ -1,0 +1,63 @@
+"""Unit tests for garmin_web.queries.detail.get_activity_detail."""
+
+import pytest
+from garmin_mcp.database.connection import get_connection
+
+from garmin_web.queries.detail import get_activity_detail
+
+FULL_ACTIVITY_ID = 9000000101
+PARTIAL_ACTIVITY_ID = 9000000102
+
+
+@pytest.mark.unit
+def test_detail_aggregates_tables(detail_db_path):
+    with get_connection(detail_db_path) as conn:
+        detail = get_activity_detail(conn, FULL_ACTIVITY_ID)
+
+    assert detail is not None
+    for key in (
+        "activity",
+        "splits",
+        "form_efficiency",
+        "hr_zones",
+        "performance_trends",
+        "form_evaluations",
+    ):
+        assert key in detail
+
+    assert detail["activity"]["activity_id"] == FULL_ACTIVITY_ID
+    assert detail["activity"]["activity_date"] == "2025-10-09"
+    assert isinstance(detail["activity"]["activity_date"], str)
+
+    # splits: 5 rows sorted by split_index ascending
+    assert len(detail["splits"]) == 5
+    assert [s["split_index"] for s in detail["splits"]] == [1, 2, 3, 4, 5]
+
+    assert detail["form_efficiency"]["gct_average"] == 248.0
+    assert len(detail["hr_zones"]) == 5
+    assert [z["zone_number"] for z in detail["hr_zones"]] == [1, 2, 3, 4, 5]
+    assert detail["performance_trends"]["pace_consistency"] == 4.2
+    assert detail["form_evaluations"]["overall_score"] == pytest.approx(4.1)
+
+
+@pytest.mark.unit
+def test_detail_missing_activity_returns_none(detail_db_path):
+    with get_connection(detail_db_path) as conn:
+        detail = get_activity_detail(conn, 999999)
+
+    assert detail is None
+
+
+@pytest.mark.unit
+def test_detail_partial_data(detail_db_path):
+    with get_connection(detail_db_path) as conn:
+        detail = get_activity_detail(conn, PARTIAL_ACTIVITY_ID)
+
+    assert detail is not None
+    assert detail["form_efficiency"] is None
+    assert detail["performance_trends"] is None
+    assert detail["form_evaluations"] is None
+    assert detail["hr_zones"] == []
+    # Other data is still returned
+    assert detail["activity"]["activity_name"] == "Partial Run"
+    assert len(detail["splits"]) == 2

--- a/packages/garmin-web/tests/test_queries_sections.py
+++ b/packages/garmin-web/tests/test_queries_sections.py
@@ -1,0 +1,43 @@
+"""Unit tests for garmin_web.queries.sections.get_sections."""
+
+import pytest
+from garmin_mcp.database.connection import get_connection
+
+from garmin_web.queries.sections import get_sections
+
+FULL_ACTIVITY_ID = 9000000101  # 5 valid sections
+PARTIAL_ACTIVITY_ID = 9000000102  # 4 valid + broken "environment" section
+
+SECTION_TYPES = {"split", "phase", "efficiency", "environment", "summary"}
+
+
+@pytest.mark.unit
+def test_sections_parses_json_per_type(detail_db_path):
+    with get_connection(detail_db_path) as conn:
+        sections = get_sections(conn, FULL_ACTIVITY_ID)
+
+    assert set(sections.keys()) == SECTION_TYPES
+    for section_type, section in sections.items():
+        assert section["parse_error"] is False, section_type
+        assert isinstance(section["data"], dict)
+        assert section["data"]["metadata"]["activity_id"] == str(FULL_ACTIVITY_ID)
+        assert section["raw"] is None
+
+
+@pytest.mark.unit
+def test_sections_invalid_json_fallback(detail_db_path):
+    with get_connection(detail_db_path) as conn:
+        sections = get_sections(conn, PARTIAL_ACTIVITY_ID)
+
+    assert set(sections.keys()) == SECTION_TYPES
+
+    broken = sections["environment"]
+    assert broken["parse_error"] is True
+    assert broken["data"] is None
+    assert broken["raw"] == '{"metadata": broken'
+
+    for section_type in SECTION_TYPES - {"environment"}:
+        section = sections[section_type]
+        assert section["parse_error"] is False, section_type
+        assert isinstance(section["data"], dict)
+        assert section["raw"] is None

--- a/packages/garmin-web/tests/test_queries_time_series.py
+++ b/packages/garmin-web/tests/test_queries_time_series.py
@@ -1,0 +1,58 @@
+"""Unit tests for garmin_web.queries.time_series.get_time_series."""
+
+import pytest
+from garmin_mcp.database.connection import get_connection
+
+from garmin_web.queries.time_series import ALLOWED_METRICS, get_time_series
+
+FULL_ACTIVITY_ID = 9000000101  # 2000 time-series rows
+PARTIAL_ACTIVITY_ID = 9000000102  # 300 time-series rows
+
+
+@pytest.mark.unit
+def test_time_series_downsamples_to_max_points(detail_db_path):
+    with get_connection(detail_db_path) as conn:
+        result = get_time_series(
+            conn, FULL_ACTIVITY_ID, ["heart_rate", "speed"], max_points=500
+        )
+
+    assert len(result["timestamps"]) <= 500
+    assert len(result["metrics"]["heart_rate"]) == len(result["timestamps"])
+    assert len(result["metrics"]["speed"]) == len(result["timestamps"])
+
+    # First (seq_no=0) and last (seq_no=1999) rows must be kept
+    assert result["timestamps"][0] == 0
+    assert result["timestamps"][-1] == 1999
+    assert result["metrics"]["heart_rate"][0] == 140.0  # 140 + 0 % 20
+    assert result["metrics"]["heart_rate"][-1] == 159.0  # 140 + 1999 % 20
+
+
+@pytest.mark.unit
+def test_time_series_below_max_returns_all(detail_db_path):
+    with get_connection(detail_db_path) as conn:
+        result = get_time_series(
+            conn, PARTIAL_ACTIVITY_ID, ["heart_rate"], max_points=500
+        )
+
+    assert len(result["timestamps"]) == 300
+    assert len(result["metrics"]["heart_rate"]) == 300
+    assert result["timestamps"][0] == 0
+    assert result["timestamps"][-1] == 299
+
+
+@pytest.mark.unit
+def test_time_series_unknown_metric_raises(detail_db_path):
+    with (
+        get_connection(detail_db_path) as conn,
+        pytest.raises(ValueError, match="Unknown metrics: bogus"),
+    ):
+        get_time_series(conn, FULL_ACTIVITY_ID, ["bogus"])
+
+
+@pytest.mark.unit
+def test_allowed_metrics_excludes_key_columns():
+    assert "activity_id" not in ALLOWED_METRICS
+    assert "seq_no" not in ALLOWED_METRICS
+    assert "timestamp_s" not in ALLOWED_METRICS
+    assert "heart_rate" in ALLOWED_METRICS
+    assert "speed" in ALLOWED_METRICS


### PR DESCRIPTION
Closes #199

Part of Epic #196 の P2。アクティビティ詳細ページ（KPIヘッダー / ECharts タイムシリーズ / スプリットテーブル / 5セクション分析カード）を実装。

## 変更内容

- **Backend**:
  - `queries/detail.py` — 6テーブル集約（activities/splits/form_efficiency/heart_rate_zones/performance_trends/form_evaluations）、date→str 変換
  - `queries/time_series.py` — `ALLOWED_METRICS`（実スキーマの25メトリクス）による検証 + 等間隔間引き（先頭・末尾保持）
  - `queries/sections.py` — analysis_data JSONパース。パース不能行は `parse_error: true` + raw 保持でフォールバック
  - `api/activity_detail.py` — `GET /api/activities/{id}`（404）、`/time-series?metrics=...`（metrics必須・未知名422）、`/sections`
- **Frontend**: `/activities/:id` ルート + ActivityDetail ページ、ECharts タイムシリーズ（dataZoom + axisPointer）、SectionCard 5タイプ + 汎用フォールバック（Spike #198 の知見: キー存在ベース分岐、react-markdown で日本語Markdown描画、逸脱データ耐性）

## Rebase 統合（P4 #204 マージ後）

`app.py`/`App.tsx`/`package.json`/`package-lock.json`/`conftest.py` のコンフリクトをオーケストレーターが解決:
- ルーティングは `/` + `/activities/:id` + `/trends` の3本に統合、nav 維持
- echarts は main の ^6.1.0 を採用（P2 コードの v6 互換をビルド・テストで確認済み）
- conftest の `form_evaluations` DDL は trends 用と detail 用で必要カラムが異なるため `_CREATE_FORM_EVALUATIONS_TRENDS` / `_CREATE_FORM_EVALUATIONS_DETAIL` に分離（別fixture DBのため共存可）

## 検証（L2 相当 — rebase 後にオーケストレーターが独立実行で確認済み）

| チェック | 結果 |
|---|---|
| `pytest -m unit` | 19 passed（detail/sections/time_series 9本 + trends 6本 + 既存4本） |
| `pytest -m integration` | 4 passed |
| `ruff check src/ tests/` | clean |
| `vitest run` | 5 passed（3ファイル） |
| `tsc + vite build` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)