### PR TITLE
fix(ingest): handle list response from get_max_metrics for VO2max

### DIFF
--- a/packages/garmin-mcp-server/src/garmin_mcp/ingest/raw_data_fetcher.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/ingest/raw_data_fetcher.py
@@ -441,16 +441,35 @@ def _collect_vo2_max(
             activity_date = start_time_local.split("T")[0]
             try:
                 max_metrics = client.get_max_metrics(activity_date)
-                generic_metrics = max_metrics.get("generic", {})
-                vo2_max_data = {
-                    "vo2MaxValue": generic_metrics.get("vo2MaxValue"),
-                    "vo2MaxPreciseValue": generic_metrics.get("vo2MaxPreciseValue"),
-                    "calendarDate": generic_metrics.get("calendarDate"),
-                }
-                raw_data["vo2_max"] = vo2_max_data
-                with open(vo2_max_file, "w", encoding="utf-8") as f:
-                    json.dump(vo2_max_data, f, ensure_ascii=False, indent=2)
-                logger.info(f"Cached vo2_max to {vo2_max_file}")
+                # get_max_metrics returns a list of entries (one per metric set);
+                # older raw dumps stored a single dict. Handle both shapes.
+                entry = (
+                    max_metrics[0]
+                    if isinstance(max_metrics, list) and max_metrics
+                    else max_metrics if isinstance(max_metrics, dict) else {}
+                )
+                generic_metrics = (
+                    entry.get("generic", {}) if isinstance(entry, dict) else {}
+                )
+                if generic_metrics:
+                    vo2_max_data = {
+                        "vo2MaxValue": generic_metrics.get("vo2MaxValue"),
+                        "vo2MaxPreciseValue": generic_metrics.get("vo2MaxPreciseValue"),
+                        "calendarDate": generic_metrics.get("calendarDate"),
+                    }
+                    raw_data["vo2_max"] = vo2_max_data
+                    with open(vo2_max_file, "w", encoding="utf-8") as f:
+                        json.dump(vo2_max_data, f, ensure_ascii=False, indent=2)
+                    logger.info(f"Cached vo2_max to {vo2_max_file}")
+                else:
+                    # Fetch succeeded but contained no usable VO2 max metrics.
+                    raw_data["vo2_max"] = {}
+                    with open(vo2_max_file, "w", encoding="utf-8") as f:
+                        json.dump({}, f, ensure_ascii=False, indent=2)
+                    logger.warning(
+                        "VO2 max response had no 'generic' metrics for "
+                        f"{activity_id} on {activity_date}; cached empty payload"
+                    )
             except Exception as e:
                 logger.warning(f"Failed to fetch VO2 max data: {e}")
                 raw_data["vo2_max"] = {}

--- a/packages/garmin-mcp-server/tests/ingest/test_vo2_max_fetcher.py
+++ b/packages/garmin-mcp-server/tests/ingest/test_vo2_max_fetcher.py
@@ -1,0 +1,92 @@
+"""Tests for VO2 max collection in raw_data_fetcher (Issue #218).
+
+`client.get_max_metrics()` returns a list of entries, but older raw dumps
+stored a single dict. `_collect_vo2_max` must parse both shapes so the
+`generic` metrics are extracted correctly instead of being silently dropped.
+"""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from garmin_mcp.ingest.raw_data_fetcher import _collect_vo2_max
+
+
+def _make_raw_data(date: str) -> dict:
+    """Minimal raw_data with an activity date so date extraction succeeds."""
+    return {
+        "activity": {"summaryDTO": {"startTimeLocal": f"{date}T07:00:00.0"}},
+    }
+
+
+@pytest.mark.unit
+def test_collect_vo2_max_parses_list_response(tmp_path):
+    """get_max_metrics returning a list → generic metrics extracted and cached."""
+    client = Mock()
+    client.get_max_metrics.return_value = [
+        {
+            "generic": {
+                "vo2MaxValue": 47.0,
+                "vo2MaxPreciseValue": 47.3,
+                "calendarDate": "2025-10-04",
+            }
+        }
+    ]
+    raw_data = _make_raw_data("2025-10-04")
+
+    _collect_vo2_max(
+        client, tmp_path, raw_data, activity_id=123, force_refetch_set=set()
+    )
+
+    expected = {
+        "vo2MaxValue": 47.0,
+        "vo2MaxPreciseValue": 47.3,
+        "calendarDate": "2025-10-04",
+    }
+    assert raw_data["vo2_max"] == expected
+    with open(tmp_path / "vo2_max.json", encoding="utf-8") as f:
+        assert json.load(f) == expected
+
+
+@pytest.mark.unit
+def test_collect_vo2_max_parses_dict_response(tmp_path):
+    """Legacy dict response (backward compat) → same extracted result."""
+    client = Mock()
+    client.get_max_metrics.return_value = {
+        "generic": {
+            "vo2MaxValue": 47.0,
+            "vo2MaxPreciseValue": 47.3,
+            "calendarDate": "2025-10-04",
+        }
+    }
+    raw_data = _make_raw_data("2025-10-04")
+
+    _collect_vo2_max(
+        client, tmp_path, raw_data, activity_id=123, force_refetch_set=set()
+    )
+
+    expected = {
+        "vo2MaxValue": 47.0,
+        "vo2MaxPreciseValue": 47.3,
+        "calendarDate": "2025-10-04",
+    }
+    assert raw_data["vo2_max"] == expected
+    with open(tmp_path / "vo2_max.json", encoding="utf-8") as f:
+        assert json.load(f) == expected
+
+
+@pytest.mark.unit
+def test_collect_vo2_max_empty_list(tmp_path):
+    """Empty list response → empty {} cached, no exception raised."""
+    client = Mock()
+    client.get_max_metrics.return_value = []
+    raw_data = _make_raw_data("2025-10-04")
+
+    _collect_vo2_max(
+        client, tmp_path, raw_data, activity_id=123, force_refetch_set=set()
+    )
+
+    assert raw_data["vo2_max"] == {}
+    with open(tmp_path / "vo2_max.json", encoding="utf-8") as f:
+        assert json.load(f) == {}


### PR DESCRIPTION
Closes #218

## Bug

`get_max_metrics()` は list（`[{"generic": {...}}]`）を返すが `_collect_vo2_max` が dict として `.get("generic")` を呼び、AttributeError が except で握り潰され空 `{}` が書かれていた。結果、2025-10-04 以降の95アクティビティで VO2max が欠落し、Webトレンドの VO2max 折れ線が 2025-10 で途切れていた。Garmin 側にデータは存在することは直接 API 呼び出しで確認済み。

## Fix

`raw_data_fetcher.py` の `_collect_vo2_max` を list/dict 両対応に:
- `entry = max_metrics[0]`（list 非空）/ `max_metrics`（dict）/ `{}`（その他）
- generic が取得できた時のみ 3キー dict を書き込み、空時は `{}` + warning（取得成功だが空 vs 例外 を区別）
- シグネチャ・呼び出し側・except 握り潰しは不変

## 検証（L2 — オーケストレーターが独立実行で確認済み）

| チェック | 結果 |
|---|---|
| unit (`test_vo2_max_fetcher.py`) | 3 passed（list/dict/empty） |
| integration | 170 passed, 6 skipped |
| ruff | clean |

## Follow-up（マージ後）
該当95件の vo2_max を force re-fetch → `vo2_max` テーブル surgical regen → Web トレンドで最新 VO2max 表示を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)