### PR TITLE
feat(garmin-web): add GPS track map with chart hover sync

### DIFF
--- a/packages/garmin-web/frontend/package-lock.json
+++ b/packages/garmin-web/frontend/package-lock.json
@@ -9,14 +9,17 @@
       "version": "0.1.0",
       "dependencies": {
         "echarts": "^6.1.0",
+        "leaflet": "^1.9.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-leaflet": "^5.0.0",
         "react-markdown": "^10.0.0",
         "react-router-dom": "^7.17.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.0",
         "@testing-library/react": "^16.1.0",
+        "@types/leaflet": "^1.9.21",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.4",
@@ -894,6 +897,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1382,12 +1395,27 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
       "dependencies": {
         "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
       }
     },
     "node_modules/@types/mdast": {
@@ -2287,6 +2315,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -3097,6 +3130,19 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",

--- a/packages/garmin-web/frontend/package.json
+++ b/packages/garmin-web/frontend/package.json
@@ -11,13 +11,16 @@
   },
   "dependencies": {
     "echarts": "^6.1.0",
+    "leaflet": "^1.9.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-leaflet": "^5.0.0",
     "react-markdown": "^10.0.0",
     "react-router-dom": "^7.17.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.0",
+    "@types/leaflet": "^1.9.21",
     "@testing-library/react": "^16.1.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/packages/garmin-web/frontend/src/api/client.ts
+++ b/packages/garmin-web/frontend/src/api/client.ts
@@ -3,6 +3,7 @@ import type {
   ActivitySummary,
   SectionsResponse,
   TimeSeriesResponse,
+  TrackResponse,
 } from "../types";
 
 export async function fetchActivities(params?: {
@@ -46,6 +47,16 @@ export async function fetchTimeSeries(
     throw new Error(`Failed to fetch time series: ${response.status}`);
   }
   return (await response.json()) as TimeSeriesResponse;
+}
+
+export async function fetchTrack(
+  activityId: string | number,
+): Promise<TrackResponse> {
+  const response = await fetch(`/api/activities/${activityId}/track`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch track: ${response.status}`);
+  }
+  return (await response.json()) as TrackResponse;
 }
 
 export async function fetchSections(

--- a/packages/garmin-web/frontend/src/components/MapPanel.test.tsx
+++ b/packages/garmin-web/frontend/src/components/MapPanel.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { TrackPoint } from "../types";
+import MapPanel, { nearestPointIndex } from "./MapPanel";
+
+// Leaflet needs a real DOM/canvas, which jsdom does not provide.
+vi.mock("react-leaflet", () => ({
+  MapContainer: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Polyline: () => <div data-testid="polyline" />,
+  CircleMarker: () => <div data-testid="hover-marker" />,
+}));
+vi.mock("leaflet/dist/leaflet.css", () => ({}));
+
+const POINTS: TrackPoint[] = [
+  { seq_no: 0, lat: 35.6, lon: 139.7 },
+  { seq_no: 5, lat: 35.601, lon: 139.701 },
+  { seq_no: 10, lat: 35.602, lon: 139.702 },
+];
+
+describe("MapPanel", () => {
+  it("MapPanel renders nothing when points empty", () => {
+    render(<MapPanel points={[]} />);
+
+    expect(screen.getByText("GPSデータがありません")).toBeInTheDocument();
+    expect(screen.queryByTestId("map-container")).not.toBeInTheDocument();
+  });
+
+  it("renders map with polyline when points exist", () => {
+    render(<MapPanel points={POINTS} />);
+
+    expect(screen.getByTestId("map-container")).toBeInTheDocument();
+    expect(screen.getByTestId("polyline")).toBeInTheDocument();
+    expect(screen.queryByText("GPSデータがありません")).not.toBeInTheDocument();
+  });
+
+  it("shows hover marker for the nearest seq_no", () => {
+    render(<MapPanel points={POINTS} hoverSeqNo={6} />);
+
+    expect(screen.getByTestId("hover-marker")).toBeInTheDocument();
+  });
+
+  it("nearestPointIndex picks the closest seq_no", () => {
+    expect(nearestPointIndex(POINTS, 0)).toBe(0);
+    expect(nearestPointIndex(POINTS, 2)).toBe(0);
+    expect(nearestPointIndex(POINTS, 3)).toBe(1);
+    expect(nearestPointIndex(POINTS, 6)).toBe(1);
+    expect(nearestPointIndex(POINTS, 9)).toBe(2);
+    expect(nearestPointIndex(POINTS, 999)).toBe(2);
+  });
+});

--- a/packages/garmin-web/frontend/src/components/MapPanel.tsx
+++ b/packages/garmin-web/frontend/src/components/MapPanel.tsx
@@ -1,0 +1,134 @@
+import type { LatLngBoundsExpression, LeafletMouseEvent } from "leaflet";
+import { useMemo, useRef } from "react";
+import { CircleMarker, MapContainer, Polyline, TileLayer } from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+import type { TrackPoint } from "../types";
+
+const HOVER_THROTTLE_MS = 50;
+
+/** Binary search: index of the point whose seq_no is nearest to target. */
+export function nearestPointIndex(points: TrackPoint[], target: number): number {
+  let low = 0;
+  let high = points.length - 1;
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    if (points[mid].seq_no < target) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  if (low > 0) {
+    const prev = points[low - 1];
+    if (target - prev.seq_no <= points[low].seq_no - target) {
+      return low - 1;
+    }
+  }
+  return low;
+}
+
+function nearestPointToLatLng(
+  points: TrackPoint[],
+  lat: number,
+  lng: number,
+): TrackPoint {
+  let best = points[0];
+  let bestDist = Infinity;
+  for (const point of points) {
+    const dLat = point.lat - lat;
+    const dLon = point.lon - lng;
+    const dist = dLat * dLat + dLon * dLon;
+    if (dist < bestDist) {
+      bestDist = dist;
+      best = point;
+    }
+  }
+  return best;
+}
+
+/**
+ * GPS track map (Leaflet + OpenStreetMap). Renders a placeholder when the
+ * activity has no GPS points (e.g. indoor runs). Hovering the polyline
+ * reports the nearest point's seq_no via onHoverSeqNo (throttled 50ms);
+ * hoverSeqNo highlights the nearest point with a marker.
+ */
+export default function MapPanel({
+  points,
+  hoverSeqNo,
+  onHoverSeqNo,
+}: {
+  points: TrackPoint[];
+  hoverSeqNo?: number | null;
+  onHoverSeqNo?: (seqNo: number | null) => void;
+}) {
+  const lastEmitRef = useRef(0);
+
+  const positions = useMemo(
+    () => points.map((point) => [point.lat, point.lon] as [number, number]),
+    [points],
+  );
+
+  const bounds = useMemo<LatLngBoundsExpression | null>(() => {
+    if (points.length === 0) {
+      return null;
+    }
+    const lats = points.map((point) => point.lat);
+    const lons = points.map((point) => point.lon);
+    return [
+      [Math.min(...lats), Math.min(...lons)],
+      [Math.max(...lats), Math.max(...lons)],
+    ];
+  }, [points]);
+
+  if (points.length === 0 || bounds == null) {
+    return <p>GPSデータがありません</p>;
+  }
+
+  const hoverPoint =
+    hoverSeqNo == null ? null : points[nearestPointIndex(points, hoverSeqNo)];
+
+  const handleMouseMove = (event: LeafletMouseEvent) => {
+    if (!onHoverSeqNo) {
+      return;
+    }
+    const now = Date.now();
+    if (now - lastEmitRef.current < HOVER_THROTTLE_MS) {
+      return;
+    }
+    lastEmitRef.current = now;
+    const nearest = nearestPointToLatLng(
+      points,
+      event.latlng.lat,
+      event.latlng.lng,
+    );
+    onHoverSeqNo(nearest.seq_no);
+  };
+
+  return (
+    <MapContainer
+      bounds={bounds}
+      scrollWheelZoom={false}
+      style={{ width: "100%", height: 400 }}
+    >
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      <Polyline
+        positions={positions}
+        pathOptions={{ color: "#1d4ed8", weight: 4 }}
+        eventHandlers={{
+          mousemove: handleMouseMove,
+          mouseout: () => onHoverSeqNo?.(null),
+        }}
+      />
+      {hoverPoint && (
+        <CircleMarker
+          center={[hoverPoint.lat, hoverPoint.lon]}
+          radius={7}
+          pathOptions={{ color: "#dc2626", fillColor: "#dc2626", fillOpacity: 0.9 }}
+        />
+      )}
+    </MapContainer>
+  );
+}

--- a/packages/garmin-web/frontend/src/components/TimeSeriesChart.tsx
+++ b/packages/garmin-web/frontend/src/components/TimeSeriesChart.tsx
@@ -28,20 +28,35 @@ function speedToPace(value: number | null): number | null {
   return Math.round(1000 / value);
 }
 
+const HOVER_THROTTLE_MS = 50;
+
 /**
  * Stacked line charts (one grid per metric) with a shared x axis:
  * dataZoom and axisPointer are linked across all grids.
  * The "speed" metric is displayed as pace (min/km, inverted axis).
+ *
+ * Hover sync (Issue #200): onHoverIndex reports the hovered data index
+ * (throttled 50ms); hoverIndex shows the tooltip at an externally chosen
+ * index (e.g. driven by the GPS map).
  */
 export default function TimeSeriesChart({
   data,
   metricLabels,
+  hoverIndex = null,
+  onHoverIndex,
 }: {
   data: TimeSeriesResponse;
   metricLabels: Record<string, string>;
+  hoverIndex?: number | null;
+  onHoverIndex?: (index: number | null) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<echarts.ECharts | null>(null);
+  const onHoverIndexRef = useRef(onHoverIndex);
+  onHoverIndexRef.current = onHoverIndex;
+  // Last index dispatched from the outside; suppresses re-emitting it.
+  const externalIndexRef = useRef<number | null>(null);
+  const lastEmitRef = useRef(0);
 
   const metricNames = Object.keys(data.metrics);
   const height = GRID_TOP + metricNames.length * (GRID_HEIGHT + GRID_GAP) + 60;
@@ -51,7 +66,28 @@ export default function TimeSeriesChart({
     if (!container || metricNames.length === 0) {
       return;
     }
-    chartRef.current ??= echarts.init(container);
+    if (!chartRef.current) {
+      const chart = echarts.init(container);
+      chartRef.current = chart;
+      chart.on("updateAxisPointer", (event) => {
+        const axesInfo = (event as { axesInfo?: { value: number }[] })
+          .axesInfo;
+        const index = axesInfo?.[0]?.value;
+        if (index == null || index === externalIndexRef.current) {
+          return;
+        }
+        const now = Date.now();
+        if (now - lastEmitRef.current < HOVER_THROTTLE_MS) {
+          return;
+        }
+        lastEmitRef.current = now;
+        onHoverIndexRef.current?.(index);
+      });
+      chart.getZr().on("globalout", () => {
+        externalIndexRef.current = null;
+        onHoverIndexRef.current?.(null);
+      });
+    }
 
     const base = data.timestamps[0] ?? 0;
     const elapsedLabels = data.timestamps.map((t) => formatElapsed(t - base));
@@ -120,6 +156,24 @@ export default function TimeSeriesChart({
     chartRef.current.resize({ height });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data, metricLabels, height]);
+
+  // Externally driven hover (map -> chart): show/hide the tooltip.
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) {
+      return;
+    }
+    externalIndexRef.current = hoverIndex;
+    if (hoverIndex == null) {
+      chart.dispatchAction({ type: "hideTip" });
+      return;
+    }
+    chart.dispatchAction({
+      type: "showTip",
+      seriesIndex: 0,
+      dataIndex: hoverIndex,
+    });
+  }, [hoverIndex]);
 
   useEffect(() => {
     const handleResize = () => chartRef.current?.resize();

--- a/packages/garmin-web/frontend/src/pages/ActivityDetail.tsx
+++ b/packages/garmin-web/frontend/src/pages/ActivityDetail.tsx
@@ -4,13 +4,16 @@ import {
   fetchActivityDetail,
   fetchSections,
   fetchTimeSeries,
+  fetchTrack,
 } from "../api/client";
+import MapPanel from "../components/MapPanel";
 import SectionCard from "../components/sections/SectionCard";
 import TimeSeriesChart from "../components/TimeSeriesChart";
 import type {
   ActivityDetailResponse,
   SectionsResponse,
   TimeSeriesResponse,
+  TrackPoint,
 } from "../types";
 import { formatDistance, formatPace } from "./ActivityList";
 
@@ -44,6 +47,33 @@ export function formatDuration(totalSeconds: number | null): string {
   return hours > 0 ? `${hours}:${mmss}` : mmss;
 }
 
+/** Binary search: index of the timestamp nearest to target (ascending). */
+export function nearestTimestampIndex(
+  timestamps: number[],
+  target: number,
+): number {
+  let low = 0;
+  let high = timestamps.length - 1;
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    if (timestamps[mid] < target) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  if (low > 0 && target - timestamps[low - 1] <= timestamps[low] - target) {
+    return low - 1;
+  }
+  return low;
+}
+
+/** Shared hover state in the seq_no / timestamp_s domain. */
+interface HoverState {
+  source: "chart" | "map";
+  value: number;
+}
+
 function orderedSectionTypes(sections: SectionsResponse): string[] {
   const known = SECTION_ORDER.filter((type) => type in sections);
   const unknown = Object.keys(sections).filter(
@@ -59,6 +89,8 @@ export default function ActivityDetail() {
   const [timeSeries, setTimeSeries] = useState<TimeSeriesResponse | null>(null);
   const [selectedMetrics, setSelectedMetrics] =
     useState<string[]>(DEFAULT_METRICS);
+  const [track, setTrack] = useState<TrackPoint[] | null>(null);
+  const [hover, setHover] = useState<HoverState | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -109,6 +141,27 @@ export default function ActivityDetail() {
     };
   }, [id, selectedMetrics]);
 
+  useEffect(() => {
+    if (!id) {
+      return;
+    }
+    let cancelled = false;
+    fetchTrack(id)
+      .then((data) => {
+        if (!cancelled) {
+          setTrack(data.points);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setTrack([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
   const toggleMetric = (key: string) => {
     setSelectedMetrics((current) =>
       current.includes(key)
@@ -132,6 +185,27 @@ export default function ActivityDetail() {
   }
 
   const { activity, splits } = detail;
+
+  // Bidirectional hover sync: chart data index <-> track seq_no, matched
+  // through the nearest timestamp / seq_no value.
+  const timestamps = timeSeries?.timestamps ?? [];
+  const chartHoverIndex =
+    hover?.source === "map" && timestamps.length > 0
+      ? nearestTimestampIndex(timestamps, hover.value)
+      : null;
+  const mapHoverSeqNo = hover?.value ?? null;
+
+  const handleChartHover = (index: number | null) => {
+    setHover(
+      index == null || timestamps.length === 0
+        ? null
+        : { source: "chart", value: timestamps[index] ?? index },
+    );
+  };
+
+  const handleMapHover = (seqNo: number | null) => {
+    setHover(seqNo == null ? null : { source: "map", value: seqNo });
+  };
 
   return (
     <div>
@@ -162,6 +236,18 @@ export default function ActivityDetail() {
         </div>
       </dl>
 
+      {/* GPS track map (placeholder when the activity has no GPS data) */}
+      {track !== null && (
+        <section>
+          <h2>コース</h2>
+          <MapPanel
+            points={track}
+            hoverSeqNo={mapHoverSeqNo}
+            onHoverSeqNo={handleMapHover}
+          />
+        </section>
+      )}
+
       {/* Time series chart with metric toggles */}
       <section>
         <h2>タイムシリーズ</h2>
@@ -178,7 +264,12 @@ export default function ActivityDetail() {
           ))}
         </div>
         {timeSeries && Object.keys(timeSeries.metrics).length > 0 ? (
-          <TimeSeriesChart data={timeSeries} metricLabels={METRIC_LABELS} />
+          <TimeSeriesChart
+            data={timeSeries}
+            metricLabels={METRIC_LABELS}
+            hoverIndex={chartHoverIndex}
+            onHoverIndex={handleChartHover}
+          />
         ) : (
           <p>表示する指標を選択してください</p>
         )}

--- a/packages/garmin-web/frontend/src/types.ts
+++ b/packages/garmin-web/frontend/src/types.ts
@@ -45,6 +45,18 @@ export interface TimeSeriesResponse {
   metrics: Record<string, (number | null)[]>;
 }
 
+// --- GPS track (Issue #200) ---
+
+export interface TrackPoint {
+  seq_no: number;
+  lat: number;
+  lon: number;
+}
+
+export interface TrackResponse {
+  points: TrackPoint[];
+}
+
 export interface SectionResult {
   data: Record<string, unknown> | null;
   parse_error: boolean;

--- a/packages/garmin-web/src/garmin_web/api/activity_detail.py
+++ b/packages/garmin-web/src/garmin_web/api/activity_detail.py
@@ -1,4 +1,4 @@
-"""Activity detail API router (detail, time-series, sections)."""
+"""Activity detail API router (detail, time-series, track, sections)."""
 
 from typing import Annotated
 
@@ -8,6 +8,7 @@ from garmin_mcp.database.connection import get_connection
 from garmin_web.queries.detail import get_activity_detail
 from garmin_web.queries.sections import get_sections
 from garmin_web.queries.time_series import get_time_series
+from garmin_web.queries.track import get_track
 
 router = APIRouter(prefix="/api")
 
@@ -44,6 +45,18 @@ def get_activity_time_series(
             )
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.get("/activities/{activity_id}/track")
+def get_activity_track(request: Request, activity_id: int) -> dict:
+    """Return the GPS track for an activity.
+
+    Activities without GPS data (e.g. indoor runs) return 200 with an
+    empty points array.
+    """
+    db_path = getattr(request.app.state, "db_path", None)
+    with get_connection(db_path) as conn:
+        return {"points": get_track(conn, activity_id)}
 
 
 @router.get("/activities/{activity_id}/sections")

--- a/packages/garmin-web/src/garmin_web/queries/track.py
+++ b/packages/garmin-web/src/garmin_web/queries/track.py
@@ -1,0 +1,27 @@
+"""Read-only query for GPS track points from time_series_metrics."""
+
+import duckdb
+
+
+def get_track(conn: duckdb.DuckDBPyConnection, activity_id: int) -> list[dict]:
+    """Fetch the GPS coordinate sequence ordered by seq_no.
+
+    Rows where latitude or longitude is NULL (e.g. indoor runs or GPS
+    dropouts) are excluded.
+
+    Args:
+        conn: Open DuckDB connection (read-only is sufficient).
+        activity_id: Target activity ID.
+
+    Returns:
+        List of {"seq_no": int, "lat": float, "lon": float}, ordered by
+        seq_no ascending. Empty list when the activity has no GPS data.
+    """
+    rows = conn.execute(
+        "SELECT seq_no, latitude, longitude FROM time_series_metrics"
+        " WHERE activity_id = ?"
+        " AND latitude IS NOT NULL AND longitude IS NOT NULL"
+        " ORDER BY seq_no",
+        [activity_id],
+    ).fetchall()
+    return [{"seq_no": row[0], "lat": row[1], "lon": row[2]} for row in rows]

--- a/packages/garmin-web/tests/conftest.py
+++ b/packages/garmin-web/tests/conftest.py
@@ -266,6 +266,8 @@ _CREATE_TIME_SERIES_METRICS = """
         heart_rate DOUBLE,
         speed DOUBLE,
         cadence DOUBLE,
+        latitude DOUBLE,
+        longitude DOUBLE,
         PRIMARY KEY (activity_id, seq_no)
     )
 """
@@ -282,6 +284,21 @@ _CREATE_SECTION_ANALYSES = """
         agent_version VARCHAR
     )
 """
+
+
+@pytest.fixture
+def track_conn():
+    """In-memory DuckDB with time_series_metrics table, no rows.
+
+    Track unit tests insert their own rows (activity_id band: 9000002xxx).
+    Column order: activity_id, seq_no, timestamp_s, heart_rate, speed,
+    cadence, latitude, longitude.
+    """
+    conn = duckdb.connect(":memory:")
+    conn.execute(_CREATE_TIME_SERIES_METRICS)
+    yield conn
+    conn.close()
+
 
 # Activity 9000000101: full data (5 splits, form_efficiency, 5 HR zones,
 # performance_trends, form_evaluations, 2000 time-series rows, 5 sections).
@@ -468,15 +485,18 @@ def detail_db_path(tmp_path: Path) -> Path:
             [1, FULL_ACTIVITY_ID, 4.1, "★★★★☆", "2025-10-09 12:00:00"],
         )
 
-        # Time series: 2000 rows (full) / 300 rows (partial)
+        # Time series: 2000 rows with GPS (full) / 300 rows without GPS
+        # (partial, simulating an indoor run).
         conn.execute(
             "INSERT INTO time_series_metrics"
-            f" SELECT {FULL_ACTIVITY_ID}, i, i, 140 + i % 20, 2.8, 170.0"
+            f" SELECT {FULL_ACTIVITY_ID}, i, i, 140 + i % 20, 2.8, 170.0,"
+            " 35.6 + i * 1e-5, 139.7 + i * 1e-5"
             " FROM range(2000) AS t(i)"
         )
         conn.execute(
             "INSERT INTO time_series_metrics"
-            f" SELECT {PARTIAL_ACTIVITY_ID}, i, i, 135 + i % 10, 2.6, 168.0"
+            f" SELECT {PARTIAL_ACTIVITY_ID}, i, i, 135 + i % 10, 2.6, 168.0,"
+            " NULL, NULL"
             " FROM range(300) AS t(i)"
         )
 

--- a/packages/garmin-web/tests/test_api_detail.py
+++ b/packages/garmin-web/tests/test_api_detail.py
@@ -5,7 +5,8 @@ from fastapi.testclient import TestClient
 
 from garmin_web.app import create_app
 
-FULL_ACTIVITY_ID = 9000000101
+FULL_ACTIVITY_ID = 9000000101  # 2000 time-series rows with GPS
+PARTIAL_ACTIVITY_ID = 9000000102  # 300 time-series rows, no GPS (indoor)
 
 
 @pytest.mark.integration
@@ -54,6 +55,27 @@ def test_api_detail_endpoints_200(detail_db_path):
         "summary",
     }
     assert all(s["parse_error"] is False for s in sections.values())
+
+
+@pytest.mark.integration
+def test_api_track_200(detail_db_path):
+    client = TestClient(create_app(db_path=detail_db_path))
+    response = client.get(f"/api/activities/{FULL_ACTIVITY_ID}/track")
+
+    assert response.status_code == 200
+    points = response.json()["points"]
+    assert len(points) == 2000
+    assert points[0] == {"seq_no": 0, "lat": 35.6, "lon": 139.7}
+    assert [p["seq_no"] for p in points] == sorted(p["seq_no"] for p in points)
+
+
+@pytest.mark.integration
+def test_api_track_empty_for_indoor(detail_db_path):
+    client = TestClient(create_app(db_path=detail_db_path))
+    response = client.get(f"/api/activities/{PARTIAL_ACTIVITY_ID}/track")
+
+    assert response.status_code == 200
+    assert response.json()["points"] == []
 
 
 @pytest.mark.integration

--- a/packages/garmin-web/tests/test_queries_track.py
+++ b/packages/garmin-web/tests/test_queries_track.py
@@ -1,0 +1,74 @@
+"""Unit tests for garmin_web.queries.track.get_track."""
+
+import pytest
+
+from garmin_web.queries.track import get_track
+
+TRACK_ACTIVITY_ID = 9000002001
+
+# seq_no values inserted out of order on purpose: ORDER BY seq_no must sort.
+_SHUFFLED_SEQ_NOS = [5, 1, 9, 3, 7, 0, 8, 2, 6, 4]
+
+_INSERT = (
+    "INSERT INTO time_series_metrics"
+    " (activity_id, seq_no, timestamp_s, heart_rate, speed, cadence,"
+    "  latitude, longitude)"
+    " VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+)
+
+
+def _gps_row(seq_no: int, lat: float | None, lon: float | None) -> tuple:
+    return (TRACK_ACTIVITY_ID, seq_no, seq_no, 140.0, 2.8, 170.0, lat, lon)
+
+
+@pytest.mark.unit
+def test_track_returns_ordered_coordinates(track_conn):
+    track_conn.executemany(
+        _INSERT,
+        [
+            _gps_row(seq_no, 35.6 + seq_no * 0.001, 139.7 + seq_no * 0.001)
+            for seq_no in _SHUFFLED_SEQ_NOS
+        ],
+    )
+
+    points = get_track(track_conn, TRACK_ACTIVITY_ID)
+
+    assert len(points) == 10
+    assert [point["seq_no"] for point in points] == list(range(10))
+    assert points[0] == {"seq_no": 0, "lat": 35.6, "lon": 139.7}
+    assert points[-1]["seq_no"] == 9
+    assert points[-1]["lat"] == pytest.approx(35.609)
+    assert points[-1]["lon"] == pytest.approx(139.709)
+
+
+@pytest.mark.unit
+def test_track_skips_null_coords(track_conn):
+    null_seq_nos = {2, 5, 8}
+    track_conn.executemany(
+        _INSERT,
+        [
+            (
+                _gps_row(seq_no, None, None)
+                if seq_no in null_seq_nos
+                else _gps_row(seq_no, 35.6 + seq_no * 0.001, 139.7 + seq_no * 0.001)
+            )
+            for seq_no in _SHUFFLED_SEQ_NOS
+        ],
+    )
+
+    points = get_track(track_conn, TRACK_ACTIVITY_ID)
+
+    assert len(points) == 7
+    assert [point["seq_no"] for point in points] == [0, 1, 3, 4, 6, 7, 9]
+
+
+@pytest.mark.unit
+def test_track_no_gps_returns_empty(track_conn):
+    track_conn.executemany(
+        _INSERT,
+        [_gps_row(seq_no, None, None) for seq_no in _SHUFFLED_SEQ_NOS],
+    )
+
+    points = get_track(track_conn, TRACK_ACTIVITY_ID)
+
+    assert points == []


### PR DESCRIPTION
Closes #200

Part of Epic #196 の P3。詳細ページに Leaflet + OSM の GPS トラック地図を追加し、ECharts タイムシリーズと双方向ホバー連動させる。

## 変更内容

- **Backend**: `queries/track.py`（lat/lon NULL 除外、seq_no 昇順）+ `GET /api/activities/{id}/track`（GPSなしは 200 + 空配列）
- **Frontend**:
  - `MapPanel.tsx` — react-leaflet + OSM、polyline + ホバーマーカー、GPSなし時はプレースホルダ
  - `TimeSeriesChart.tsx` — `hoverIndex`/`onHoverIndex` props（updateAxisPointer listen、50ms throttle、外部 dispatch ループ抑止）
  - `ActivityDetail.tsx` — 共有 hover state でグラフ⇄地図を最近傍（二分探索）連動
  - 依存追加: leaflet 1.9.4 / react-leaflet 5.0.0

## 検証（L2 相当 — オーケストレーターが独立実行で確認済み）

| チェック | 結果 |
|---|---|
| `pytest -m unit` | 22 passed（track 3本含む） |
| `pytest -m integration` | 6 passed（track API 2本含む） |
| `ruff check src/ tests/` | clean |
| `vitest run` | 9 passed（MapPanel 4本含む） |
| `tsc + vite build` | pass |

## 設計からの逸脱（理由付き）

- track API テストは新規ファイルではなく既存 `tests/test_api_detail.py` に追加（既存の配置パターンに合わせた）
- polyline は単色 + ホバーマーカー（track API に speed が無いため。Issue 内で許可済み）
- conftest の `_CREATE_TIME_SERIES_METRICS` に latitude/longitude を追加し、FULL activity に GPS 付与・PARTIAL は NULL（indoor 役）。既存テスト全通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)