### PR TITLE
feat(form): make cadence evaluation pace-dependent (trained baseline)

### DIFF
--- a/packages/garmin-mcp-server/src/garmin_mcp/database/db_writer.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/database/db_writer.py
@@ -335,6 +335,13 @@ class GarminDBWriter:
                     cadence_minimum INTEGER DEFAULT 180,
                     cadence_achieved BOOLEAN,
 
+                    cadence_expected DOUBLE,
+                    cadence_delta_pct DOUBLE,
+                    cadence_star_rating VARCHAR,
+                    cadence_score DOUBLE,
+                    cadence_needs_improvement BOOLEAN,
+                    cadence_evaluation_text VARCHAR,
+
                     overall_score FLOAT,
                     overall_star_rating VARCHAR,
 

--- a/packages/garmin-mcp-server/src/garmin_mcp/database/migrations/add_cadence_columns.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/database/migrations/add_cadence_columns.py
@@ -1,0 +1,61 @@
+"""Migration: Add pace-dependent cadence evaluation columns to form_evaluations.
+
+Adds expected/delta/star/score/needs_improvement/evaluation_text columns for
+cadence, mirroring the GCT/VO/VR structure. The legacy cadence_actual,
+cadence_minimum and cadence_achieved columns are retained for backward
+compatibility.
+"""
+
+from pathlib import Path
+
+import duckdb
+
+from garmin_mcp.database.connection import get_write_connection
+
+CADENCE_COLUMNS: list[tuple[str, str]] = [
+    ("cadence_expected", "DOUBLE"),
+    ("cadence_delta_pct", "DOUBLE"),
+    ("cadence_star_rating", "VARCHAR"),
+    ("cadence_score", "DOUBLE"),
+    ("cadence_needs_improvement", "BOOLEAN"),
+    ("cadence_evaluation_text", "VARCHAR"),
+]
+
+
+def add_cadence_columns(conn: duckdb.DuckDBPyConnection) -> None:
+    """Add pace-dependent cadence columns to form_evaluations (idempotent)."""
+    for col_name, col_type in CADENCE_COLUMNS:
+        conn.execute(
+            f"ALTER TABLE form_evaluations "
+            f"ADD COLUMN IF NOT EXISTS {col_name} {col_type}"
+        )
+
+
+def migrate_cadence_schema(db_path: str | None = None) -> None:
+    """Add pace-dependent cadence columns to form_evaluations table.
+
+    Args:
+        db_path: Path to DuckDB database. If None, uses
+            GARMIN_DATA_DIR/database/garmin_performance.duckdb
+
+    Raises:
+        FileNotFoundError: If database file does not exist
+    """
+    if db_path is None:
+        from garmin_mcp.utils.paths import get_default_db_path
+
+        db_path = get_default_db_path()
+
+    if not Path(db_path).exists():
+        raise FileNotFoundError(f"Database not found: {db_path}")
+
+    with get_write_connection(db_path) as conn:
+        add_cadence_columns(conn)
+        print("✅ Cadence columns migration completed successfully")
+        for col_name, col_type in CADENCE_COLUMNS:
+            print(f"   - Added {col_name} ({col_type}) to form_evaluations")
+
+
+if __name__ == "__main__":
+    """Run migration on production database."""
+    migrate_cadence_schema()

--- a/packages/garmin-mcp-server/src/garmin_mcp/database/migrations/registry.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/database/migrations/registry.py
@@ -86,6 +86,13 @@ def _wrap_remove_fk(conn: duckdb.DuckDBPyConnection) -> None:
     pass
 
 
+def _wrap_add_cadence_columns(conn: duckdb.DuckDBPyConnection) -> None:
+    """Wrap cadence columns migration to run on an existing connection."""
+    from .add_cadence_columns import add_cadence_columns
+
+    add_cadence_columns(conn)
+
+
 def _wrap_plan_versioning(conn: duckdb.DuckDBPyConnection) -> None:
     """Wrap plan versioning migration to run on an existing connection."""
     from .add_plan_versioning import _column_exists, _table_exists
@@ -129,4 +136,5 @@ MIGRATIONS: list[tuple[int, str, Callable[[duckdb.DuckDBPyConnection], None]]] =
     (3, "phase2_integrated_score", _wrap_phase2),
     (4, "remove_fk_constraints", _wrap_remove_fk),
     (5, "add_plan_versioning", _wrap_plan_versioning),
+    (6, "add_cadence_columns", _wrap_add_cadence_columns),
 ]

--- a/packages/garmin-mcp-server/src/garmin_mcp/database/readers/form.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/database/readers/form.py
@@ -102,8 +102,23 @@ class FormReader(BaseDBReader):
         """
         try:
             with self._get_connection() as conn:
+                # Detect pace-dependent cadence columns (backward compatible
+                # with older databases that predate the cadence migration).
+                schema = conn.execute("PRAGMA table_info(form_evaluations)").fetchall()
+                column_names = {row[1] for row in schema}
+                has_cadence_cols = "cadence_expected" in column_names
+
+                cadence_select = (
+                    """,
+                        cadence_expected, cadence_delta_pct, cadence_star_rating,
+                        cadence_score, cadence_needs_improvement,
+                        cadence_evaluation_text"""
+                    if has_cadence_cols
+                    else ""
+                )
+
                 result = conn.execute(
-                    """
+                    f"""
                     SELECT
                         gct_ms_expected, gct_ms_actual, gct_delta_pct,
                         gct_star_rating, gct_score, gct_needs_improvement,
@@ -119,7 +134,7 @@ class FormReader(BaseDBReader):
                         power_avg_w, power_wkg, speed_actual_mps, speed_expected_mps,
                         power_efficiency_score, power_efficiency_rating,
                         power_efficiency_needs_improvement,
-                        integrated_score, training_mode
+                        integrated_score, training_mode{cadence_select}
                     FROM form_evaluations
                     WHERE activity_id = ?
                     """,
@@ -168,6 +183,13 @@ class FormReader(BaseDBReader):
                         "actual": result[21],
                         "minimum": result[22],
                         "achieved": result[23],
+                        # Pace-dependent fields only present on migrated DBs.
+                        "expected": result[35] if has_cadence_cols else None,
+                        "delta_pct": result[36] if has_cadence_cols else None,
+                        "star_rating": result[37] if has_cadence_cols else None,
+                        "score": result[38] if has_cadence_cols else None,
+                        "needs_improvement": (result[39] if has_cadence_cols else None),
+                        "evaluation_text": (result[40] if has_cadence_cols else None),
                     },
                     "power": {
                         "avg_w": result[26],

--- a/packages/garmin-mcp-server/src/garmin_mcp/form_baseline/evaluator.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/form_baseline/evaluator.py
@@ -49,7 +49,10 @@ def evaluate_and_store(
                     needs_improvement, evaluation_text}
             - vo: {same structure as gct}
             - vr: {same structure as gct}
-            - cadence: {actual, minimum, achieved}
+            - cadence: pace-dependent {actual, expected, delta_pct, star_rating,
+                       score, needs_improvement, evaluation_text} when a cadence
+                       baseline is available, otherwise legacy
+                       {actual, minimum, achieved}
             - overall_score: float (0-5.0)
             - overall_star_rating: str
 
@@ -77,6 +80,7 @@ def evaluate_and_store(
         "gct_ms": splits_data["gct_ms"],
         "vo_cm": splits_data["vo_cm"],
         "vr_pct": splits_data["vr_pct"],
+        "cadence": splits_data["cadence"],
     }
 
     # Predict expectations and score
@@ -132,8 +136,40 @@ def evaluate_and_store(
         gct_rating["score"] + vo_rating["score"] + vr_rating["score"]
     ) / 3.0
 
-    # Cadence evaluation
-    cadence_achieved = splits_data["cadence"] >= 180.0
+    # Cadence evaluation (pace-dependent when a cadence baseline is available).
+    # Falls back to the legacy fixed-180 flag when no cadence model exists
+    # (backward compatible with older databases / untrained activities).
+    has_cadence_model = "cadence" in models and "cadence_penalty" in score_result
+    if has_cadence_model:
+        cadence_rating = compute_star_rating(
+            penalty=score_result["cadence_penalty"],
+            delta_pct=score_result["cadence_delta_pct"],
+        )
+        cadence_text = generate_evaluation_text(
+            metric="cadence",
+            actual=score_result["cadence_actual"],
+            expected=score_result["cadence_exp"],
+            delta_pct=score_result["cadence_delta_pct"],
+            pace_s_per_km=splits_data["pace_s_per_km"],
+            star_rating=cadence_rating["star_rating"],
+            score=cadence_rating["score"],
+        )
+        cadence_eval = {
+            "actual": score_result["cadence_actual"],
+            "expected": score_result["cadence_exp"],
+            "delta_pct": score_result["cadence_delta_pct"],
+            "star_rating": cadence_rating["star_rating"],
+            "score": cadence_rating["score"],
+            "needs_improvement": score_result["cadence_needs_improvement"],
+            "evaluation_text": cadence_text,
+        }
+    else:
+        # Legacy behaviour: no cadence baseline available.
+        cadence_eval = {
+            "actual": splits_data["cadence"],
+            "minimum": 180,
+            "achieved": splits_data["cadence"] >= 180.0,
+        }
 
     # Build result dictionary
     evaluation = {
@@ -167,11 +203,7 @@ def evaluate_and_store(
             "needs_improvement": score_result["vr_needs_improvement"],
             "evaluation_text": vr_text,
         },
-        "cadence": {
-            "actual": splits_data["cadence"],
-            "minimum": 180,
-            "achieved": cadence_achieved,
-        },
+        "cadence": cadence_eval,
         "overall_score": overall_score,
         "overall_star_rating": compute_star_rating(
             penalty=(5.0 - overall_score) * 20.0,
@@ -277,6 +309,8 @@ def evaluate_and_store(
                 vo_penalty, vo_star_rating, vo_score, vo_needs_improvement, vo_evaluation_text,
                 vr_penalty, vr_star_rating, vr_score, vr_needs_improvement, vr_evaluation_text,
                 cadence_actual, cadence_minimum, cadence_achieved,
+                cadence_expected, cadence_delta_pct, cadence_star_rating,
+                cadence_score, cadence_needs_improvement, cadence_evaluation_text,
                 overall_score, overall_star_rating,
                 power_avg_w, power_wkg, speed_actual_mps, speed_expected_mps,
                 power_efficiency_score, power_efficiency_rating, power_efficiency_needs_improvement,
@@ -284,6 +318,7 @@ def evaluate_and_store(
             ) VALUES (
                 nextval('form_evaluations_seq'),
                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?,
                 ?, ?, ?, ?, ?, ?, ?, ?, ?
             )
             ON CONFLICT (activity_id) DO UPDATE SET
@@ -314,6 +349,12 @@ def evaluate_and_store(
                 cadence_actual = EXCLUDED.cadence_actual,
                 cadence_minimum = EXCLUDED.cadence_minimum,
                 cadence_achieved = EXCLUDED.cadence_achieved,
+                cadence_expected = EXCLUDED.cadence_expected,
+                cadence_delta_pct = EXCLUDED.cadence_delta_pct,
+                cadence_star_rating = EXCLUDED.cadence_star_rating,
+                cadence_score = EXCLUDED.cadence_score,
+                cadence_needs_improvement = EXCLUDED.cadence_needs_improvement,
+                cadence_evaluation_text = EXCLUDED.cadence_evaluation_text,
                 overall_score = EXCLUDED.overall_score,
                 overall_star_rating = EXCLUDED.overall_star_rating,
                 power_avg_w = EXCLUDED.power_avg_w,
@@ -359,10 +400,19 @@ def evaluate_and_store(
                 evaluation["vr"]["score"],
                 evaluation["vr"]["needs_improvement"],
                 evaluation["vr"]["evaluation_text"],
-                # Cadence
+                # Cadence (legacy columns retained for backward compatibility)
                 evaluation["cadence"]["actual"],
-                evaluation["cadence"]["minimum"],
-                evaluation["cadence"]["achieved"],
+                evaluation["cadence"].get("minimum", 180),
+                evaluation["cadence"].get(
+                    "achieved", evaluation["cadence"]["actual"] >= 180.0
+                ),
+                # Cadence (pace-dependent columns; None when no cadence model)
+                evaluation["cadence"].get("expected"),
+                evaluation["cadence"].get("delta_pct"),
+                evaluation["cadence"].get("star_rating"),
+                evaluation["cadence"].get("score"),
+                evaluation["cadence"].get("needs_improvement"),
+                evaluation["cadence"].get("evaluation_text"),
                 # Overall
                 evaluation["overall_score"],
                 evaluation["overall_star_rating"],

--- a/packages/garmin-mcp-server/src/garmin_mcp/form_baseline/model_loader.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/form_baseline/model_loader.py
@@ -20,7 +20,9 @@ def load_models_from_file(
         model_file: Path to JSON file with model coefficients
 
     Returns:
-        Dictionary of models: {'gct': GCTPowerModel, 'vo': LinearModel, 'vr': LinearModel}
+        Dictionary of models: {'gct': GCTPowerModel, 'vo': LinearModel,
+        'vr': LinearModel}. May also contain 'cadence': LinearModel when a
+        cadence baseline is available (optional for backward compatibility).
 
     Raises:
         FileNotFoundError: If model file doesn't exist
@@ -62,11 +64,27 @@ def load_models_from_file(
         speed_range=(vr_data["speed_range"]["min"], vr_data["speed_range"]["max"]),
     )
 
-    return {
+    models: dict[str, GCTPowerModel | LinearModel] = {
         "gct": gct_model,
         "vo": vo_model,
         "vr": vr_model,
     }
+
+    # Cadence model is optional (backward compatible with older model files)
+    cadence_data = data.get("cadence")
+    if cadence_data is not None:
+        models["cadence"] = LinearModel(
+            a=cadence_data["a"],
+            b=cadence_data["b"],
+            rmse=cadence_data["rmse"],
+            n_samples=cadence_data["n_samples"],
+            speed_range=(
+                cadence_data["speed_range"]["min"],
+                cadence_data["speed_range"]["max"],
+            ),
+        )
+
+    return models
 
 
 def load_models_from_db(
@@ -87,7 +105,9 @@ def load_models_from_db(
         condition_group: Condition group name (default: 'flat_road')
 
     Returns:
-        Dictionary of models: {'gct': GCTPowerModel, 'vo': LinearModel, 'vr': LinearModel}
+        Dictionary of models: {'gct': GCTPowerModel, 'vo': LinearModel,
+        'vr': LinearModel}. May also contain 'cadence': LinearModel when a
+        cadence baseline is available (optional for backward compatibility).
 
     Raises:
         ValueError: If no baseline found for the activity date
@@ -148,9 +168,18 @@ def load_models_from_db(
                     n_samples=int(n_samples),
                     speed_range=(float(speed_min), float(speed_max)),
                 )
+            elif metric == "cadence":
+                # Cadence is optional (backward compatible: absent in old DBs)
+                models["cadence"] = LinearModel(
+                    a=float(a),
+                    b=float(b),
+                    rmse=float(rmse),
+                    n_samples=int(n_samples),
+                    speed_range=(float(speed_min), float(speed_max)),
+                )
 
-        # Validate all metrics present
-        if len(models) != 3 or not all(m in models for m in ["gct", "vo", "vr"]):
+        # Validate core metrics present (cadence is optional)
+        if not all(m in models for m in ["gct", "vo", "vr"]):
             raise ValueError(
                 f"Incomplete baseline data. Found metrics: {list(models.keys())}"
             )

--- a/packages/garmin-mcp-server/src/garmin_mcp/form_baseline/predictor.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/form_baseline/predictor.py
@@ -26,6 +26,8 @@ def predict_expectations(
             - gct_ms_exp: Expected ground contact time (ms)
             - vo_cm_exp: Expected vertical oscillation (cm)
             - vr_pct_exp: Expected vertical ratio (%)
+            - cadence_exp: Expected cadence (spm), only present when a
+              'cadence' model is available (backward compatible)
 
     Example:
         >>> from garmin_mcp.form_baseline.trainer import train_models
@@ -51,10 +53,18 @@ def predict_expectations(
     assert isinstance(vr_model, LinearModel)
     vr_pct_exp = vr_model.predict(speed_mps)
 
-    return {
+    result = {
         "pace": pace_s_per_km,
         "speed_mps": speed_mps,
         "gct_ms_exp": gct_ms_exp,
         "vo_cm_exp": vo_cm_exp,
         "vr_pct_exp": vr_pct_exp,
     }
+
+    # Cadence is optional (backward compatible: absent in old baselines)
+    cadence_model = models.get("cadence")
+    if cadence_model is not None:
+        assert isinstance(cadence_model, LinearModel)
+        result["cadence_exp"] = cadence_model.predict(speed_mps)
+
+    return result

--- a/packages/garmin-mcp-server/src/garmin_mcp/form_baseline/scorer.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/form_baseline/scorer.py
@@ -14,23 +14,45 @@ from .predictor import predict_expectations
 from .trainer import GCTPowerModel, LinearModel
 
 # Penalty factors by direction.
-# Lower-than-expected (negative delta) = efficiency improvement → reduced penalty.
-# Higher-than-expected (positive delta) = degradation → full penalty.
-IMPROVEMENT_FACTOR: dict[str, float] = {"gct": 0.3, "vo": 0.3, "vr": 0.2}
-DEGRADATION_FACTOR: dict[str, float] = {"gct": 1.0, "vo": 1.0, "vr": 1.0}
+# For GCT/VO/VR: lower-than-expected (negative delta) = efficiency improvement
+#   → reduced penalty; higher-than-expected (positive delta) = degradation → full.
+# For cadence the direction is REVERSED: higher-than-expected (positive delta) =
+#   improvement → reduced penalty; lower-than-expected (negative delta) =
+#   degradation → full penalty.
+IMPROVEMENT_FACTOR: dict[str, float] = {
+    "gct": 0.3,
+    "vo": 0.3,
+    "vr": 0.2,
+    "cadence": 0.3,
+}
+DEGRADATION_FACTOR: dict[str, float] = {
+    "gct": 1.0,
+    "vo": 1.0,
+    "vr": 1.0,
+    "cadence": 1.0,
+}
 
 
 def _compute_penalty(metric: str, delta_pct: float) -> float:
     """Compute asymmetric penalty for a single metric.
 
+    For GCT/VO/VR a negative delta (actual < expected) is an improvement.
+    For cadence the direction is reversed: a positive delta (actual > expected)
+    is the improvement and a negative delta (actual < expected) is degradation.
+
     Args:
-        metric: 'gct', 'vo', or 'vr'
-        delta_pct: Percentage delta from expected (negative = improvement)
+        metric: 'gct', 'vo', 'vr', or 'cadence'
+        delta_pct: Percentage delta from expected
 
     Returns:
         Penalty score clamped to 0-100.
     """
-    factor = IMPROVEMENT_FACTOR[metric] if delta_pct < 0 else DEGRADATION_FACTOR[metric]
+    # Reversed direction for cadence: positive delta = improvement.
+    is_improvement = delta_pct > 0 if metric == "cadence" else delta_pct < 0
+
+    factor = (
+        IMPROVEMENT_FACTOR[metric] if is_improvement else DEGRADATION_FACTOR[metric]
+    )
     return max(0.0, min(100.0, abs(delta_pct) * factor * 10.0))
 
 
@@ -147,7 +169,7 @@ def score_observation(
     vo_needs_improvement = vo_penalty > 20.0
     vr_needs_improvement = vr_penalty > 20.0
 
-    return {
+    result = {
         **expectations,
         "gct_ms_actual": obs["gct_ms"],
         "vo_cm_actual": obs["vo_cm"],
@@ -164,6 +186,21 @@ def score_observation(
         "vo_needs_improvement": vo_needs_improvement,
         "vr_needs_improvement": vr_needs_improvement,
     }
+
+    # Cadence is an INDEPENDENT metric: it is NOT included in overall_score or
+    # the consistency adjustment. It is only scored when a cadence model is
+    # available and the observation provides a cadence value.
+    cadence_exp = expectations.get("cadence_exp")
+    if cadence_exp is not None and obs.get("cadence") is not None:
+        cadence_actual = obs["cadence"]
+        cadence_delta_pct = ((cadence_actual - cadence_exp) / cadence_exp) * 100.0
+        cadence_penalty = _compute_penalty("cadence", cadence_delta_pct)
+        result["cadence_actual"] = cadence_actual
+        result["cadence_delta_pct"] = cadence_delta_pct
+        result["cadence_penalty"] = cadence_penalty
+        result["cadence_needs_improvement"] = cadence_penalty > 20.0
+
+    return result
 
 
 def compute_star_rating(

--- a/packages/garmin-mcp-server/src/garmin_mcp/form_baseline/text_generator.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/form_baseline/text_generator.py
@@ -34,7 +34,7 @@ def generate_evaluation_text(
     and receive positive text, while higher-than-expected values indicate degradation.
 
     Args:
-        metric: 'gct', 'vo', or 'vr'
+        metric: 'gct', 'vo', 'vr', or 'cadence'
         actual: Actual measured value
         expected: Expected value from baseline model
         delta_pct: Delta percentage ((actual - expected) / expected * 100)
@@ -49,6 +49,16 @@ def generate_evaluation_text(
         >>> generate_evaluation_text('gct', 258.0, 261.0, -1.1, 431.0, '★★★★★', 5.0)
         '258msは期待値261ms±2%の理想範囲内です。適切な接地時間を維持できています。★★★★★'
     """
+    # Cadence has REVERSED semantics (higher cadence = better), so it is
+    # handled separately from the GCT/VO/VR efficiency metrics.
+    if metric == "cadence":
+        return _generate_cadence_text(
+            actual=actual,
+            expected=expected,
+            delta_pct=delta_pct,
+            star_rating=star_rating,
+        )
+
     # Metric-specific labels
     labels = {
         "gct": {
@@ -124,6 +134,61 @@ def generate_evaluation_text(
             f"{actual_str}{unit}は期待値{expected_str}{unit}より"
             f"{abs(delta_pct):.0f}%{direction}、大きく外れています。"
             f"フォームの不安定さが見られます。{label['improvement_action']}を推奨します。{star_rating}"
+        )
+
+    return text
+
+
+def _generate_cadence_text(
+    actual: float,
+    expected: float,
+    delta_pct: float,
+    star_rating: str,
+) -> str:
+    """Generate Japanese evaluation text for cadence.
+
+    Cadence has reversed semantics compared to GCT/VO/VR: a higher-than-expected
+    cadence (positive delta) is an improvement, while a lower-than-expected
+    cadence (negative delta) is degradation.
+
+    Args:
+        actual: Actual measured cadence (spm)
+        expected: Expected cadence from baseline model (spm)
+        delta_pct: Delta percentage ((actual - expected) / expected * 100)
+        star_rating: Star rating string (e.g., '★★★★★')
+
+    Returns:
+        Japanese evaluation text
+    """
+    actual_str = f"{actual:.0f}"
+    expected_str = f"{expected:.0f}"
+
+    if abs(delta_pct) <= 2:
+        text = (
+            f"{actual_str}spmは期待値{expected_str}spm±2%の理想範囲内です。"
+            f"適切なケイデンスを維持できています。{star_rating}"
+        )
+    elif delta_pct > 0 and abs(delta_pct) <= 5:
+        text = (
+            f"{actual_str}spmは期待値{expected_str}spmより"
+            f"{abs(delta_pct):.1f}%高く、効率的なピッチ走法です。{star_rating}"
+        )
+    elif delta_pct > 0:
+        text = (
+            f"{actual_str}spmは期待値{expected_str}spmより"
+            f"{abs(delta_pct):.0f}%高く、良好なケイデンスです。{star_rating}"
+        )
+    elif abs(delta_pct) <= 5:
+        text = (
+            f"{actual_str}spmは期待値{expected_str}spmより"
+            f"{abs(delta_pct):.1f}%低く、やや下回っています。"
+            f"ピッチをわずかに上げる余地があります。{star_rating}"
+        )
+    else:
+        text = (
+            f"{actual_str}spmは期待値{expected_str}spmより"
+            f"{abs(delta_pct):.0f}%低く、大きく下回っています。"
+            f"ピッチを上げる意識でケイデンスの改善を推奨します。{star_rating}"
         )
 
     return text

--- a/packages/garmin-mcp-server/src/garmin_mcp/form_baseline/trainer.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/form_baseline/trainer.py
@@ -140,13 +140,16 @@ def fit_gct_power(df: pd.DataFrame, fallback_ransac: bool = True) -> GCTPowerMod
     )
 
 
-def fit_linear(df: pd.DataFrame, metric: Literal["vo", "vr"]) -> LinearModel:
+def fit_linear(df: pd.DataFrame, metric: Literal["vo", "vr", "cadence"]) -> LinearModel:
     """
-    Train linear model for VO or VR.
+    Train linear model for VO, VR or cadence.
 
     Args:
         df: DataFrame with columns ['{metric}_value', 'speed_mps']
-        metric: 'vo' (Vertical Oscillation) or 'vr' (Vertical Ratio)
+        metric: 'vo' (Vertical Oscillation), 'vr' (Vertical Ratio) or
+            'cadence' (Step cadence). For cadence, b > 0 is expected
+            (faster speed -> higher cadence), but no monotonicity check
+            is enforced (linear fit only).
 
     Returns:
         LinearModel
@@ -161,6 +164,8 @@ def fit_linear(df: pd.DataFrame, metric: Literal["vo", "vr"]) -> LinearModel:
         df_clean = drop_outliers(df, column=column, valid_range=(2, 15))
     elif metric == "vr":
         df_clean = drop_outliers(df, column=column, valid_range=(2, 20))
+    elif metric == "cadence":
+        df_clean = drop_outliers(df, column=column, valid_range=(140.0, 210.0))
     else:
         raise ValueError(f"Unknown metric: {metric}")
 
@@ -371,6 +376,7 @@ def train_form_baselines(
             'gct': {'alpha': float, 'd': float, 'rmse': float, 'n_samples': int},
             'vo': {'a': float, 'b': float, 'rmse': float, 'n_samples': int},
             'vr': {'a': float, 'b': float, 'rmse': float, 'n_samples': int},
+            'cadence': {'a': float, 'b': float, 'rmse': float, 'n_samples': int},
             'power': {'power_a': float, 'power_b': float, 'power_rmse': float, 'n_samples': int},
             'period_start': str,
             'period_end': str,
@@ -442,6 +448,7 @@ def train_form_baselines(
                 df_clean, "vertical_oscillation", (5.0, 20.0)
             )
             df_clean = utils.drop_outliers(df_clean, "vertical_ratio", (4.0, 15.0))
+            df_clean = utils.drop_outliers(df_clean, "cadence", (140.0, 210.0))
 
             if len(df_clean) < 50:
                 # Insufficient data after outlier removal
@@ -454,11 +461,13 @@ def train_form_baselines(
             df_clean["gct_ms"] = df_clean["ground_contact_time"]
             df_clean["vo_value"] = df_clean["vertical_oscillation"]
             df_clean["vr_value"] = df_clean["vertical_ratio"]
+            df_clean["cadence_value"] = df_clean["cadence"]
 
-            # Train GCT, VO, VR models
+            # Train GCT, VO, VR, cadence models
             gct_model: GCTPowerModel = fit_gct_power(df_clean)
             vo_model: LinearModel = fit_linear(df_clean, "vo")
             vr_model: LinearModel = fit_linear(df_clean, "vr")
+            cadence_model: LinearModel = fit_linear(df_clean, "cadence")
 
             # Insert GCT model
             conn.execute(
@@ -580,6 +589,46 @@ def train_form_baselines(
                 ],
             )
 
+            # Insert cadence model
+            conn.execute(
+                """
+            INSERT INTO form_baseline_history (
+                history_id, user_id, condition_group, metric, model_type,
+                coef_alpha, coef_d, coef_a, coef_b,
+                period_start, period_end,
+                n_samples, rmse, speed_range_min, speed_range_max
+            ) VALUES (nextval('form_baseline_history_seq'), ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (user_id, condition_group, metric, period_start, period_end)
+            DO UPDATE SET
+                model_type = EXCLUDED.model_type,
+                coef_alpha = EXCLUDED.coef_alpha,
+                coef_d = EXCLUDED.coef_d,
+                coef_a = EXCLUDED.coef_a,
+                coef_b = EXCLUDED.coef_b,
+                n_samples = EXCLUDED.n_samples,
+                rmse = EXCLUDED.rmse,
+                speed_range_min = EXCLUDED.speed_range_min,
+                speed_range_max = EXCLUDED.speed_range_max,
+                trained_at = now()
+            """,
+                [
+                    user_id,
+                    condition_group,
+                    "cadence",
+                    "linear",
+                    None,
+                    None,
+                    cadence_model.a,
+                    cadence_model.b,
+                    period_start,
+                    period_end,
+                    cadence_model.n_samples,
+                    cadence_model.rmse,
+                    cadence_model.speed_range[0],
+                    cadence_model.speed_range[1],
+                ],
+            )
+
             # Train Power model
             power_result = train_power_efficiency_baseline(
                 user_id=user_id,
@@ -607,6 +656,12 @@ def train_form_baselines(
                     "b": vr_model.b,
                     "rmse": vr_model.rmse,
                     "n_samples": vr_model.n_samples,
+                },
+                "cadence": {
+                    "a": cadence_model.a,
+                    "b": cadence_model.b,
+                    "rmse": cadence_model.rmse,
+                    "n_samples": cadence_model.n_samples,
                 },
                 "period_start": period_start,
                 "period_end": period_end,

--- a/packages/garmin-mcp-server/tests/database/test_aggregate_power.py
+++ b/packages/garmin-mcp-server/tests/database/test_aggregate_power.py
@@ -69,6 +69,13 @@ def tmp_db_path(tmp_path: Path) -> str:
             cadence_minimum INTEGER DEFAULT 180,
             cadence_achieved BOOLEAN,
 
+            cadence_expected DOUBLE,
+            cadence_delta_pct DOUBLE,
+            cadence_star_rating VARCHAR,
+            cadence_score DOUBLE,
+            cadence_needs_improvement BOOLEAN,
+            cadence_evaluation_text VARCHAR,
+
             overall_score FLOAT,
             overall_star_rating VARCHAR,
 

--- a/packages/garmin-mcp-server/tests/database/test_cadence_columns_migration.py
+++ b/packages/garmin-mcp-server/tests/database/test_cadence_columns_migration.py
@@ -1,0 +1,71 @@
+"""Test migration that adds pace-dependent cadence columns to form_evaluations."""
+
+import duckdb
+import pytest
+
+
+@pytest.fixture
+def tmp_db_path(tmp_path):
+    """Create a temporary DuckDB database with legacy form_evaluations schema."""
+    db_path = tmp_path / "test_cadence.duckdb"
+    conn = duckdb.connect(str(db_path))
+
+    # Legacy form_evaluations with only the old cadence columns
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS form_evaluations (
+            activity_id INTEGER PRIMARY KEY,
+            cadence_actual FLOAT,
+            cadence_minimum INTEGER DEFAULT 180,
+            cadence_achieved BOOLEAN
+        )
+        """)
+    conn.close()
+
+    from garmin_mcp.database.migrations.add_cadence_columns import (
+        migrate_cadence_schema,
+    )
+
+    migrate_cadence_schema(str(db_path))
+    return str(db_path)
+
+
+@pytest.mark.integration
+def test_migration_adds_cadence_columns(tmp_db_path):
+    """All new pace-dependent cadence columns should exist after migration."""
+    conn = duckdb.connect(tmp_db_path, read_only=True)
+    schema = conn.execute("PRAGMA table_info(form_evaluations)").fetchall()
+    column_names = [row[1] for row in schema]
+    conn.close()
+
+    expected = [
+        "cadence_expected",
+        "cadence_delta_pct",
+        "cadence_star_rating",
+        "cadence_score",
+        "cadence_needs_improvement",
+        "cadence_evaluation_text",
+    ]
+    for col in expected:
+        assert col in column_names, f"{col} column should exist"
+
+    # Legacy columns retained for backward compatibility
+    for legacy in ("cadence_actual", "cadence_minimum", "cadence_achieved"):
+        assert legacy in column_names, f"legacy {legacy} should be retained"
+
+
+@pytest.mark.integration
+def test_migration_is_idempotent(tmp_db_path):
+    """Running the migration twice should not error (ADD COLUMN IF NOT EXISTS)."""
+    from garmin_mcp.database.migrations.add_cadence_columns import (
+        migrate_cadence_schema,
+    )
+
+    # Second run should be a no-op
+    migrate_cadence_schema(tmp_db_path)
+
+    conn = duckdb.connect(tmp_db_path, read_only=True)
+    schema = conn.execute("PRAGMA table_info(form_evaluations)").fetchall()
+    column_names = [row[1] for row in schema]
+    conn.close()
+
+    assert "cadence_expected" in column_names

--- a/packages/garmin-mcp-server/tests/database/test_migration_runner.py
+++ b/packages/garmin-mcp-server/tests/database/test_migration_runner.py
@@ -72,10 +72,10 @@ class TestMigrationRunner:
         runner = MigrationRunner(db_path)
         applied = runner.run_pending()
 
-        assert len(applied) == 5
+        assert len(applied) == 6
         assert applied[0] == "phase0_power_prep"
-        assert applied[-1] == "add_plan_versioning"
-        assert runner.get_current_version() == 5
+        assert applied[-1] == "add_cadence_columns"
+        assert runner.get_current_version() == 6
 
     def test_run_pending_skips_applied(self, db_path: Path) -> None:
         """Running twice applies nothing the second time."""
@@ -83,7 +83,7 @@ class TestMigrationRunner:
         first = runner.run_pending()
         second = runner.run_pending()
 
-        assert len(first) == 5
+        assert len(first) == 6
         assert second == []
 
     def test_run_pending_partial(self, db_path: Path) -> None:
@@ -110,8 +110,12 @@ class TestMigrationRunner:
         runner = MigrationRunner(db_path)
         applied = runner.run_pending()
 
-        assert runner.get_current_version() == 5
-        assert applied == ["remove_fk_constraints", "add_plan_versioning"]
+        assert runner.get_current_version() == 6
+        assert applied == [
+            "remove_fk_constraints",
+            "add_plan_versioning",
+            "add_cadence_columns",
+        ]
 
     def test_migration_records_applied_at(self, db_path: Path) -> None:
         """Each applied migration records a timestamp."""
@@ -124,7 +128,7 @@ class TestMigrationRunner:
         ).fetchall()
         conn.close()
 
-        assert len(rows) == 5
+        assert len(rows) == 6
         for version, name, applied_at in rows:
             assert applied_at is not None
             assert isinstance(name, str)

--- a/packages/garmin-mcp-server/tests/form_baseline/test_evaluator.py
+++ b/packages/garmin-mcp-server/tests/form_baseline/test_evaluator.py
@@ -292,6 +292,126 @@ class TestEvaluateAndStore:
         assert result["cadence"]["achieved"] is False
 
 
+@pytest.mark.integration
+class TestEvaluatorCadencePaceDependent:
+    """Pace-dependent cadence evaluation (mock DuckDB)."""
+
+    def _patch_common(self, mocker, cadence_actual: float):
+        """Patch shared evaluator dependencies. Returns mocks dict."""
+        # models include a cadence model -> pace-dependent path
+        mocker.patch(
+            "garmin_mcp.form_baseline.evaluator.load_models_from_file",
+            return_value={
+                "gct": mocker.Mock(),
+                "vo": mocker.Mock(),
+                "vr": mocker.Mock(),
+                "cadence": mocker.Mock(),
+            },
+        )
+        # Slow easy-pace activity (~7:11/km) with cadence below fixed-180
+        mocker.patch(
+            "garmin_mcp.form_baseline.evaluator.get_splits_data",
+            return_value={
+                "pace_s_per_km": 431.0,
+                "gct_ms": 258.0,
+                "vo_cm": 7.1,
+                "vr_pct": 7.3,
+                "cadence": cadence_actual,
+            },
+        )
+        # score_observation returns cadence_* because a cadence model exists.
+        # Expected cadence at this slow pace is 174spm (NOT fixed 180).
+        cadence_exp = 174.0
+        cadence_delta_pct = (cadence_actual - cadence_exp) / cadence_exp * 100.0
+        # Reversed direction: below expected -> degradation, above -> improvement
+        if cadence_delta_pct >= 0:
+            cadence_penalty = abs(cadence_delta_pct) * 0.3 * 10.0
+        else:
+            cadence_penalty = abs(cadence_delta_pct) * 1.0 * 10.0
+        mocker.patch(
+            "garmin_mcp.form_baseline.evaluator.score_observation",
+            return_value={
+                "gct_ms_exp": 259.0,
+                "vo_cm_exp": 7.0,
+                "vr_pct_exp": 7.2,
+                "gct_ms_actual": 258.0,
+                "vo_cm_actual": 7.1,
+                "vr_pct_actual": 7.3,
+                "gct_delta_pct": -0.4,
+                "gct_penalty": 2.0,
+                "vo_delta_cm": 0.1,
+                "vo_delta_pct": 1.4,
+                "vo_penalty": 2.0,
+                "vr_delta_pct": 1.4,
+                "vr_penalty": 2.0,
+                "score": 99.3,
+                "gct_needs_improvement": False,
+                "vo_needs_improvement": False,
+                "vr_needs_improvement": False,
+                "cadence_exp": cadence_exp,
+                "cadence_actual": cadence_actual,
+                "cadence_delta_pct": cadence_delta_pct,
+                "cadence_penalty": cadence_penalty,
+                "cadence_needs_improvement": cadence_penalty > 20.0,
+            },
+        )
+        mocker.patch(
+            "garmin_mcp.form_baseline.evaluator.compute_star_rating",
+            return_value={
+                "star_rating": "★★★★★",
+                "score": 5.0,
+                "category": "excellent",
+            },
+        )
+        mocker.patch(
+            "garmin_mcp.form_baseline.evaluator.generate_evaluation_text",
+            return_value="ケイデンス評価文",
+        )
+        mocker.patch(
+            "garmin_mcp.form_baseline.evaluator.generate_overall_text",
+            return_value="Overall text",
+        )
+        mock_conn = mocker.MagicMock()
+        mocker.patch("duckdb.connect", return_value=mock_conn)
+
+    def test_evaluator_cadence_pace_dependent(self, mocker):
+        """Slow-pace 176spm should NOT be flagged (above pace-adjusted 174spm)."""
+        # 176spm < fixed 180 but >= pace-adjusted expectation 174spm
+        self._patch_common(mocker, cadence_actual=176.0)
+
+        result = evaluate_and_store(
+            activity_id=20790040925,
+            activity_date="2025-10-25",
+            db_path=":memory:",
+            model_file=Path("/tmp/test.json"),
+        )
+
+        cadence = result["cadence"]
+        # Pace-dependent structure (not legacy minimum/achieved)
+        assert "expected" in cadence
+        assert "delta_pct" in cadence
+        assert "evaluation_text" in cadence
+        assert cadence["expected"] == 174.0
+        assert cadence["actual"] == 176.0
+        # Above pace-adjusted expectation -> not flagged despite < 180
+        assert cadence["needs_improvement"] is False
+
+    def test_evaluator_cadence_below_baseline_flagged(self, mocker):
+        """Cadence well below pace-adjusted expectation should be flagged."""
+        self._patch_common(mocker, cadence_actual=165.0)
+
+        result = evaluate_and_store(
+            activity_id=20790040925,
+            activity_date="2025-10-25",
+            db_path=":memory:",
+            model_file=Path("/tmp/test.json"),
+        )
+
+        cadence = result["cadence"]
+        # 165 vs 174 = -5.2% degradation -> penalty ~51.7 -> flagged
+        assert cadence["needs_improvement"] is True
+
+
 @pytest.mark.unit
 class TestComputeStarRating:
     """Test cases for compute_star_rating function."""

--- a/packages/garmin-mcp-server/tests/form_baseline/test_predictor.py
+++ b/packages/garmin-mcp-server/tests/form_baseline/test_predictor.py
@@ -3,6 +3,7 @@
 import pytest
 
 from garmin_mcp.form_baseline.predictor import predict_expectations
+from garmin_mcp.form_baseline.trainer import LinearModel
 
 
 @pytest.mark.unit
@@ -98,3 +99,27 @@ class TestPredictExpectations:
         assert result1["gct_ms_exp"] == result2["gct_ms_exp"]
         assert result1["vo_cm_exp"] == result2["vo_cm_exp"]
         assert result1["vr_pct_exp"] == result2["vr_pct_exp"]
+
+    def test_predict_cadence_from_speed(self, sample_models: dict) -> None:
+        """Cadence expectation predicted from speed via LinearModel."""
+        # cadence = 160.0 + 5.0 * speed
+        models = dict(sample_models)
+        models["cadence"] = LinearModel(
+            a=160.0, b=5.0, rmse=2.0, n_samples=100, speed_range=(2.0, 5.0)
+        )
+
+        pace_s_per_km = 400.0  # speed = 2.5 m/s
+        speed_mps = 1000.0 / pace_s_per_km
+
+        result = predict_expectations(models, pace_s_per_km)
+
+        # Expected cadence = 160.0 + 5.0 * 2.5 = 172.5
+        expected_cadence = 160.0 + 5.0 * speed_mps
+        assert "cadence_exp" in result
+        assert abs(result["cadence_exp"] - expected_cadence) < 0.01
+        assert abs(result["cadence_exp"] - 172.5) < 0.01
+
+    def test_predict_no_cadence_when_model_absent(self, sample_models: dict) -> None:
+        """cadence_exp is absent when no cadence model (backward compatible)."""
+        result = predict_expectations(sample_models, 300.0)
+        assert "cadence_exp" not in result

--- a/packages/garmin-mcp-server/tests/form_baseline/test_scorer.py
+++ b/packages/garmin-mcp-server/tests/form_baseline/test_scorer.py
@@ -8,6 +8,27 @@ from garmin_mcp.form_baseline.scorer import (
     compute_star_rating,
     score_observation,
 )
+from garmin_mcp.form_baseline.trainer import GCTPowerModel, LinearModel
+
+
+@pytest.fixture
+def models_with_cadence() -> dict:
+    """Sample models including a constant cadence model (expected = 180spm)."""
+    return {
+        "gct": GCTPowerModel(
+            alpha=5.3, d=-0.15, rmse=5.0, n_samples=100, speed_range=(3.0, 5.0)
+        ),
+        "vo": LinearModel(
+            a=10.0, b=-2.0, rmse=0.5, n_samples=100, speed_range=(3.0, 5.0)
+        ),
+        "vr": LinearModel(
+            a=10.0, b=-0.5, rmse=0.3, n_samples=100, speed_range=(3.0, 5.0)
+        ),
+        # b=0 -> predict(speed) == 180 for any speed
+        "cadence": LinearModel(
+            a=180.0, b=0.0, rmse=2.0, n_samples=100, speed_range=(3.0, 5.0)
+        ),
+    }
 
 
 @pytest.mark.unit
@@ -138,6 +159,79 @@ class TestScoreObservation:
         assert result["gct_ms_actual"] == 200.0
         assert result["vo_cm_actual"] == 8.0
         assert result["vr_pct_actual"] == 7.5
+
+
+@pytest.mark.unit
+class TestScoreCadence:
+    """Tests for pace-dependent cadence scoring (reversed direction)."""
+
+    def test_score_cadence_below_expected_penalized(
+        self, models_with_cadence: dict
+    ) -> None:
+        """actual=172, expected=180 -> below expected -> needs_improvement=True."""
+        obs = {
+            "pace_s_per_km": 300.0,
+            "gct_ms": 250.0,
+            "vo_cm": 8.0,
+            "vr_pct": 7.5,
+            "cadence": 172.0,
+        }
+
+        result = score_observation(models_with_cadence, obs)
+
+        # delta_pct = (172 - 180) / 180 * 100 = -4.44% (degradation for cadence)
+        assert result["cadence_actual"] == 172.0
+        assert result["cadence_delta_pct"] < 0
+        # Degradation uses full factor: 4.44 * 1.0 * 10 = ~44.4 -> > 20
+        assert result["cadence_penalty"] > 20.0
+        assert result["cadence_needs_improvement"] is True
+
+    def test_score_cadence_above_expected_no_penalty(
+        self, models_with_cadence: dict
+    ) -> None:
+        """actual=185, expected=180 -> above expected -> no penalty, 5 stars."""
+        obs = {
+            "pace_s_per_km": 300.0,
+            "gct_ms": 250.0,
+            "vo_cm": 8.0,
+            "vr_pct": 7.5,
+            "cadence": 185.0,
+        }
+
+        result = score_observation(models_with_cadence, obs)
+
+        # delta_pct = (185 - 180) / 180 * 100 = +2.78% (improvement for cadence)
+        assert result["cadence_actual"] == 185.0
+        assert result["cadence_delta_pct"] > 0
+        # Improvement uses reduced factor: 2.78 * 0.3 * 10 = ~8.3 -> < 10
+        assert result["cadence_penalty"] < 10.0
+        assert result["cadence_needs_improvement"] is False
+
+        rating = compute_star_rating(
+            penalty=result["cadence_penalty"],
+            delta_pct=result["cadence_delta_pct"],
+        )
+        assert rating["score"] == 5.0
+
+    def test_score_cadence_not_in_overall(self, models_with_cadence: dict) -> None:
+        """Cadence must not change overall score vs no-cadence models."""
+        obs_base = {
+            "pace_s_per_km": 300.0,
+            "gct_ms": 250.0,
+            "vo_cm": 8.0,
+            "vr_pct": 7.5,
+        }
+        models_no_cadence = {
+            k: v for k, v in models_with_cadence.items() if k != "cadence"
+        }
+
+        score_without = score_observation(models_no_cadence, dict(obs_base))
+        score_with = score_observation(
+            models_with_cadence, {**obs_base, "cadence": 150.0}
+        )
+
+        # Overall score identical despite very poor cadence
+        assert score_with["score"] == score_without["score"]
 
 
 @pytest.mark.unit

--- a/packages/garmin-mcp-server/tests/form_baseline/test_trainer.py
+++ b/packages/garmin-mcp-server/tests/form_baseline/test_trainer.py
@@ -204,3 +204,40 @@ class TestFitLinear:
         # Should raise ValueError or have issues
         with pytest.raises((ValueError, Exception)):
             fit_linear(df, metric="vo")
+
+    def test_fit_linear_cadence_positive_slope(self):
+        """Cadence increases with speed -> b > 0."""
+        # Synthetic data: cadence = 160.0 + 5.0 * speed (positive slope)
+        speed_values = np.array([2.5, 3.0, 3.5, 4.0, 4.5, 5.0])
+        a_true = 160.0
+        b_true = 5.0
+        cadence_values = a_true + b_true * speed_values
+
+        df = pd.DataFrame({"cadence_value": cadence_values, "speed_mps": speed_values})
+
+        model = fit_linear(df, metric="cadence")
+
+        # Faster speed -> higher cadence: positive slope
+        assert model.b > 0
+        assert abs(model.a - a_true) < 0.5
+        assert abs(model.b - b_true) < 0.5
+        assert model.n_samples == 6
+
+    def test_fit_linear_cadence_outlier_removal(self):
+        """Cadence values below 140spm / above 210spm are removed."""
+        # 6 valid points plus 2 outliers (one < 140, one > 210)
+        speed_values = np.array([2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 3.2, 3.8])
+        cadence_values = np.array(
+            [172.0, 175.0, 178.0, 181.0, 184.0, 187.0, 130.0, 215.0]
+        )
+
+        df = pd.DataFrame({"cadence_value": cadence_values, "speed_mps": speed_values})
+
+        model = fit_linear(df, metric="cadence")
+
+        # Two outliers removed -> 6 valid samples remain
+        assert model.n_samples == 6
+        # Speed range should reflect only valid rows (3.2 and 3.8 kept, but
+        # their cadence outliers removed them) -> min 2.5, max 5.0
+        assert model.speed_range[0] == 2.5
+        assert model.speed_range[1] == 5.0


### PR DESCRIPTION
## 概要

ケイデンス評価を固定180spm閾値から、速度依存の学習baseline方式へ変更。GCT/VO/VR と同じ `LinearModel`（cadence = a + b×speed, b>0）で「速度→期待ケイデンス」を学習し、期待値からの乖離で評価する。

イージー/リカバリーペースで一律180spmを要求して過剰にフラグを立てる問題を解消する。実データ（31ラン）でケイデンス vs ペース相関 -0.36 と速度依存が明確だったことが根拠。

## 変更内容
- `trainer.py`: `fit_linear` を `cadence`（外れ値域140-210、単調性チェックなし）対応に拡張、cadence baseline 学習＋永続化
- `predictor.py` / `model_loader.py`: cadence 期待値予測・モデルロード（**baseline 不在時はスキップで後方互換**）
- `scorer.py`: cadence は方向反転（actual<expected=劣化）。overall_score/consistency には不参加の独立指標
- `evaluator.py`: 固定180を廃止、baseline があればペース依存評価、無ければ従来通り
- `text_generator.py`: cadence 評価テキスト
- `database/migrations/`: `form_evaluations` に cadence_expected 等6カラム追加（`ADD COLUMN IF NOT EXISTS`、既存カラム残置）
- `db_writer.py` / `readers/form.py`: 新カラムの書き込み・読み出し（reader は pre-migration DB を introspection でグレースフル処理）

## 検証（L2、オーケストレーターが自分のターンで実行）
- 指定7テスト + 追加2件: **9 passed**
- integration suite: **173 passed, 7 skipped**（0 failures）
- コードレビュー: 方向反転・後方互換フォールバックを確認

## マージ後の必要作業
cadence baseline は未学習のため、マージ後に1回手動再学習が必要（全 condition_group を train）。それまでは従来の固定180フォールバックで動作。

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)