### PR TITLE
feat(garmin-web): overhaul UI with Tailwind light-clean theme

### DIFF
--- a/packages/garmin-web/frontend/index.html
+++ b/packages/garmin-web/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>garmin-web</title>
+    <title>Garmin Performance</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/garmin-web/frontend/package-lock.json
+++ b/packages/garmin-web/frontend/package-lock.json
@@ -8,13 +8,15 @@
       "name": "garmin-web-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@tailwindcss/vite": "^4.3.0",
         "echarts": "^6.1.0",
         "leaflet": "^1.9.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-leaflet": "^5.0.0",
         "react-markdown": "^10.0.0",
-        "react-router-dom": "^7.17.0"
+        "react-router-dom": "^7.17.0",
+        "tailwindcss": "^4.3.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.0",
@@ -443,7 +445,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "aix"
@@ -459,7 +460,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -475,7 +475,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -491,7 +490,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -507,7 +505,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -523,7 +520,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -539,7 +535,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -555,7 +550,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -571,7 +565,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -587,7 +580,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -603,7 +595,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -619,7 +610,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -635,7 +625,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -651,7 +640,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -667,7 +655,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -683,7 +670,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -699,7 +685,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -715,7 +700,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -731,7 +715,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -747,7 +730,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -763,7 +745,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -779,7 +760,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openharmony"
@@ -795,7 +775,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -811,7 +790,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -827,7 +805,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -843,7 +820,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -856,7 +832,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -866,7 +841,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -876,7 +850,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -884,14 +857,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -920,7 +891,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -933,7 +903,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -946,7 +915,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -959,7 +927,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -972,7 +939,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -985,7 +951,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -998,7 +963,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1011,7 +975,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1024,7 +987,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1037,7 +999,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1050,7 +1011,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1063,7 +1023,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1076,7 +1035,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1089,7 +1047,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1102,7 +1059,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1115,7 +1071,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1128,7 +1083,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1141,7 +1095,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1154,7 +1107,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1167,7 +1119,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -1180,7 +1131,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openharmony"
@@ -1193,7 +1143,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1206,7 +1155,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1219,7 +1167,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1232,11 +1179,252 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
+      "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "tailwindcss": "4.3.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
@@ -1904,6 +2092,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -1938,6 +2134,18 @@
       "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
       "dev": true
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -1960,7 +2168,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -2042,7 +2249,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -2059,7 +2265,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -2077,6 +2282,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
@@ -2246,6 +2456,14 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2320,6 +2538,243 @@
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -2358,7 +2813,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -2947,7 +3401,6 @@
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3029,14 +3482,12 @@
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -3048,7 +3499,6 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3263,7 +3713,6 @@
       "version": "4.61.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
       "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -3356,7 +3805,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3447,6 +3895,23 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "node_modules/tailwindcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3463,7 +3928,6 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.4"
@@ -3721,7 +4185,6 @@
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
-      "dev": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/packages/garmin-web/frontend/package.json
+++ b/packages/garmin-web/frontend/package.json
@@ -10,18 +10,20 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@tailwindcss/vite": "^4.3.0",
     "echarts": "^6.1.0",
     "leaflet": "^1.9.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-leaflet": "^5.0.0",
     "react-markdown": "^10.0.0",
-    "react-router-dom": "^7.17.0"
+    "react-router-dom": "^7.17.0",
+    "tailwindcss": "^4.3.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.0",
-    "@types/leaflet": "^1.9.21",
     "@testing-library/react": "^16.1.0",
+    "@types/leaflet": "^1.9.21",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/packages/garmin-web/frontend/src/App.tsx
+++ b/packages/garmin-web/frontend/src/App.tsx
@@ -1,4 +1,5 @@
-import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import Layout from "./components/Layout";
 import ActivityDetail from "./pages/ActivityDetail";
 import ActivityList from "./pages/ActivityList";
 import TrendsDashboard from "./pages/TrendsDashboard";
@@ -6,14 +7,13 @@ import TrendsDashboard from "./pages/TrendsDashboard";
 export default function App() {
   return (
     <BrowserRouter>
-      <nav>
-        <Link to="/">アクティビティ一覧</Link> | <Link to="/trends">トレンド</Link>
-      </nav>
-      <Routes>
-        <Route path="/" element={<ActivityList />} />
-        <Route path="/activities/:id" element={<ActivityDetail />} />
-        <Route path="/trends" element={<TrendsDashboard />} />
-      </Routes>
+      <Layout>
+        <Routes>
+          <Route path="/" element={<ActivityList />} />
+          <Route path="/activities/:id" element={<ActivityDetail />} />
+          <Route path="/trends" element={<TrendsDashboard />} />
+        </Routes>
+      </Layout>
     </BrowserRouter>
   );
 }

--- a/packages/garmin-web/frontend/src/components/Layout.test.tsx
+++ b/packages/garmin-web/frontend/src/components/Layout.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import Layout from "./Layout";
+
+describe("Layout", () => {
+  it("Layout renders nav links with active state", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Layout>
+          <p>コンテンツ</p>
+        </Layout>
+      </MemoryRouter>,
+    );
+
+    const listLink = screen.getByRole("link", { name: "一覧" });
+    const trendsLink = screen.getByRole("link", { name: "トレンド" });
+    expect(listLink).toBeInTheDocument();
+    expect(trendsLink).toBeInTheDocument();
+
+    // NavLink marks the active route with aria-current="page"
+    expect(listLink).toHaveAttribute("aria-current", "page");
+    expect(trendsLink).not.toHaveAttribute("aria-current");
+
+    // Children are rendered inside the content container
+    expect(screen.getByText("コンテンツ")).toBeInTheDocument();
+  });
+});

--- a/packages/garmin-web/frontend/src/components/Layout.tsx
+++ b/packages/garmin-web/frontend/src/components/Layout.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+import { NavLink } from "react-router-dom";
+
+function navLinkClass({ isActive }: { isActive: boolean }): string {
+  const base = "rounded-md px-3 py-1.5 text-sm font-medium transition-colors";
+  return isActive
+    ? `${base} bg-indigo-50 text-indigo-700`
+    : `${base} text-slate-600 hover:bg-slate-100 hover:text-slate-900`;
+}
+
+/**
+ * App shell: sticky white header (brand + nav with active state) and a
+ * centered content container. Purely presentational.
+ */
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-800">
+      <header className="sticky top-0 z-[1100] border-b border-slate-200 bg-white shadow-sm">
+        <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4">
+          <NavLink
+            to="/"
+            className="text-base font-bold tracking-tight text-indigo-600"
+          >
+            Garmin Performance
+          </NavLink>
+          <nav aria-label="メインナビゲーション" className="flex gap-1">
+            <NavLink to="/" end className={navLinkClass}>
+              一覧
+            </NavLink>
+            <NavLink to="/trends" className={navLinkClass}>
+              トレンド
+            </NavLink>
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto max-w-5xl px-4 py-6">{children}</main>
+    </div>
+  );
+}

--- a/packages/garmin-web/frontend/src/components/MapPanel.tsx
+++ b/packages/garmin-web/frontend/src/components/MapPanel.tsx
@@ -81,7 +81,11 @@ export default function MapPanel({
   }, [points]);
 
   if (points.length === 0 || bounds == null) {
-    return <p>GPSデータがありません</p>;
+    return (
+      <p className="px-5 py-8 text-center text-sm text-slate-500">
+        GPSデータがありません
+      </p>
+    );
   }
 
   const hoverPoint =
@@ -116,7 +120,7 @@ export default function MapPanel({
       />
       <Polyline
         positions={positions}
-        pathOptions={{ color: "#1d4ed8", weight: 4 }}
+        pathOptions={{ color: "#4f46e5", weight: 4 }}
         eventHandlers={{
           mousemove: handleMouseMove,
           mouseout: () => onHoverSeqNo?.(null),
@@ -126,7 +130,7 @@ export default function MapPanel({
         <CircleMarker
           center={[hoverPoint.lat, hoverPoint.lon]}
           radius={7}
-          pathOptions={{ color: "#dc2626", fillColor: "#dc2626", fillOpacity: 0.9 }}
+          pathOptions={{ color: "#f59e0b", fillColor: "#f59e0b", fillOpacity: 0.9 }}
         />
       )}
     </MapContainer>

--- a/packages/garmin-web/frontend/src/components/TimeSeriesChart.tsx
+++ b/packages/garmin-web/frontend/src/components/TimeSeriesChart.tsx
@@ -1,6 +1,12 @@
 import * as echarts from "echarts";
 import { useEffect, useRef } from "react";
 import type { TimeSeriesResponse } from "../types";
+import {
+  AXIS_LABEL_COLOR,
+  CHART_FONT_SIZE,
+  CHART_PALETTE,
+  GRID_LINE_COLOR,
+} from "./chartTheme";
 
 const GRID_HEIGHT = 140;
 const GRID_GAP = 50;
@@ -96,6 +102,8 @@ export default function TimeSeriesChart({
 
     const option: echarts.EChartsOption = {
       animation: false,
+      color: CHART_PALETTE,
+      textStyle: { fontSize: CHART_FONT_SIZE, color: AXIS_LABEL_COLOR },
       axisPointer: { link: [{ xAxisIndex: "all" }] },
       tooltip: { trigger: "axis" },
       grid: metricNames.map((_, i) => ({
@@ -108,7 +116,12 @@ export default function TimeSeriesChart({
         type: "category",
         gridIndex: i,
         data: elapsedLabels,
-        axisLabel: { show: i === lastIndex },
+        axisLabel: {
+          show: i === lastIndex,
+          color: AXIS_LABEL_COLOR,
+          fontSize: CHART_FONT_SIZE,
+        },
+        axisLine: { lineStyle: { color: GRID_LINE_COLOR } },
         axisPointer: { show: true },
       })),
       yAxis: metricNames.map((name, i) => {
@@ -117,11 +130,17 @@ export default function TimeSeriesChart({
           type: "value",
           gridIndex: i,
           name: metricLabels[name] ?? name,
+          nameTextStyle: { color: AXIS_LABEL_COLOR, fontSize: CHART_FONT_SIZE },
           scale: true,
           inverse: isPace,
-          axisLabel: isPace
-            ? { formatter: (value: number) => formatPaceLabel(value) }
-            : {},
+          axisLabel: {
+            color: AXIS_LABEL_COLOR,
+            fontSize: CHART_FONT_SIZE,
+            ...(isPace
+              ? { formatter: (value: number) => formatPaceLabel(value) }
+              : {}),
+          },
+          splitLine: { lineStyle: { color: GRID_LINE_COLOR } },
         };
       }),
       series: metricNames.map((name, i) => {

--- a/packages/garmin-web/frontend/src/components/chartTheme.ts
+++ b/packages/garmin-web/frontend/src/components/chartTheme.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared visual tokens for ECharts (Issue #210 light-clean theme).
+ * Visual styling only — chart data shaping stays in each component.
+ */
+
+/** indigo-600, sky-500, emerald-500, amber-500, violet-500 */
+export const CHART_PALETTE = [
+  "#4f46e5",
+  "#0ea5e9",
+  "#10b981",
+  "#f59e0b",
+  "#8b5cf6",
+];
+
+/** slate-200 */
+export const GRID_LINE_COLOR = "#e2e8f0";
+
+/** slate-500 */
+export const AXIS_LABEL_COLOR = "#64748b";
+
+export const CHART_FONT_SIZE = 12;
+
+/** Spread into every option: palette + unified typography. */
+export const BASE_CHART_OPTION = {
+  color: CHART_PALETTE,
+  textStyle: { fontSize: CHART_FONT_SIZE, color: AXIS_LABEL_COLOR },
+} as const;
+
+/** Spread into category/value axes for unified line + label styling. */
+export const AXIS_STYLE = {
+  axisLabel: { color: AXIS_LABEL_COLOR, fontSize: CHART_FONT_SIZE },
+  axisLine: { lineStyle: { color: GRID_LINE_COLOR } },
+  splitLine: { lineStyle: { color: GRID_LINE_COLOR } },
+} as const;

--- a/packages/garmin-web/frontend/src/components/sections/EfficiencySectionCard.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/EfficiencySectionCard.tsx
@@ -1,6 +1,11 @@
 import type { EfficiencySectionData } from "../../types";
 import KeyValueList from "./KeyValueList";
 import MarkdownText from "./MarkdownText";
+import {
+  SECTION_CARD_CLASS,
+  SECTION_SUBTITLE_CLASS,
+  SECTION_TITLE_CLASS,
+} from "./SectionCard";
 
 const FIELDS: { key: keyof EfficiencySectionData & string; label: string }[] = [
   { key: "efficiency", label: "フォーム効率" },
@@ -16,8 +21,8 @@ export default function EfficiencySectionCard({
   data: EfficiencySectionData;
 }) {
   return (
-    <section className="section-card">
-      <h3>効率分析</h3>
+    <section className={SECTION_CARD_CLASS}>
+      <h3 className={SECTION_TITLE_CLASS}>効率分析</h3>
       {FIELDS.map(({ key, label }) => {
         const text = data[key];
         if (typeof text !== "string") {
@@ -25,7 +30,7 @@ export default function EfficiencySectionCard({
         }
         return (
           <div key={key}>
-            <h4>{label}</h4>
+            <h4 className={SECTION_SUBTITLE_CLASS}>{label}</h4>
             <MarkdownText text={text} />
           </div>
         );

--- a/packages/garmin-web/frontend/src/components/sections/EnvironmentSectionCard.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/EnvironmentSectionCard.tsx
@@ -1,6 +1,7 @@
 import type { EnvironmentSectionData } from "../../types";
 import KeyValueList from "./KeyValueList";
 import MarkdownText from "./MarkdownText";
+import { SECTION_CARD_CLASS, SECTION_TITLE_CLASS } from "./SectionCard";
 
 const KNOWN_KEYS = ["metadata", "environmental"];
 
@@ -10,8 +11,8 @@ export default function EnvironmentSectionCard({
   data: EnvironmentSectionData;
 }) {
   return (
-    <section className="section-card">
-      <h3>環境影響</h3>
+    <section className={SECTION_CARD_CLASS}>
+      <h3 className={SECTION_TITLE_CLASS}>環境影響</h3>
       {typeof data.environmental === "string" && (
         <MarkdownText text={data.environmental} />
       )}

--- a/packages/garmin-web/frontend/src/components/sections/FallbackCard.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/FallbackCard.tsx
@@ -1,4 +1,5 @@
 import KeyValueList from "./KeyValueList";
+import { SECTION_CARD_CLASS, SECTION_TITLE_CLASS } from "./SectionCard";
 
 /** Generic card rendering all fields as key-value pairs. */
 export default function FallbackCard({
@@ -11,8 +12,8 @@ export default function FallbackCard({
   exclude?: string[];
 }) {
   return (
-    <section className="section-card">
-      <h3>{title}</h3>
+    <section className={SECTION_CARD_CLASS}>
+      <h3 className={SECTION_TITLE_CLASS}>{title}</h3>
       <KeyValueList data={data} exclude={exclude} />
     </section>
   );

--- a/packages/garmin-web/frontend/src/components/sections/KeyValueList.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/KeyValueList.tsx
@@ -13,7 +13,7 @@ export function renderValue(value: unknown): ReactNode {
   }
   if (Array.isArray(value)) {
     return (
-      <ul>
+      <ul className="list-disc space-y-0.5 pl-5">
         {value.map((item, index) => (
           // eslint-disable-next-line react/no-array-index-key
           <li key={index}>{renderValue(item)}</li>
@@ -44,11 +44,13 @@ export default function KeyValueList({
     return null;
   }
   return (
-    <dl className="key-value-list">
+    <dl className="mt-3 divide-y divide-slate-100 border-t border-slate-100">
       {entries.map(([key, value]) => (
-        <div key={key} className="key-value-item">
-          <dt>{key}</dt>
-          <dd>{renderValue(value)}</dd>
+        <div key={key} className="py-2">
+          <dt className="text-xs font-medium tracking-wide text-slate-500">
+            {key}
+          </dt>
+          <dd className="mt-0.5 text-sm text-slate-700">{renderValue(value)}</dd>
         </div>
       ))}
     </dl>

--- a/packages/garmin-web/frontend/src/components/sections/MarkdownText.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/MarkdownText.tsx
@@ -2,5 +2,9 @@ import ReactMarkdown from "react-markdown";
 
 /** Renders Markdown-style Japanese analysis text from section JSON. */
 export default function MarkdownText({ text }: { text: string }) {
-  return <ReactMarkdown>{text}</ReactMarkdown>;
+  return (
+    <div className="markdown-body text-sm leading-relaxed text-slate-700">
+      <ReactMarkdown>{text}</ReactMarkdown>
+    </div>
+  );
 }

--- a/packages/garmin-web/frontend/src/components/sections/PhaseSectionCard.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/PhaseSectionCard.tsx
@@ -1,6 +1,11 @@
 import type { PhaseSectionData } from "../../types";
 import KeyValueList from "./KeyValueList";
 import MarkdownText from "./MarkdownText";
+import {
+  SECTION_CARD_CLASS,
+  SECTION_SUBTITLE_CLASS,
+  SECTION_TITLE_CLASS,
+} from "./SectionCard";
 
 const PHASE_FIELDS: { key: keyof PhaseSectionData & string; label: string }[] = [
   { key: "warmup_evaluation", label: "ウォームアップ" },
@@ -14,8 +19,8 @@ const KNOWN_KEYS = ["metadata", ...PHASE_FIELDS.map((field) => field.key)];
 
 export default function PhaseSectionCard({ data }: { data: PhaseSectionData }) {
   return (
-    <section className="section-card">
-      <h3>フェーズ評価</h3>
+    <section className={SECTION_CARD_CLASS}>
+      <h3 className={SECTION_TITLE_CLASS}>フェーズ評価</h3>
       {PHASE_FIELDS.map(({ key, label }) => {
         const text = data[key];
         if (typeof text !== "string") {
@@ -23,7 +28,7 @@ export default function PhaseSectionCard({ data }: { data: PhaseSectionData }) {
         }
         return (
           <div key={key}>
-            <h4>{label}</h4>
+            <h4 className={SECTION_SUBTITLE_CLASS}>{label}</h4>
             <MarkdownText text={text} />
           </div>
         );

--- a/packages/garmin-web/frontend/src/components/sections/SectionCard.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/SectionCard.tsx
@@ -14,6 +14,15 @@ export const SECTION_TITLES: Record<string, string> = {
   environment: "環境影響",
 };
 
+/** Shared Tailwind classes for analysis section cards (Issue #210). */
+export const SECTION_CARD_CLASS =
+  "rounded-xl border border-slate-200 bg-white p-5 shadow-sm";
+
+export const SECTION_TITLE_CLASS = "mb-2 text-base font-semibold text-slate-800";
+
+export const SECTION_SUBTITLE_CLASS =
+  "mt-4 mb-1 text-sm font-semibold text-slate-600";
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -36,19 +45,28 @@ export default function SectionCard({
 
   if (section.parse_error) {
     return (
-      <section className="section-card">
-        <h3>{title}</h3>
-        <p role="alert">分析データのJSON解析に失敗しました。</p>
-        {section.raw != null && <pre>{section.raw}</pre>}
+      <section className={SECTION_CARD_CLASS}>
+        <h3 className={SECTION_TITLE_CLASS}>{title}</h3>
+        <p
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+        >
+          分析データのJSON解析に失敗しました。
+        </p>
+        {section.raw != null && (
+          <pre className="mt-2 overflow-x-auto rounded-lg bg-slate-100 p-3 text-xs text-slate-700">
+            {section.raw}
+          </pre>
+        )}
       </section>
     );
   }
 
   if (!isRecord(section.data)) {
     return (
-      <section className="section-card">
-        <h3>{title}</h3>
-        <p>分析データがありません。</p>
+      <section className={SECTION_CARD_CLASS}>
+        <h3 className={SECTION_TITLE_CLASS}>{title}</h3>
+        <p className="text-sm text-slate-500">分析データがありません。</p>
       </section>
     );
   }

--- a/packages/garmin-web/frontend/src/components/sections/SplitSectionCard.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/SplitSectionCard.tsx
@@ -1,6 +1,11 @@
 import type { SplitSectionData } from "../../types";
 import KeyValueList from "./KeyValueList";
 import MarkdownText from "./MarkdownText";
+import {
+  SECTION_CARD_CLASS,
+  SECTION_SUBTITLE_CLASS,
+  SECTION_TITLE_CLASS,
+} from "./SectionCard";
 
 const KNOWN_KEYS = ["metadata", "highlights", "analyses"];
 
@@ -19,27 +24,34 @@ export default function SplitSectionCard({ data }: { data: SplitSectionData }) {
     : [];
 
   return (
-    <section className="section-card">
-      <h3>スプリット分析</h3>
+    <section className={SECTION_CARD_CLASS}>
+      <h3 className={SECTION_TITLE_CLASS}>スプリット分析</h3>
       {typeof data.highlights === "string" && (
         <>
-          <h4>ハイライト</h4>
+          <h4 className={SECTION_SUBTITLE_CLASS}>ハイライト</h4>
           <MarkdownText text={data.highlights} />
         </>
       )}
       {analysisEntries.length > 0 && (
         <>
-          <h4>スプリット別分析</h4>
-          {analysisEntries.map(([key, text]) => (
-            <div key={key} className="split-analysis">
-              <h5>{key.replace("split_", "")} km</h5>
-              {typeof text === "string" ? (
-                <MarkdownText text={text} />
-              ) : (
-                String(text)
-              )}
-            </div>
-          ))}
+          <h4 className={SECTION_SUBTITLE_CLASS}>スプリット別分析</h4>
+          <div className="space-y-2">
+            {analysisEntries.map(([key, text]) => (
+              <div
+                key={key}
+                className="rounded-lg border border-slate-100 bg-slate-50 px-3 py-2"
+              >
+                <h5 className="text-xs font-semibold tabular-nums text-indigo-600">
+                  {key.replace("split_", "")} km
+                </h5>
+                {typeof text === "string" ? (
+                  <MarkdownText text={text} />
+                ) : (
+                  String(text)
+                )}
+              </div>
+            ))}
+          </div>
         </>
       )}
       <KeyValueList data={data} exclude={KNOWN_KEYS} />

--- a/packages/garmin-web/frontend/src/components/sections/SummarySectionCard.tsx
+++ b/packages/garmin-web/frontend/src/components/sections/SummarySectionCard.tsx
@@ -1,6 +1,11 @@
 import type { SummarySectionData } from "../../types";
 import KeyValueList from "./KeyValueList";
 import MarkdownText from "./MarkdownText";
+import {
+  SECTION_CARD_CLASS,
+  SECTION_SUBTITLE_CLASS,
+  SECTION_TITLE_CLASS,
+} from "./SectionCard";
 
 const KNOWN_KEYS = [
   "metadata",
@@ -17,16 +22,22 @@ export default function SummarySectionCard({
   data: SummarySectionData;
 }) {
   return (
-    <section className="section-card">
-      <h3>
+    <section className={SECTION_CARD_CLASS}>
+      <h3 className={SECTION_TITLE_CLASS}>
         総合評価
-        {typeof data.star_rating === "string" ? ` ${data.star_rating}` : ""}
+        {typeof data.star_rating === "string" ? (
+          <span className="ml-2 font-normal text-amber-500">
+            {data.star_rating}
+          </span>
+        ) : (
+          ""
+        )}
       </h3>
       {typeof data.summary === "string" && <MarkdownText text={data.summary} />}
       {Array.isArray(data.key_strengths) && data.key_strengths.length > 0 && (
         <>
-          <h4>強み</h4>
-          <ul>
+          <h4 className={SECTION_SUBTITLE_CLASS}>強み</h4>
+          <ul className="list-disc space-y-1 pl-5">
             {data.key_strengths.map((item) => (
               <li key={String(item)}>
                 <MarkdownText text={String(item)} />
@@ -38,8 +49,8 @@ export default function SummarySectionCard({
       {Array.isArray(data.improvement_areas) &&
         data.improvement_areas.length > 0 && (
           <>
-            <h4>改善ポイント</h4>
-            <ul>
+            <h4 className={SECTION_SUBTITLE_CLASS}>改善ポイント</h4>
+            <ul className="list-disc space-y-1 pl-5">
               {data.improvement_areas.map((item) => (
                 <li key={String(item)}>
                   <MarkdownText text={String(item)} />
@@ -50,7 +61,7 @@ export default function SummarySectionCard({
         )}
       {typeof data.recommendations === "string" && (
         <>
-          <h4>推奨事項</h4>
+          <h4 className={SECTION_SUBTITLE_CLASS}>推奨事項</h4>
           <MarkdownText text={data.recommendations} />
         </>
       )}

--- a/packages/garmin-web/frontend/src/index.css
+++ b/packages/garmin-web/frontend/src/index.css
@@ -1,0 +1,52 @@
+@import "tailwindcss";
+
+@theme {
+  --font-sans:
+    "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Noto Sans JP", system-ui,
+    -apple-system, "Segoe UI", sans-serif;
+}
+
+@layer base {
+  body {
+    @apply bg-slate-50 font-sans text-slate-800 antialiased;
+  }
+}
+
+/*
+ * Markdown-rendered analysis text (react-markdown output).
+ * Tailwind preflight strips list/paragraph styles, so restore a compact
+ * reading style scoped to .markdown-body.
+ */
+.markdown-body p {
+  margin: 0.25rem 0;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  margin: 0.25rem 0;
+  padding-left: 1.25rem;
+}
+
+.markdown-body ul {
+  list-style: disc;
+}
+
+.markdown-body ol {
+  list-style: decimal;
+}
+
+.markdown-body li {
+  margin: 0.125rem 0;
+}
+
+.markdown-body strong {
+  font-weight: 600;
+  color: var(--color-slate-900);
+}
+
+.markdown-body code {
+  border-radius: 0.25rem;
+  background-color: var(--color-slate-100);
+  padding: 0.0625rem 0.25rem;
+  font-size: 0.85em;
+}

--- a/packages/garmin-web/frontend/src/main.tsx
+++ b/packages/garmin-web/frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import "./index.css";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {

--- a/packages/garmin-web/frontend/src/pages/ActivityDetail.tsx
+++ b/packages/garmin-web/frontend/src/pages/ActivityDetail.tsx
@@ -175,13 +175,32 @@ export default function ActivityDetail() {
   };
 
   if (loading) {
-    return <p>読み込み中...</p>;
+    return (
+      <div className="flex items-center justify-center gap-3 py-16 text-sm text-slate-500">
+        <span
+          aria-hidden="true"
+          className="h-5 w-5 animate-spin rounded-full border-2 border-slate-300 border-t-indigo-600"
+        />
+        読み込み中...
+      </div>
+    );
   }
   if (error) {
-    return <p role="alert">エラー: {error}</p>;
+    return (
+      <p
+        role="alert"
+        className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+      >
+        エラー: {error}
+      </p>
+    );
   }
   if (!detail) {
-    return <p>アクティビティが見つかりません</p>;
+    return (
+      <p className="rounded-xl border border-slate-200 bg-white px-4 py-12 text-center text-sm text-slate-500 shadow-sm">
+        アクティビティが見つかりません
+      </p>
+    );
   }
 
   const { activity, splits } = detail;
@@ -207,61 +226,93 @@ export default function ActivityDetail() {
     setHover(seqNo == null ? null : { source: "map", value: seqNo });
   };
 
-  return (
-    <div>
-      <p>
-        <Link to="/">← アクティビティ一覧</Link>
-      </p>
-      <h1>
-        {activity.activity_name ?? "アクティビティ"} ({activity.activity_date})
-      </h1>
+  const kpis: { label: string; value: string }[] = [
+    { label: "距離", value: formatDistance(activity.total_distance_km) },
+    { label: "時間", value: formatDuration(activity.total_time_seconds) },
+    { label: "平均ペース", value: formatPace(activity.avg_pace_seconds_per_km) },
+    {
+      label: "平均心拍",
+      value: `${activity.avg_heart_rate ?? "-"} bpm`,
+    },
+  ];
 
-      {/* KPI header */}
-      <dl className="kpi-header">
-        <div>
-          <dt>距離</dt>
-          <dd>{formatDistance(activity.total_distance_km)}</dd>
-        </div>
-        <div>
-          <dt>時間</dt>
-          <dd>{formatDuration(activity.total_time_seconds)}</dd>
-        </div>
-        <div>
-          <dt>平均ペース</dt>
-          <dd>{formatPace(activity.avg_pace_seconds_per_km)}</dd>
-        </div>
-        <div>
-          <dt>平均心拍</dt>
-          <dd>{activity.avg_heart_rate ?? "-"} bpm</dd>
-        </div>
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link
+          to="/"
+          className="text-sm font-medium text-indigo-600 hover:text-indigo-800"
+        >
+          ← アクティビティ一覧
+        </Link>
+        <h1 className="mt-2 text-xl font-bold text-slate-900">
+          {activity.activity_name ?? "アクティビティ"}{" "}
+          <span className="font-normal text-slate-500">
+            ({activity.activity_date})
+          </span>
+        </h1>
+      </div>
+
+      {/* KPI header: 4 stat cards */}
+      <dl className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        {kpis.map(({ label, value }) => (
+          <div
+            key={label}
+            className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+          >
+            <dt className="text-xs font-medium tracking-wide text-slate-500 uppercase">
+              {label}
+            </dt>
+            <dd className="mt-1 text-2xl font-semibold tabular-nums text-slate-900">
+              {value}
+            </dd>
+          </div>
+        ))}
       </dl>
 
       {/* GPS track map (placeholder when the activity has no GPS data) */}
       {track !== null && (
-        <section>
-          <h2>コース</h2>
-          <MapPanel
-            points={track}
-            hoverSeqNo={mapHoverSeqNo}
-            onHoverSeqNo={handleMapHover}
-          />
+        <section className="rounded-xl border border-slate-200 bg-white shadow-sm">
+          <h2 className="px-5 pt-4 pb-2 text-base font-semibold text-slate-800">
+            コース
+          </h2>
+          <div className="overflow-hidden rounded-b-xl">
+            <MapPanel
+              points={track}
+              hoverSeqNo={mapHoverSeqNo}
+              onHoverSeqNo={handleMapHover}
+            />
+          </div>
         </section>
       )}
 
       {/* Time series chart with metric toggles */}
-      <section>
-        <h2>タイムシリーズ</h2>
-        <div className="metric-toggles">
-          {AVAILABLE_METRICS.map(({ key, label }) => (
-            <label key={key} style={{ marginRight: "1em" }}>
-              <input
-                type="checkbox"
-                checked={selectedMetrics.includes(key)}
-                onChange={() => toggleMetric(key)}
-              />
-              {label}
-            </label>
-          ))}
+      <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 text-base font-semibold text-slate-800">
+          タイムシリーズ
+        </h2>
+        <div className="mb-4 flex flex-wrap gap-2">
+          {AVAILABLE_METRICS.map(({ key, label }) => {
+            const checked = selectedMetrics.includes(key);
+            return (
+              <label
+                key={key}
+                className={`inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1 text-sm transition-colors ${
+                  checked
+                    ? "border-indigo-200 bg-indigo-50 text-indigo-700"
+                    : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  className="accent-indigo-600"
+                  checked={checked}
+                  onChange={() => toggleMetric(key)}
+                />
+                {label}
+              </label>
+            );
+          })}
         </div>
         {timeSeries && Object.keys(timeSeries.metrics).length > 0 ? (
           <TimeSeriesChart
@@ -271,34 +322,50 @@ export default function ActivityDetail() {
             onHoverIndex={handleChartHover}
           />
         ) : (
-          <p>表示する指標を選択してください</p>
+          <p className="py-8 text-center text-sm text-slate-500">
+            表示する指標を選択してください
+          </p>
         )}
       </section>
 
       {/* Splits table */}
       {splits.length > 0 && (
-        <section>
-          <h2>スプリット</h2>
-          <table>
+        <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 className="mb-3 text-base font-semibold text-slate-800">
+            スプリット
+          </h2>
+          <table className="w-full text-sm">
             <thead>
-              <tr>
-                <th>#</th>
-                <th>距離</th>
-                <th>ペース</th>
-                <th>心拍</th>
-                <th>ケイデンス</th>
-                <th>パワー</th>
+              <tr className="text-xs tracking-wide text-slate-500 uppercase">
+                <th className="px-2 py-2 text-left font-medium">#</th>
+                <th className="px-2 py-2 text-right font-medium">距離</th>
+                <th className="px-2 py-2 text-right font-medium">ペース</th>
+                <th className="px-2 py-2 text-right font-medium">心拍</th>
+                <th className="px-2 py-2 text-right font-medium">ケイデンス</th>
+                <th className="px-2 py-2 text-right font-medium">パワー</th>
               </tr>
             </thead>
-            <tbody>
+            <tbody className="divide-y divide-slate-100">
               {splits.map((split) => (
-                <tr key={split.split_index}>
-                  <td>{split.split_index}</td>
-                  <td>{formatDistance(split.distance)}</td>
-                  <td>{formatPace(split.pace_seconds_per_km)}</td>
-                  <td>{split.heart_rate ?? "-"}</td>
-                  <td>{split.cadence ?? "-"}</td>
-                  <td>{split.power ?? "-"}</td>
+                <tr key={split.split_index} className="hover:bg-slate-50">
+                  <td className="px-2 py-2 text-left tabular-nums text-slate-500">
+                    {split.split_index}
+                  </td>
+                  <td className="px-2 py-2 text-right tabular-nums">
+                    {formatDistance(split.distance)}
+                  </td>
+                  <td className="px-2 py-2 text-right tabular-nums">
+                    {formatPace(split.pace_seconds_per_km)}
+                  </td>
+                  <td className="px-2 py-2 text-right tabular-nums">
+                    {split.heart_rate ?? "-"}
+                  </td>
+                  <td className="px-2 py-2 text-right tabular-nums">
+                    {split.cadence ?? "-"}
+                  </td>
+                  <td className="px-2 py-2 text-right tabular-nums">
+                    {split.power ?? "-"}
+                  </td>
                 </tr>
               ))}
             </tbody>
@@ -309,14 +376,16 @@ export default function ActivityDetail() {
       {/* Section analysis cards */}
       {sections && Object.keys(sections).length > 0 && (
         <section>
-          <h2>分析</h2>
-          {orderedSectionTypes(sections).map((sectionType) => (
-            <SectionCard
-              key={sectionType}
-              sectionType={sectionType}
-              section={sections[sectionType]}
-            />
-          ))}
+          <h2 className="mb-3 text-base font-semibold text-slate-800">分析</h2>
+          <div className="space-y-4">
+            {orderedSectionTypes(sections).map((sectionType) => (
+              <SectionCard
+                key={sectionType}
+                sectionType={sectionType}
+                section={sections[sectionType]}
+              />
+            ))}
+          </div>
         </section>
       )}
     </div>

--- a/packages/garmin-web/frontend/src/pages/ActivityList.test.tsx
+++ b/packages/garmin-web/frontend/src/pages/ActivityList.test.tsx
@@ -50,9 +50,9 @@ describe("ActivityList", () => {
     expect(await screen.findByText("2025-10-09")).toBeInTheDocument();
     expect(screen.getByText("2025-10-07")).toBeInTheDocument();
 
-    // 2 data rows + 1 header row in the single 2025-10 month group
-    const rows = screen.getAllByRole("row");
-    expect(rows).toHaveLength(3);
+    // 2 activity row cards in the single 2025-10 month group
+    const rows = screen.getAllByRole("listitem");
+    expect(rows).toHaveLength(2);
 
     // Month grouping heading
     expect(

--- a/packages/garmin-web/frontend/src/pages/ActivityList.tsx
+++ b/packages/garmin-web/frontend/src/pages/ActivityList.tsx
@@ -66,49 +66,68 @@ export default function ActivityList() {
   }, []);
 
   if (loading) {
-    return <p>読み込み中...</p>;
+    return (
+      <div className="flex items-center justify-center gap-3 py-16 text-sm text-slate-500">
+        <span
+          aria-hidden="true"
+          className="h-5 w-5 animate-spin rounded-full border-2 border-slate-300 border-t-indigo-600"
+        />
+        読み込み中...
+      </div>
+    );
   }
   if (error) {
-    return <p role="alert">エラー: {error}</p>;
+    return (
+      <p
+        role="alert"
+        className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+      >
+        エラー: {error}
+      </p>
+    );
   }
   if (activities.length === 0) {
-    return <p>アクティビティがありません</p>;
+    return (
+      <p className="rounded-xl border border-slate-200 bg-white px-4 py-12 text-center text-sm text-slate-500 shadow-sm">
+        アクティビティがありません
+      </p>
+    );
   }
 
   const groups = groupByMonth(activities);
 
   return (
     <div>
-      <h1>アクティビティ一覧</h1>
+      <h1 className="mb-6 text-xl font-bold text-slate-900">
+        アクティビティ一覧
+      </h1>
       {[...groups.entries()].map(([month, monthActivities]) => (
-        <section key={month}>
-          <h2>{month}</h2>
-          <table>
-            <thead>
-              <tr>
-                <th>日付</th>
-                <th>名前</th>
-                <th>距離</th>
-                <th>ペース</th>
-                <th>平均HR</th>
-              </tr>
-            </thead>
-            <tbody>
-              {monthActivities.map((activity) => (
-                <tr
-                  key={activity.activity_id}
-                  onClick={() => navigate(`/activities/${activity.activity_id}`)}
-                  style={{ cursor: "pointer" }}
-                >
-                  <td>{activity.activity_date}</td>
-                  <td>{activity.activity_name ?? "-"}</td>
-                  <td>{formatDistance(activity.total_distance_km)}</td>
-                  <td>{formatPace(activity.avg_pace_seconds_per_km)}</td>
-                  <td>{activity.avg_heart_rate ?? "-"}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <section key={month} className="mb-8">
+          <h2 className="mb-2 text-sm font-semibold text-slate-500">{month}</h2>
+          <ul className="space-y-2">
+            {monthActivities.map((activity) => (
+              <li
+                key={activity.activity_id}
+                onClick={() => navigate(`/activities/${activity.activity_id}`)}
+                className="flex cursor-pointer items-center gap-4 rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm transition-shadow hover:shadow-md"
+              >
+                <span className="shrink-0 rounded-md bg-indigo-50 px-2 py-1 text-xs font-semibold tabular-nums text-indigo-700">
+                  {activity.activity_date}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-sm font-medium text-slate-800">
+                  {activity.activity_name ?? "-"}
+                </span>
+                <span className="flex shrink-0 items-baseline gap-4 text-right text-sm tabular-nums text-slate-600">
+                  <span>{formatDistance(activity.total_distance_km)}</span>
+                  <span>{formatPace(activity.avg_pace_seconds_per_km)}</span>
+                  <span>
+                    {activity.avg_heart_rate ?? "-"}
+                    <span className="ml-0.5 text-xs text-slate-400">bpm</span>
+                  </span>
+                </span>
+              </li>
+            ))}
+          </ul>
         </section>
       ))}
     </div>

--- a/packages/garmin-web/frontend/src/pages/TrendsDashboard.tsx
+++ b/packages/garmin-web/frontend/src/pages/TrendsDashboard.tsx
@@ -60,26 +60,45 @@ export default function TrendsDashboard() {
   }, []);
 
   if (error) {
-    return <p role="alert">エラー: {error}</p>;
+    return (
+      <p
+        role="alert"
+        className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+      >
+        エラー: {error}
+      </p>
+    );
   }
 
   const loading =
     volume == null || physiology == null || form == null || efficiency == null;
   if (loading) {
-    return <p>読み込み中...</p>;
+    return (
+      <div className="flex items-center justify-center gap-3 py-16 text-sm text-slate-500">
+        <span
+          aria-hidden="true"
+          className="h-5 w-5 animate-spin rounded-full border-2 border-slate-300 border-t-indigo-600"
+        />
+        読み込み中...
+      </div>
+    );
   }
 
   return (
     <div>
-      <h1>トレンドダッシュボード</h1>
-      <VolumeBlock
-        data={volume}
-        granularity={granularity}
-        onGranularityChange={setGranularity}
-      />
-      <PhysiologyBlock data={physiology} />
-      <FormBlock data={form} />
-      <EfficiencyBlock data={efficiency} />
+      <h1 className="mb-6 text-xl font-bold text-slate-900">
+        トレンドダッシュボード
+      </h1>
+      <div className="grid gap-4 md:grid-cols-2">
+        <VolumeBlock
+          data={volume}
+          granularity={granularity}
+          onGranularityChange={setGranularity}
+        />
+        <PhysiologyBlock data={physiology} />
+        <FormBlock data={form} />
+        <EfficiencyBlock data={efficiency} />
+      </div>
     </div>
   );
 }

--- a/packages/garmin-web/frontend/src/pages/trends/EfficiencyBlock.tsx
+++ b/packages/garmin-web/frontend/src/pages/trends/EfficiencyBlock.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import EChart from "../../components/EChart";
+import { AXIS_STYLE, BASE_CHART_OPTION } from "../../components/chartTheme";
 import type { EfficiencyTrendPoint } from "../../api/trends";
 
 interface EfficiencyBlockProps {
@@ -17,10 +18,15 @@ const ZONE_KEYS = [
 export default function EfficiencyBlock({ data }: EfficiencyBlockProps) {
   const option = useMemo(
     () => ({
+      ...BASE_CHART_OPTION,
       tooltip: { trigger: "axis" as const },
       legend: { data: ZONE_KEYS.map((_, i) => `Zone ${i + 1}`) },
-      xAxis: { type: "category" as const, data: data.map((p) => p.date) },
-      yAxis: { type: "value" as const, name: "%", max: 100 },
+      xAxis: {
+        type: "category" as const,
+        data: data.map((p) => p.date),
+        ...AXIS_STYLE,
+      },
+      yAxis: { type: "value" as const, name: "%", max: 100, ...AXIS_STYLE },
       series: ZONE_KEYS.map((key, i) => ({
         name: `Zone ${i + 1}`,
         type: "bar" as const,
@@ -32,10 +38,17 @@ export default function EfficiencyBlock({ data }: EfficiencyBlockProps) {
   );
 
   return (
-    <section aria-label="効率">
-      <h2>効率推移 (HRゾーン分布)</h2>
+    <section
+      aria-label="効率"
+      className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm"
+    >
+      <h2 className="mb-3 text-base font-semibold text-slate-800">
+        効率推移 (HRゾーン分布)
+      </h2>
       {data.length === 0 ? (
-        <p>データがありません</p>
+        <p className="py-8 text-center text-sm text-slate-500">
+          データがありません
+        </p>
       ) : (
         <EChart option={option} ariaLabel="HRゾーン分布の積み上げ棒グラフ" />
       )}

--- a/packages/garmin-web/frontend/src/pages/trends/FormBlock.tsx
+++ b/packages/garmin-web/frontend/src/pages/trends/FormBlock.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import EChart from "../../components/EChart";
+import { AXIS_STYLE, BASE_CHART_OPTION } from "../../components/chartTheme";
 import type { FormTrendPoint } from "../../api/trends";
 
 interface FormBlockProps {
@@ -9,10 +10,15 @@ interface FormBlockProps {
 export default function FormBlock({ data }: FormBlockProps) {
   const option = useMemo(
     () => ({
+      ...BASE_CHART_OPTION,
       tooltip: { trigger: "axis" as const },
       legend: { data: ["総合スコア", "GCT Δ%", "VO Δcm", "VR Δ%"] },
-      xAxis: { type: "category" as const, data: data.map((p) => p.date) },
-      yAxis: { type: "value" as const, scale: true },
+      xAxis: {
+        type: "category" as const,
+        data: data.map((p) => p.date),
+        ...AXIS_STYLE,
+      },
+      yAxis: { type: "value" as const, scale: true, ...AXIS_STYLE },
       series: [
         {
           name: "総合スコア",
@@ -40,10 +46,17 @@ export default function FormBlock({ data }: FormBlockProps) {
   );
 
   return (
-    <section aria-label="フォーム">
-      <h2>フォームスコア推移</h2>
+    <section
+      aria-label="フォーム"
+      className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm"
+    >
+      <h2 className="mb-3 text-base font-semibold text-slate-800">
+        フォームスコア推移
+      </h2>
       {data.length === 0 ? (
-        <p>データがありません</p>
+        <p className="py-8 text-center text-sm text-slate-500">
+          データがありません
+        </p>
       ) : (
         <EChart option={option} ariaLabel="フォーム評価の折れ線グラフ" />
       )}

--- a/packages/garmin-web/frontend/src/pages/trends/PhysiologyBlock.tsx
+++ b/packages/garmin-web/frontend/src/pages/trends/PhysiologyBlock.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import EChart from "../../components/EChart";
+import { AXIS_STYLE, BASE_CHART_OPTION } from "../../components/chartTheme";
 import type { PhysiologyTrend } from "../../api/trends";
 
 interface PhysiologyBlockProps {
@@ -9,12 +10,23 @@ interface PhysiologyBlockProps {
 export default function PhysiologyBlock({ data }: PhysiologyBlockProps) {
   const option = useMemo(
     () => ({
+      ...BASE_CHART_OPTION,
       tooltip: { trigger: "axis" as const },
       legend: { data: ["VO2max", "LT心拍"] },
-      xAxis: { type: "category" as const, data: data.vo2max.map((p) => p.date) },
+      xAxis: {
+        type: "category" as const,
+        data: data.vo2max.map((p) => p.date),
+        ...AXIS_STYLE,
+      },
       yAxis: [
-        { type: "value" as const, name: "VO2max", scale: true },
-        { type: "value" as const, name: "LT心拍 (bpm)", scale: true },
+        { type: "value" as const, name: "VO2max", scale: true, ...AXIS_STYLE },
+        {
+          type: "value" as const,
+          name: "LT心拍 (bpm)",
+          scale: true,
+          ...AXIS_STYLE,
+          splitLine: { show: false },
+        },
       ],
       series: [
         {
@@ -38,14 +50,21 @@ export default function PhysiologyBlock({ data }: PhysiologyBlockProps) {
     data.vo2max.length === 0 && data.lactate_threshold.length === 0;
 
   return (
-    <section aria-label="生理指標">
-      <h2>生理指標 (VO2max / 乳酸閾値)</h2>
+    <section
+      aria-label="生理指標"
+      className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm"
+    >
+      <h2 className="mb-3 text-base font-semibold text-slate-800">
+        生理指標 (VO2max / 乳酸閾値)
+      </h2>
       {isEmpty ? (
-        <p>データがありません</p>
+        <p className="py-8 text-center text-sm text-slate-500">
+          データがありません
+        </p>
       ) : (
         <>
           {latestVo2max?.value != null && (
-            <p>
+            <p className="mb-2 text-sm text-slate-600">
               最新VO2max: {latestVo2max.value.toFixed(1)} ({latestVo2max.date})
             </p>
           )}

--- a/packages/garmin-web/frontend/src/pages/trends/VolumeBlock.tsx
+++ b/packages/garmin-web/frontend/src/pages/trends/VolumeBlock.tsx
@@ -1,11 +1,20 @@
 import { useMemo } from "react";
 import EChart from "../../components/EChart";
+import { AXIS_STYLE, BASE_CHART_OPTION } from "../../components/chartTheme";
 import type { Granularity, VolumeTrendPoint } from "../../api/trends";
 
 interface VolumeBlockProps {
   data: VolumeTrendPoint[];
   granularity: Granularity;
   onGranularityChange: (granularity: Granularity) => void;
+}
+
+function toggleClass(active: boolean): string {
+  const base =
+    "rounded-md px-3 py-1 text-sm font-medium transition-colors cursor-pointer";
+  return active
+    ? `${base} bg-white text-indigo-700 shadow-sm`
+    : `${base} text-slate-600 hover:text-slate-900`;
 }
 
 export default function VolumeBlock({
@@ -15,14 +24,20 @@ export default function VolumeBlock({
 }: VolumeBlockProps) {
   const option = useMemo(
     () => ({
+      ...BASE_CHART_OPTION,
       tooltip: { trigger: "axis" as const },
-      xAxis: { type: "category" as const, data: data.map((p) => p.bucket) },
-      yAxis: { type: "value" as const, name: "km" },
+      xAxis: {
+        type: "category" as const,
+        data: data.map((p) => p.bucket),
+        ...AXIS_STYLE,
+      },
+      yAxis: { type: "value" as const, name: "km", ...AXIS_STYLE },
       series: [
         {
           name: "距離 (km)",
           type: "bar" as const,
           data: data.map((p) => p.distance_km),
+          itemStyle: { borderRadius: [3, 3, 0, 0] },
         },
       ],
     }),
@@ -30,29 +45,42 @@ export default function VolumeBlock({
   );
 
   return (
-    <section aria-label="走行量">
-      <h2>走行量</h2>
-      <div role="group" aria-label="集計単位">
-        <button
-          type="button"
-          aria-pressed={granularity === "week"}
-          onClick={() => onGranularityChange("week")}
+    <section
+      aria-label="走行量"
+      className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm"
+    >
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h2 className="text-base font-semibold text-slate-800">走行量</h2>
+        <div
+          role="group"
+          aria-label="集計単位"
+          className="inline-flex rounded-lg border border-slate-200 bg-slate-100 p-0.5"
         >
-          週
-        </button>
-        <button
-          type="button"
-          aria-pressed={granularity === "month"}
-          onClick={() => onGranularityChange("month")}
-        >
-          月
-        </button>
+          <button
+            type="button"
+            aria-pressed={granularity === "week"}
+            className={toggleClass(granularity === "week")}
+            onClick={() => onGranularityChange("week")}
+          >
+            週
+          </button>
+          <button
+            type="button"
+            aria-pressed={granularity === "month"}
+            className={toggleClass(granularity === "month")}
+            onClick={() => onGranularityChange("month")}
+          >
+            月
+          </button>
+        </div>
       </div>
       {data.length === 0 ? (
-        <p>データがありません</p>
+        <p className="py-8 text-center text-sm text-slate-500">
+          データがありません
+        </p>
       ) : (
         <>
-          <p>
+          <p className="mb-2 text-sm text-slate-600">
             直近{granularity === "week" ? "週" : "月"} ({data[data.length - 1].bucket}
             ): {data[data.length - 1].distance_km.toFixed(1)} km /{" "}
             {data[data.length - 1].run_count} 回

--- a/packages/garmin-web/frontend/vite.config.ts
+++ b/packages/garmin-web/frontend/vite.config.ts
@@ -1,8 +1,9 @@
+import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   server: {
     proxy: {
       "/api": "http://127.0.0.1:8765",


### PR DESCRIPTION
Closes #210

ユーザーフィードバック「スタイルがほとんどあたっていない」への対応。Tailwind CSS v4（@tailwindcss/vite）を導入し、全画面をライト・クリーンテーマで刷新。

## 変更内容

- **テーマ基盤**: `index.css`（Tailwind + 日本語フォントスタック + markdown-body スタイル）、`chartTheme.ts`（ECharts を indigo/sky/emerald/amber 系に統一）
- **共通 Layout**: sticky 白ヘッダー + ブランド + NavLink ナビ（アクティブ状態、`aria-current`）+ `max-w-5xl` コンテナ。leaflet 対策の `z-[1100]`
- **一覧**: テーブル → 行カード（日付バッジ + 距離/ペース/HR 右寄せ `tabular-nums`、hover で浮く）
- **詳細**: KPI 4枚のスタットカード、各セクションをカードで包み、メトリクストグルをピル型に
- **トレンド**: カードグリッド + セグメントコントロール風トグル
- **状態表示**: スピナー + `role="alert"` スタイル統一
- ロジック（API/hooks/formatters/hover連動）は無変更

## 検証（L2 相当 — オーケストレーターが独立実行で確認済み）

| チェック | 結果 |
|---|---|
| `vitest run` | 10 passed（新規 Layout テスト含む） |
| `tsc + vite build` | pass |
| backend `pytest -m "unit or integration"` | 32 passed（無変更確認） |
| `ruff check` | clean |

## 設計からの逸脱（理由付き）

- ActivityList テストのセレクタを row → listitem に変更（行カード化のため。アサーションの意味は維持）
- `chartTheme.ts` / `Layout.test.tsx` を追加（配色トークンの重複排除とテスト置き場）
- `index.html` の title を「Garmin Performance」に変更（ヘッダーと整合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)