### PR TITLE
feat(garmin-web): serve SPA, add CLI entrypoint, CI jobs and docs

### DIFF
--- a/.claude/rules/dev/dev-reference.md
+++ b/.claude/rules/dev/dev-reference.md
@@ -69,6 +69,7 @@ Skip: Design セクションなし、Issue番号不明、dry-run時。
 | `.claude/agents/*-analyst.md` | L3 |
 | `handlers/`, `database/readers/` | L1 |
 | `reporting/`, `ingest/`, `database/migrations/` | L2 |
+| `packages/garmin-web/` | L2 |
 | `.claude/rules/`, `docs/`, `CLAUDE.md` | skip |
 
 迷ったら L2。L3 は agent 定義変更時のみ。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      web: ${{ steps.filter.outputs.web }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -21,6 +22,9 @@ jobs:
               - 'packages/**'
               - 'pyproject.toml'
               - '.pre-commit-config.yaml'
+              - '.github/workflows/**'
+            web:
+              - 'packages/garmin-web/**'
               - '.github/workflows/**'
 
   lint-and-test:
@@ -55,18 +59,80 @@ jobs:
       - name: Run unit tests with coverage
         run: uv run pytest -m unit --tb=short -n 4 --maxfail=5 --cov=garmin_mcp --cov-report=term-missing --cov-fail-under=60
 
+  web-backend:
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/garmin-web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Lint with ruff
+        run: uv run ruff check src/ tests/
+
+      - name: Run unit and integration tests
+        run: uv run pytest -m "unit or integration" --tb=short
+
+  web-frontend:
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/garmin-web/frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: packages/garmin-web/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Run tests
+        run: npx vitest run
+
+      - name: Build
+        run: npm run build
+
   ci-guard:
-    needs: [changes, lint-and-test]
+    needs: [changes, lint-and-test, web-backend, web-frontend]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check CI result
         run: |
-          if [ "${{ needs.changes.outputs.code }}" == "false" ]; then
+          if [ "${{ needs.changes.outputs.code }}" == "false" ] && [ "${{ needs.changes.outputs.web }}" == "false" ]; then
             echo "No code changes — skipping CI"
             exit 0
           fi
-          if [ "${{ needs.lint-and-test.result }}" != "success" ]; then
+          if [ "${{ needs.changes.outputs.code }}" == "true" ] && [ "${{ needs.lint-and-test.result }}" != "success" ]; then
             echo "lint-and-test failed"
+            exit 1
+          fi
+          if [ "${{ needs.changes.outputs.web }}" == "true" ] && [ "${{ needs.web-backend.result }}" != "success" ]; then
+            echo "web-backend failed"
+            exit 1
+          fi
+          if [ "${{ needs.changes.outputs.web }}" == "true" ] && [ "${{ needs.web-frontend.result }}" != "success" ]; then
+            echo "web-frontend failed"
             exit 1
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ FIFO キュー + Validation Agent 方式。詳細は `.claude/rules/dev/worktree
 ```
 garmin-performance-analysis/
 ├── packages/
-│   └── garmin-mcp-server/
+│   ├── garmin-mcp-server/
 │       ├── pyproject.toml
 │       ├── src/garmin_mcp/
 │       │   ├── ingest/             # API → Raw data (ApiClient, RawDataFetcher, DuckDBSaver)
@@ -149,6 +149,10 @@ garmin-performance-analysis/
 │       │   │   └── regenerate/     # DuckDB regeneration utilities
 │       │   ├── tool_schemas.py     # MCP tool definitions (30 tools)
 │       │   └── validation/         # Data validation
+│       └── tests/
+│   └── garmin-web/                 # Web app (see docs/garmin-web.md)
+│       ├── src/garmin_web/         # FastAPI backend (api/, queries/, cli.py)
+│       ├── frontend/               # Vite + React SPA
 │       └── tests/
 ├── .claude/
 │   ├── agents/                     # 5 analysis agents

--- a/docs/garmin-web.md
+++ b/docs/garmin-web.md
@@ -1,0 +1,93 @@
+# garmin-web
+
+Web app for browsing Garmin running analysis results stored in DuckDB.
+
+- **Backend**: FastAPI (`packages/garmin-web/src/garmin_web/`)
+- **Frontend**: Vite + React + TypeScript (`packages/garmin-web/frontend/`)
+
+## Running the app
+
+### Production-style (single process)
+
+Build the frontend once, then start the server. FastAPI serves the built
+SPA from `frontend/dist` with an `index.html` fallback for client-side
+routes (deep links like `/activities/123` work).
+
+```bash
+# 1. Build the frontend
+npm --prefix packages/garmin-web/frontend run build
+
+# 2. Start the server (default: http://127.0.0.1:8765)
+uv run garmin-web
+uv run garmin-web --host 0.0.0.0 --port 8888   # custom bind
+```
+
+If `frontend/dist` does not exist, the server logs a warning and serves
+the API only.
+
+### Development (two processes)
+
+Run uvicorn with auto-reload and the Vite dev server side by side.
+Vite proxies `/api` to port 8765 (see `frontend/vite.config.ts`).
+
+```bash
+# Terminal 1: backend (port 8765)
+uv run --directory packages/garmin-web uvicorn garmin_web.app:create_app --factory --reload --port 8765
+
+# Terminal 2: frontend dev server (port 5173)
+npm --prefix packages/garmin-web/frontend run dev
+```
+
+Open http://localhost:5173 during development.
+
+## API
+
+All endpoints are read-only `GET` under `/api`.
+
+| Endpoint | Description |
+|----------|-------------|
+| `/api/activities?from=YYYY-MM-DD&to=YYYY-MM-DD` | Activity list, date descending. `from`/`to` are optional inclusive bounds |
+| `/api/activities/{id}` | Aggregated detail (splits, form efficiency, HR zones, performance trends, form evaluation). 404 if unknown |
+| `/api/activities/{id}/time-series?metrics=heart_rate,speed&max_points=500` | Downsampled time series. `metrics` is a required comma-separated list; unknown metrics → 422 |
+| `/api/activities/{id}/track` | GPS track points. Indoor runs return an empty `points` array |
+| `/api/activities/{id}/sections` | Section analyses (split / phase / efficiency / environment / summary) |
+| `/api/trends/volume?from=...&to=...` | Weekly distance / duration / run-count aggregates |
+| `/api/trends/physiology?from=...&to=...` | VO2max and lactate threshold history |
+| `/api/trends/form?from=...&to=...` | Form evaluation score history |
+| `/api/trends/efficiency?from=...&to=...` | Pace/HR efficiency and HR zone distribution history |
+
+## Architecture
+
+```
+Browser (React SPA)
+  └── /api/*  → FastAPI routers (api/)
+                  └── queries/  → SQL query functions
+                        └── garmin_mcp.database.connection.get_connection()
+                              └── DuckDB (read-only)
+  └── /*      → SPA fallback (frontend/dist/index.html)
+```
+
+- **Read-only DB access**: reuses `get_connection()` from
+  `garmin-mcp-server` (workspace dependency). The DB path resolves from
+  `GARMIN_DATA_DIR` unless `create_app(db_path=...)` is given.
+- **Connection per request**: each request opens and closes its own
+  connection via a context manager. No connection pooling or shared
+  state, which keeps the app safe alongside the single-writer ingest
+  process.
+- **App factory**: `create_app(db_path=None, static_dir=None)`.
+  `static_dir` overrides the default package-relative `frontend/dist`
+  (used by tests).
+- **Route precedence**: API routers are registered before the SPA
+  catch-all, so `/api/*` is never shadowed; unknown `/api/*` paths
+  return 404 JSON, not HTML.
+
+## Tests
+
+```bash
+uv run --directory packages/garmin-web pytest -m unit -v
+uv run --directory packages/garmin-web pytest -m integration -v
+npm --prefix packages/garmin-web/frontend run test
+```
+
+CI runs both backend (pytest + ruff) and frontend (tsc + vitest + build)
+jobs when `packages/garmin-web/**` changes (`.github/workflows/ci.yml`).

--- a/packages/garmin-web/pyproject.toml
+++ b/packages/garmin-web/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
     "garmin-mcp-server",
 ]
 
+[project.scripts]
+garmin-web = "garmin_web.cli:main"
+
 [tool.uv.sources]
 garmin-mcp-server = { workspace = true }
 

--- a/packages/garmin-web/src/garmin_web/app.py
+++ b/packages/garmin-web/src/garmin_web/app.py
@@ -1,23 +1,39 @@
 """FastAPI application factory for garmin-web."""
 
+import logging
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 
 from garmin_web.api.activities import router as activities_router
 from garmin_web.api.activity_detail import router as activity_detail_router
 from garmin_web.api.trends import router as trends_router
 
+logger = logging.getLogger(__name__)
+
 VITE_DEV_ORIGIN = "http://localhost:5173"
 
+# packages/garmin-web/src/garmin_web/app.py -> packages/garmin-web/frontend/dist
+_DEFAULT_STATIC_DIR = (
+    Path(__file__).resolve().parent.parent.parent / "frontend" / "dist"
+)
 
-def create_app(db_path: str | Path | None = None) -> FastAPI:
+
+def create_app(
+    db_path: str | Path | None = None,
+    static_dir: str | Path | None = None,
+) -> FastAPI:
     """Create the garmin-web FastAPI application.
 
     Args:
         db_path: Path to the DuckDB database file. If None, the path is
             resolved from GARMIN_DATA_DIR via garmin_mcp configuration.
+        static_dir: Directory containing the built frontend (index.html +
+            assets). If None, defaults to the package-relative
+            `frontend/dist`. If the directory or its index.html is missing,
+            a warning is logged and the API still works without the SPA.
 
     Returns:
         Configured FastAPI application.
@@ -34,4 +50,36 @@ def create_app(db_path: str | Path | None = None) -> FastAPI:
     app.include_router(activities_router)
     app.include_router(activity_detail_router)
     app.include_router(trends_router)
+
+    resolved_static_dir = Path(static_dir) if static_dir else _DEFAULT_STATIC_DIR
+    _mount_spa(app, resolved_static_dir)
     return app
+
+
+def _mount_spa(app: FastAPI, static_dir: Path) -> None:
+    """Serve the built SPA with an index.html fallback for client routes.
+
+    Registered after the API routers, so `/api/*` routes always win.
+    When the build output is missing the SPA is simply not served.
+    """
+    index_file = static_dir / "index.html"
+    if not index_file.is_file():
+        logger.warning(
+            "Frontend build not found at %s — serving API only. "
+            "Run `npm run build` in packages/garmin-web/frontend.",
+            static_dir,
+        )
+        return
+
+    static_root = static_dir.resolve()
+
+    @app.get("/{full_path:path}", include_in_schema=False)
+    def spa_fallback(full_path: str) -> FileResponse:
+        # Never shadow the API: unknown /api paths must stay 404, not HTML.
+        if full_path == "api" or full_path.startswith("api/"):
+            raise HTTPException(status_code=404, detail="Not Found")
+        if full_path:
+            candidate = (static_root / full_path).resolve()
+            if candidate.is_file() and candidate.is_relative_to(static_root):
+                return FileResponse(candidate)
+        return FileResponse(index_file)

--- a/packages/garmin-web/src/garmin_web/cli.py
+++ b/packages/garmin-web/src/garmin_web/cli.py
@@ -1,0 +1,35 @@
+"""CLI entrypoint for garmin-web (`uv run garmin-web`)."""
+
+import argparse
+
+import uvicorn
+
+from garmin_web.app import create_app
+
+
+def main() -> None:
+    """Start the garmin-web server with uvicorn.
+
+    Options: --host (default 127.0.0.1), --port (default 8765).
+    """
+    parser = argparse.ArgumentParser(
+        prog="garmin-web",
+        description="Serve the Garmin analysis web app (API + built frontend).",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Bind address (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8765,
+        help="Bind port (default: 8765)",
+    )
+    args = parser.parse_args()
+    uvicorn.run(create_app(), host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/garmin-web/tests/test_app_static.py
+++ b/packages/garmin-web/tests/test_app_static.py
@@ -1,0 +1,51 @@
+"""Tests for SPA static serving and fallback in create_app()."""
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from garmin_web.app import create_app
+
+_INDEX_HTML = "<!doctype html><html><body>garmin-web spa</body></html>"
+
+
+@pytest.fixture
+def static_dir(tmp_path: Path) -> Path:
+    """Fake frontend build output with an index.html."""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text(_INDEX_HTML)
+    return dist
+
+
+@pytest.mark.unit
+def test_spa_fallback_serves_index(static_dir):
+    client = TestClient(create_app(static_dir=static_dir))
+    response = client.get("/activities/123")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "garmin-web spa" in response.text
+
+
+@pytest.mark.unit
+def test_api_routes_not_shadowed(fixture_db_path, static_dir):
+    client = TestClient(create_app(db_path=fixture_db_path, static_dir=static_dir))
+    response = client.get("/api/activities")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert len(payload) == 2
+
+
+@pytest.mark.unit
+def test_missing_dist_api_still_works(fixture_db_path, tmp_path):
+    app = create_app(db_path=fixture_db_path, static_dir=tmp_path / "does-not-exist")
+    client = TestClient(app)
+    response = client.get("/api/activities")
+
+    assert response.status_code == 200
+    assert len(response.json()) == 2

--- a/packages/garmin-web/tests/test_cli.py
+++ b/packages/garmin-web/tests/test_cli.py
@@ -1,0 +1,21 @@
+"""Tests for the garmin-web CLI entrypoint."""
+
+from unittest.mock import patch
+
+import pytest
+
+from garmin_web.cli import main
+
+
+@pytest.mark.unit
+def test_cli_default_args(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["garmin-web"])
+    with (
+        patch("garmin_web.cli.uvicorn.run") as mock_run,
+        patch("garmin_web.cli.create_app") as mock_create_app,
+    ):
+        main()
+
+    mock_run.assert_called_once_with(
+        mock_create_app.return_value, host="127.0.0.1", port=8765
+    )


### PR DESCRIPTION
Closes #202

Part of Epic #196 の P5（最終）。普段使いの形に仕上げる。

## 変更内容

- **SPA 静的配信**: `create_app()` が `frontend/dist` を検出して catch-all SPA fallback を登録。`/api/*` は shadow されず（未知の `/api/*` は 404 JSON）、実ファイルは path-traversal ガード付きで配信。dist 不在時は warning ログのみで API は動作
- **起動コマンド**: `cli.py` + `[project.scripts]` で `uv run garmin-web`（--host 127.0.0.1 / --port 8765）
- **CI**: `changes` に `web` フィルタ追加、`web-backend`（uv sync → ruff → pytest unit+integration）/ `web-frontend`（npm ci → tsc → vitest → build, node 20）ジョブ追加。`ci-guard` はフィルタ毎に個別判定し required check 名と既存動作を維持
- **Docs**: `docs/garmin-web.md` 新規（起動・API一覧・アーキテクチャ）、CLAUDE.md のディレクトリ構造更新、dev-reference.md の Validation 判定表に `packages/garmin-web/` = L2 を追加

## 検証（L2 相当 — オーケストレーターが独立実行で確認済み）

| チェック | 結果 |
|---|---|
| `pytest -m unit` | 26 passed（static/cli 4本含む） |
| `pytest -m integration` | 6 passed |
| `ruff check src/ tests/` | clean |
| `npm run build` | pass（dist 生成） |
| `uv run garmin-web --help` | usage 表示 OK |

## 設計からの逸脱（理由付き）

- frontend の lint 相当は `npx tsc --noEmit`（ESLint 設定が存在しないため。build 内 tsc と重複するが失敗切り分け用に独立ステップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)