### PR TITLE
fix(ingest): support flat vo2_max raw format in inserter

### DIFF
--- a/packages/garmin-mcp-server/src/garmin_mcp/database/inserters/vo2_max.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/database/inserters/vo2_max.py
@@ -90,7 +90,9 @@ def _extract_vo2_max_from_raw(raw_vo2_max_file: str) -> dict | None:
     """
     Extract vo2_max data from raw API response (vo2_max.json).
 
-    Raw data structure:
+    Supports two raw data structures:
+
+    1. Nested "generic" format (legacy full responses):
     {
         "generic": {
             "vo2MaxValue": 45,
@@ -99,6 +101,15 @@ def _extract_vo2_max_from_raw(raw_vo2_max_file: str) -> dict | None:
             "fitnessAge": null
         }
     }
+
+    2. Flat format (reduced responses written by RawDataFetcher):
+    {
+        "vo2MaxValue": 48.0,
+        "vo2MaxPreciseValue": 47.6,
+        "calendarDate": "2025-10-12"
+    }
+
+    Both list-wrapped (``[{...}]``) and bare dict variants are accepted.
 
     Args:
         raw_vo2_max_file: Path to raw vo2_max.json file
@@ -123,22 +134,30 @@ def _extract_vo2_max_from_raw(raw_vo2_max_file: str) -> dict | None:
                 return None
             raw_data = raw_data[0]  # Get first element
 
-        # Extract from "generic" section
+        # Select source: prefer nested "generic" section (legacy full format),
+        # fall back to top-level fields (flat reduced format).
         generic = raw_data.get("generic", {})
-        if not generic:
-            logger.warning(f"No 'generic' section in {raw_vo2_max_file}")
+        if generic:
+            source = generic
+        elif (
+            raw_data.get("vo2MaxPreciseValue") is not None
+            or raw_data.get("vo2MaxValue") is not None
+        ):
+            source = raw_data
+        else:
+            logger.warning(f"No vo2_max fields found in {raw_vo2_max_file}")
             return None
 
         # Map raw API fields to performance.json format
         # Note: fitness_age removed (device does not provide this data)
         return {
-            "precise_value": generic.get("vo2MaxPreciseValue"),
+            "precise_value": source.get("vo2MaxPreciseValue"),
             "value": (
-                float(generic.get("vo2MaxValue"))
-                if generic.get("vo2MaxValue") is not None
+                float(source.get("vo2MaxValue"))
+                if source.get("vo2MaxValue") is not None
                 else None
             ),
-            "date": generic.get("calendarDate"),
+            "date": source.get("calendarDate"),
             "category": 0,  # Default category (not provided in raw data)
         }
 

--- a/packages/garmin-mcp-server/tests/database/inserters/test_vo2_max.py
+++ b/packages/garmin-mcp-server/tests/database/inserters/test_vo2_max.py
@@ -149,6 +149,76 @@ class TestVO2MaxInserter:
         assert result is True
         assert db_path.exists()
 
+    def test_extract_vo2_max_generic_nested(self, tmp_path):
+        """Test extraction from list-wrapped nested 'generic' format (legacy)."""
+        from garmin_mcp.database.inserters.vo2_max import _extract_vo2_max_from_raw
+
+        raw = [
+            {
+                "generic": {
+                    "vo2MaxValue": 47.0,
+                    "vo2MaxPreciseValue": 47.3,
+                    "calendarDate": "2025-10-04",
+                }
+            }
+        ]
+        vo2_file = tmp_path / "vo2_max.json"
+        with open(vo2_file, "w", encoding="utf-8") as f:
+            json.dump(raw, f)
+
+        result = _extract_vo2_max_from_raw(str(vo2_file))
+
+        assert result is not None
+        assert result["precise_value"] == 47.3
+        assert result["value"] == 47.0
+        assert result["date"] == "2025-10-04"
+        assert result["category"] == 0
+
+    def test_extract_vo2_max_flat(self, tmp_path):
+        """Test extraction from flat top-level format (reduced responses)."""
+        from garmin_mcp.database.inserters.vo2_max import _extract_vo2_max_from_raw
+
+        raw = {
+            "vo2MaxValue": 48.0,
+            "vo2MaxPreciseValue": 47.6,
+            "calendarDate": "2025-10-12",
+        }
+        vo2_file = tmp_path / "vo2_max.json"
+        with open(vo2_file, "w", encoding="utf-8") as f:
+            json.dump(raw, f)
+
+        result = _extract_vo2_max_from_raw(str(vo2_file))
+
+        assert result is not None
+        assert result["precise_value"] == 47.6
+        assert result["value"] == 48.0
+        assert result["date"] == "2025-10-12"
+        assert result["category"] == 0
+
+    def test_extract_vo2_max_empty(self, tmp_path):
+        """Test empty dict (no generic, no flat fields) returns None."""
+        from garmin_mcp.database.inserters.vo2_max import _extract_vo2_max_from_raw
+
+        vo2_file = tmp_path / "vo2_max.json"
+        with open(vo2_file, "w", encoding="utf-8") as f:
+            json.dump({}, f)
+
+        result = _extract_vo2_max_from_raw(str(vo2_file))
+
+        assert result is None
+
+    def test_extract_vo2_max_empty_list(self, tmp_path):
+        """Test empty list returns None."""
+        from garmin_mcp.database.inserters.vo2_max import _extract_vo2_max_from_raw
+
+        vo2_file = tmp_path / "vo2_max.json"
+        with open(vo2_file, "w", encoding="utf-8") as f:
+            json.dump([], f)
+
+        result = _extract_vo2_max_from_raw(str(vo2_file))
+
+        assert result is None
+
     def test_insert_vo2_max_raw_data_integrity(
         self, sample_raw_vo2_max_file, initialized_db_path
     ):


### PR DESCRIPTION
Closes #222

## Bug
#218 で fetcher が vo2_max.json に値を書くようになったが、その形式は**フラット dict**（`{"vo2MaxValue","vo2MaxPreciseValue","calendarDate"}`）。inserter `_extract_vo2_max_from_raw` は `generic` ネストを要求していたため挿入をスキップ（regen は誤って success 報告、行は増えない）。今後の全 ingest でも vo2_max が入らない状態だった。

## Fix
`_extract_vo2_max_from_raw` を2形式対応に: `generic` があればそこから（旧 full 形式の後方互換）、無くトップレベルに vo2Max フィールドがあればそこから（フラット形式）、どちらも無ければ None。返却キー・型は不変。

## 検証（L2 — オーケストレーターが独立実行で確認済み）
| チェック | 結果 |
|---|---|
| unit (`test_vo2_max.py`) | 11 passed（新規4: generic/flat/empty/empty_list + 既存7） |
| integration | 174 passed, 6 skipped |
| ruff | clean |

## Follow-up（マージ後）
`vo2_max` テーブルを surgical regen（再 fetch 不要）→ Web トレンドで最新 VO2max 表示を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)