### PR TITLE
chore(agents): pin analyst models instead of session inherit

### DIFF
--- a/.claude/agents/efficiency-section-analyst.md
+++ b/.claude/agents/efficiency-section-analyst.md
@@ -2,7 +2,7 @@
 name: efficiency-section-analyst
 description: フォーム効率（GCT/VO/VR）と心拍効率（ゾーン分布）を分析し、DuckDBに保存するエージェント。
 tools: mcp__garmin-db__get_form_evaluations, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__get_heart_rate_zones_detail, mcp__garmin-db__get_form_baseline_trend, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
-model: claude-sonnet-4-6
+model: sonnet
 ---
 
 # Efficiency Section Analyst

--- a/.claude/agents/efficiency-section-analyst.md
+++ b/.claude/agents/efficiency-section-analyst.md
@@ -2,7 +2,7 @@
 name: efficiency-section-analyst
 description: フォーム効率（GCT/VO/VR）と心拍効率（ゾーン分布）を分析し、DuckDBに保存するエージェント。
 tools: mcp__garmin-db__get_form_evaluations, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__get_heart_rate_zones_detail, mcp__garmin-db__get_form_baseline_trend, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
-model: inherit
+model: claude-sonnet-4-6
 ---
 
 # Efficiency Section Analyst

--- a/.claude/agents/environment-section-analyst.md
+++ b/.claude/agents/environment-section-analyst.md
@@ -2,7 +2,7 @@
 name: environment-section-analyst
 description: 気温・湿度・風速・地形の環境要因がパフォーマンスに与えた影響を分析し、DuckDBに保存するエージェント。環境条件の影響評価が必要な時に呼び出す。
 tools: mcp__garmin-db__get_weather_data, mcp__garmin-db__get_splits_elevation, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
-model: claude-sonnet-4-6
+model: sonnet
 ---
 
 # Environment Section Analyst

--- a/.claude/agents/environment-section-analyst.md
+++ b/.claude/agents/environment-section-analyst.md
@@ -2,7 +2,7 @@
 name: environment-section-analyst
 description: 気温・湿度・風速・地形の環境要因がパフォーマンスに与えた影響を分析し、DuckDBに保存するエージェント。環境条件の影響評価が必要な時に呼び出す。
 tools: mcp__garmin-db__get_weather_data, mcp__garmin-db__get_splits_elevation, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
-model: inherit
+model: claude-sonnet-4-6
 ---
 
 # Environment Section Analyst

--- a/.claude/agents/phase-section-analyst.md
+++ b/.claude/agents/phase-section-analyst.md
@@ -2,7 +2,7 @@
 name: phase-section-analyst
 description: トレーニングフェーズ評価専門エージェント。通常ランは3フェーズ（warmup/run/cooldown）、インターバルトレーニングは4フェーズ（warmup/run/recovery/cooldown）で評価し、DuckDBに保存する。
 tools: mcp__garmin-db__get_performance_trends, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
-model: inherit
+model: claude-sonnet-4-6
 ---
 
 # Phase Section Analyst

--- a/.claude/agents/phase-section-analyst.md
+++ b/.claude/agents/phase-section-analyst.md
@@ -2,7 +2,7 @@
 name: phase-section-analyst
 description: トレーニングフェーズ評価専門エージェント。通常ランは3フェーズ（warmup/run/cooldown）、インターバルトレーニングは4フェーズ（warmup/run/recovery/cooldown）で評価し、DuckDBに保存する。
 tools: mcp__garmin-db__get_performance_trends, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
-model: claude-sonnet-4-6
+model: sonnet
 ---
 
 # Phase Section Analyst

--- a/.claude/agents/split-section-analyst.md
+++ b/.claude/agents/split-section-analyst.md
@@ -2,7 +2,7 @@
 name: split-section-analyst
 description: 全1kmスプリットのペース・心拍・フォーム指標を詳細分析し、環境統合評価を行うエージェント。DuckDBに保存。スプリット毎の変化パターン検出が必要な時に呼び出す。
 tools: mcp__garmin-db__get_splits_comprehensive, mcp__garmin-db__detect_form_anomalies_summary, mcp__garmin-db__get_form_anomaly_details, mcp__garmin-db__get_split_time_series_detail, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
-model: inherit
+model: claude-sonnet-4-6
 ---
 
 # Split Section Analyst

--- a/.claude/agents/split-section-analyst.md
+++ b/.claude/agents/split-section-analyst.md
@@ -2,7 +2,7 @@
 name: split-section-analyst
 description: 全1kmスプリットのペース・心拍・フォーム指標を詳細分析し、環境統合評価を行うエージェント。DuckDBに保存。スプリット毎の変化パターン検出が必要な時に呼び出す。
 tools: mcp__garmin-db__get_splits_comprehensive, mcp__garmin-db__detect_form_anomalies_summary, mcp__garmin-db__get_form_anomaly_details, mcp__garmin-db__get_split_time_series_detail, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
-model: claude-sonnet-4-6
+model: sonnet
 ---
 
 # Split Section Analyst

--- a/.claude/agents/summary-section-analyst.md
+++ b/.claude/agents/summary-section-analyst.md
@@ -2,7 +2,7 @@
 name: summary-section-analyst
 description: 総合評価と改善提案を生成するエージェント。DuckDBに保存。総合評価が必要な時に呼び出す。
 tools: mcp__garmin-db__get_splits_comprehensive, mcp__garmin-db__get_form_efficiency_summary, mcp__garmin-db__get_form_evaluations, mcp__garmin-db__get_performance_trends, mcp__garmin-db__get_vo2_max_data, mcp__garmin-db__get_lactate_threshold_data, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__compare_similar_workouts, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
-model: claude-opus-4-8
+model: opus
 ---
 
 # Summary Section Analyst

--- a/.claude/agents/summary-section-analyst.md
+++ b/.claude/agents/summary-section-analyst.md
@@ -2,7 +2,7 @@
 name: summary-section-analyst
 description: 総合評価と改善提案を生成するエージェント。DuckDBに保存。総合評価が必要な時に呼び出す。
 tools: mcp__garmin-db__get_splits_comprehensive, mcp__garmin-db__get_form_efficiency_summary, mcp__garmin-db__get_form_evaluations, mcp__garmin-db__get_performance_trends, mcp__garmin-db__get_vo2_max_data, mcp__garmin-db__get_lactate_threshold_data, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__compare_similar_workouts, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
-model: inherit
+model: claude-opus-4-8
 ---
 
 # Summary Section Analyst


### PR DESCRIPTION
## 概要

解析5サブエージェントの frontmatter `model:` を `inherit`（セッション継承）から明示固定に変更。

| ファイル | 変更 | 根拠 |
|---|---|---|
| split-section-analyst | `inherit` → `claude-sonnet-4-6` | contract当てはめ＋定型生成。Sonnetで十分 |
| phase-section-analyst | `inherit` → `claude-sonnet-4-6` | 最もルールベース（contract lookup中心） |
| efficiency-section-analyst | `inherit` → `claude-sonnet-4-6` | ペース補正評価＋トレンド比較。中程度 |
| environment-section-analyst | `inherit` → `claude-sonnet-4-6` | 気温×湿度の相乗計算・地形分類。中程度 |
| summary-section-analyst | `inherit` → `claude-opus-4-8` | 4軸加重統合＋改善提案＋コーチ文。判断的タスク |

## 動機

これらは **contract 駆動エージェント**（評価の重み・閾値・フォーマットが `get_analysis_contract()` で外部化、出力は `validate_section_json()` でスキーマ検証）。モデルの仕事は「MCP取得 → ルール当てはめ → 定型日本語生成」で自由推論ではない。Opus 4.8 セッションで全エージェントが Opus を継承するのは過剰（コストの無駄）。`inherit` は Haiku セッション時に summary 品質低下リスクもある。明示固定で分析品質とコストをセッションモデルから分離・安定化する。

summary を Fable 5 にする案は検討の上不採用（長時間自律エージェント向けで単発分析には過剰、Opus の2倍コスト）。

## 検証

- **コードレビュー**: diff は値のみ変更（5行）、frontmatter 構造不変で YAML 有効
- **モデル ID**: `claude-sonnet-4-6` / `claude-opus-4-8` は現行有効 ID。サブエージェント frontmatter はフル ID 受付可
- **注記**: `model:` は Claude Code ハーネスがプロジェクトルートの `.claude/agents/` から読む設定で MCP 管轄外。標準 L3 E2E（`reload_server` → `/analyze-activity`）では worktree 定義を行使できないため、behavioral 検証は**マージ後の最初の `/analyze-activity` 実行**で確認する（Sonnet に落とした4セクションの出力品質）

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)