### PR TITLE
feat(garmin-web): consolidate next-run guidance into prescription unit

### DIFF
--- a/packages/garmin-web/frontend/src/components/report/NextRunTarget.test.tsx
+++ b/packages/garmin-web/frontend/src/components/report/NextRunTarget.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import NextRunTarget from "./NextRunTarget";
+
+// Real-schema mock (Issue #224: structured next_run_target object).
+const fullData = {
+  recommended_type: "aerobic_base",
+  target_hr_low: 140,
+  target_hr_high: 150,
+  reference_pace_low_formatted: "6:52",
+  reference_pace_high_formatted: "7:02",
+  success_criterion: "Zone 1+2比率85%以上を維持し、平均心拍150bpm以下に収める",
+  adjustment_tip: "心拍が150bpmを超えそうな場合はペースを5秒/km落とす",
+  summary_ja:
+    "次回は平均心拍140-150bpm（Zone 2中心）を目安に、参考ペース6:52-7:02/kmで",
+};
+
+describe("NextRunTarget", () => {
+  it("renders prescription fields with labels", () => {
+    render(<NextRunTarget data={fullData} />);
+
+    // Lead summary
+    expect(screen.getByText(fullData.summary_ja)).toBeInTheDocument();
+    // Japanese training-type badge (not the raw english key)
+    expect(screen.getByText("ベース走")).toBeInTheDocument();
+    // Target HR / reference pace chips
+    expect(screen.getByText("目標HR")).toBeInTheDocument();
+    expect(screen.getByText("140–150 bpm")).toBeInTheDocument();
+    expect(screen.getByText("参考ペース")).toBeInTheDocument();
+    expect(screen.getByText("6:52–7:02 /km")).toBeInTheDocument();
+    // Labeled success criterion / adjustment tip
+    expect(screen.getByText("成功条件")).toBeInTheDocument();
+    expect(screen.getByText(fullData.success_criterion)).toBeInTheDocument();
+    expect(screen.getByText("調整ヒント")).toBeInTheDocument();
+    expect(screen.getByText(fullData.adjustment_tip)).toBeInTheDocument();
+
+    // Raw english keys must never reach the DOM
+    expect(screen.queryByText("recommended_type")).not.toBeInTheDocument();
+    expect(screen.queryByText("target_hr_low")).not.toBeInTheDocument();
+    expect(screen.queryByText("success_criterion")).not.toBeInTheDocument();
+  });
+
+  it("hides missing fields", () => {
+    // Only a type + a single HR bound; pace and tips absent.
+    render(
+      <NextRunTarget
+        data={{
+          recommended_type: "tempo",
+          target_hr_low: 160,
+        }}
+      />,
+    );
+
+    // Known type label still resolves
+    expect(screen.getByText("テンポ走")).toBeInTheDocument();
+    // Single-bound HR renders as a single value
+    expect(screen.getByText("目標HR")).toBeInTheDocument();
+    expect(screen.getByText("160 bpm")).toBeInTheDocument();
+
+    // Absent fields are not rendered (no crash)
+    expect(screen.queryByText("参考ペース")).not.toBeInTheDocument();
+    expect(screen.queryByText("成功条件")).not.toBeInTheDocument();
+    expect(screen.queryByText("調整ヒント")).not.toBeInTheDocument();
+  });
+
+  it("shows unknown training types verbatim without crashing", () => {
+    render(<NextRunTarget data={{ recommended_type: "fartlek" }} />);
+    expect(screen.getByText("fartlek")).toBeInTheDocument();
+  });
+});

--- a/packages/garmin-web/frontend/src/components/report/NextRunTarget.tsx
+++ b/packages/garmin-web/frontend/src/components/report/NextRunTarget.tsx
@@ -1,0 +1,131 @@
+import type { JSX, ReactNode } from "react";
+
+/** Japanese labels for known training types; unknown types fall through to raw. */
+const TYPE_LABELS: Record<string, string> = {
+  aerobic_base: "ベース走",
+  recovery: "リカバリー",
+  tempo: "テンポ走",
+  interval: "インターバル",
+  long_run: "ロング走",
+  threshold: "閾値走",
+};
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() !== "" ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/** Builds a "low–high" / "low" / "high" range string, or null when both absent. */
+function formatRange(
+  low: string | number | null,
+  high: string | number | null,
+  unit: string,
+): string | null {
+  if (low != null && high != null) {
+    return `${low}–${high} ${unit}`;
+  }
+  if (low != null) {
+    return `${low} ${unit}`;
+  }
+  if (high != null) {
+    return `${high} ${unit}`;
+  }
+  return null;
+}
+
+function Chip({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full bg-indigo-50 px-3 py-1 text-xs font-medium text-indigo-700">
+      <span className="text-indigo-500">{label}</span>
+      <span className="tabular-nums">{value}</span>
+    </span>
+  );
+}
+
+function LabeledLine({ label, value }: { label: string; value: string }) {
+  return (
+    <p className="text-sm text-slate-700">
+      <span className="font-semibold text-indigo-700">{label}</span>
+      <span className="ml-1.5">{value}</span>
+    </p>
+  );
+}
+
+/**
+ * Prescription card for the structured `next_run_target` object: lead summary,
+ * a Japanese training-type badge, target HR / reference pace chips, and
+ * labeled success criterion / adjustment tip. Renders only present fields and
+ * never exposes raw English keys. Returns null for non-object input.
+ */
+export default function NextRunTarget({
+  data,
+}: {
+  data: Record<string, unknown>;
+}): JSX.Element | null {
+  if (data == null || typeof data !== "object" || Array.isArray(data)) {
+    return null;
+  }
+
+  const summaryJa = asString(data.summary_ja);
+  const recommendedType = asString(data.recommended_type);
+  const typeLabel =
+    recommendedType != null
+      ? (TYPE_LABELS[recommendedType] ?? recommendedType)
+      : null;
+
+  const hrRange = formatRange(
+    asNumber(data.target_hr_low),
+    asNumber(data.target_hr_high),
+    "bpm",
+  );
+  const paceRange = formatRange(
+    asString(data.reference_pace_low_formatted),
+    asString(data.reference_pace_high_formatted),
+    "/km",
+  );
+
+  const successCriterion = asString(data.success_criterion);
+  const adjustmentTip = asString(data.adjustment_tip);
+
+  const chips: ReactNode[] = [];
+  if (hrRange != null) {
+    chips.push(<Chip key="hr" label="目標HR" value={hrRange} />);
+  }
+  if (paceRange != null) {
+    chips.push(<Chip key="pace" label="参考ペース" value={paceRange} />);
+  }
+
+  return (
+    <div className="rounded-lg border border-indigo-100 bg-indigo-50/40 p-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <h3 className="text-xs font-semibold tracking-wide text-indigo-700 uppercase">
+          次回への処方
+        </h3>
+        {typeLabel != null && (
+          <span className="rounded-full bg-indigo-600 px-2.5 py-0.5 text-xs font-semibold text-white">
+            {typeLabel}
+          </span>
+        )}
+      </div>
+      {summaryJa != null && (
+        <p className="mt-2 text-sm leading-relaxed text-slate-700">{summaryJa}</p>
+      )}
+      {chips.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-2">{chips}</div>
+      )}
+      {(successCriterion != null || adjustmentTip != null) && (
+        <div className="mt-3 space-y-1.5">
+          {successCriterion != null && (
+            <LabeledLine label="成功条件" value={successCriterion} />
+          )}
+          {adjustmentTip != null && (
+            <LabeledLine label="調整ヒント" value={adjustmentTip} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/garmin-web/frontend/src/components/report/SummaryReport.test.tsx
+++ b/packages/garmin-web/frontend/src/components/report/SummaryReport.test.tsx
@@ -24,7 +24,9 @@ function section(data: Record<string, unknown>) {
 
 describe("SummaryReport", () => {
   it("renders strengths, improvements and recommendations", () => {
-    render(<SummaryReport section={section(baseData)} />);
+    const { container } = render(
+      <SummaryReport section={section(baseData)} />,
+    );
 
     // Large star rating parsed from the star_rating string
     expect(screen.getByLabelText("評価 4.3 / 5.0")).toBeInTheDocument();
@@ -39,7 +41,10 @@ describe("SummaryReport", () => {
     expect(screen.getByText("改善ポイント")).toBeInTheDocument();
     expect(screen.getByText("後半のペース低下")).toBeInTheDocument();
 
-    expect(screen.getByText("推奨事項")).toBeInTheDocument();
+    // recommendations now live inside a collapsed <details> ("詳しい改善ポイント")
+    expect(screen.getByText("詳しい改善ポイント")).toBeInTheDocument();
+    const details = container.querySelector("details");
+    expect(details).not.toBeNull();
     expect(
       screen.getByText(
         "次回は HR 135-145 を維持してイージーランを実施しましょう。",
@@ -58,19 +63,66 @@ describe("SummaryReport", () => {
       />,
     );
 
-    // next_action renders as an action callout, not a key-value row
-    expect(screen.getByText("次のアクション")).toBeInTheDocument();
-    expect(
-      screen.getByText("次回はHR 135-145でイージーランを実施"),
-    ).toBeInTheDocument();
+    // next_action renders as a single lead heading, not a key-value row
+    const leads = screen.getAllByText("次回はHR 135-145でイージーランを実施");
+    expect(leads).toHaveLength(1);
     expect(screen.queryByText("next_action")).not.toBeInTheDocument();
     // integrated_score renders as a badge
     expect(screen.getByText("統合スコア 4.1")).toBeInTheDocument();
     unmount();
 
-    // Absent next_action -> callout is not rendered
+    // Absent next_action -> lead heading is not rendered
     render(<SummaryReport section={section(baseData)} />);
-    expect(screen.queryByText("次のアクション")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("次回はHR 135-145でイージーランを実施"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("collapses recommendations into details", () => {
+    const { container } = render(
+      <SummaryReport
+        section={section({
+          ...baseData,
+          next_action: "次回はZone 2を維持",
+        })}
+      />,
+    );
+
+    // recommendations are rendered inside a <details> element
+    const details = container.querySelector("details");
+    expect(details).not.toBeNull();
+    expect(
+      details?.textContent?.includes(
+        "次回は HR 135-145 を維持してイージーランを実施しましょう。",
+      ),
+    ).toBe(true);
+
+    // next_action appears exactly once (as the lead heading)
+    expect(screen.getAllByText("次回はZone 2を維持")).toHaveLength(1);
+  });
+
+  it("renders next_run_target as a prescription card, not a key dump", () => {
+    render(
+      <SummaryReport
+        section={section({
+          ...baseData,
+          next_run_target: {
+            recommended_type: "aerobic_base",
+            target_hr_low: 140,
+            target_hr_high: 150,
+            reference_pace_low_formatted: "6:52",
+            reference_pace_high_formatted: "7:02",
+            success_criterion: "Zone 1+2比率85%以上を維持",
+            summary_ja: "次回は平均心拍140-150bpmを目安に",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("ベース走")).toBeInTheDocument();
+    expect(screen.getByText("140–150 bpm")).toBeInTheDocument();
+    // No raw english keys leak into the DOM
+    expect(screen.queryByText("recommended_type")).not.toBeInTheDocument();
   });
 
   it("unknown fields fall back to key-value", () => {

--- a/packages/garmin-web/frontend/src/components/report/SummaryReport.tsx
+++ b/packages/garmin-web/frontend/src/components/report/SummaryReport.tsx
@@ -2,6 +2,7 @@ import type { SectionResult } from "../../types";
 import ActionCallout from "./ActionCallout";
 import FallbackFields, { renderValue } from "./FallbackFields";
 import MarkdownText from "./MarkdownText";
+import NextRunTarget from "./NextRunTarget";
 import ReportCard from "./ReportCard";
 import StarRating from "./StarRating";
 
@@ -115,20 +116,33 @@ export default function SummaryReport({
                 )}
             </div>
           )}
-          {typeof data.recommendations === "string" && (
-            <ActionCallout title="推奨事項">
-              <MarkdownText text={data.recommendations} />
-            </ActionCallout>
-          )}
-          {typeof data.next_action === "string" && (
-            <ActionCallout title="次のアクション">
-              <MarkdownText text={data.next_action} />
-            </ActionCallout>
-          )}
-          {data.next_run_target != null && (
-            <ActionCallout title="次回ラン目標">
-              {renderValue(data.next_run_target)}
-            </ActionCallout>
+          {(typeof data.next_action === "string" ||
+            data.next_run_target != null ||
+            typeof data.recommendations === "string") && (
+            <div className="space-y-3">
+              {typeof data.next_action === "string" && (
+                <p className="text-sm font-semibold text-slate-800">
+                  {data.next_action}
+                </p>
+              )}
+              {data.next_run_target != null &&
+                typeof data.next_run_target === "object" &&
+                !Array.isArray(data.next_run_target) && (
+                  <NextRunTarget
+                    data={data.next_run_target as Record<string, unknown>}
+                  />
+                )}
+              {typeof data.recommendations === "string" && (
+                <details className="rounded-lg border border-slate-100 bg-slate-50/60 px-4 py-2">
+                  <summary className="cursor-pointer text-sm font-medium text-slate-600">
+                    詳しい改善ポイント
+                  </summary>
+                  <div className="mt-2">
+                    <MarkdownText text={data.recommendations} />
+                  </div>
+                </details>
+              )}
+            </div>
           )}
           {data.plan_achievement != null && (
             <ActionCallout title="プラン達成度">


### PR DESCRIPTION
Closes #224

総合評価の推奨系3フィールド（`recommendations`/`next_action`/`next_run_target`）が横並びで重複感があり `next_run_target` が生キーダンプだった問題を、「次回への処方」1ユニットに再構成。フロント表示のみ、DB・エージェント出力は不変。

## 変更内容
- 新規 `NextRunTarget.tsx`: `next_run_target` 専用の処方カード（summary_ja リード + 日本語タイプバッジ + 目標HR/参考ペースのチップ + 成功条件/調整ヒント。生キー非表示・欠損非表示・未知 type は原文表示）
- `SummaryReport.tsx`: 「次回への処方」セクションに統合（`next_action` を太字リード見出し1回 → 処方カード → `recommendations` は `<details>`「詳しい改善ポイント」で折りたたみ）
- 旧 3連 ActionCallout を廃止。`plan_achievement`・`integrated_score`・星・強み/改善点・FallbackFields は現状維持

## 検証（L2 — オーケストレーターが独立実行で確認済み）
| チェック | 結果 |
|---|---|
| `vitest run` | 24 passed（NextRunTarget/SummaryReport 8本含む） |
| `tsc + vite build` | pass |
| backend `pytest -m "unit or integration"` | 34 passed（無変更確認） |
| `ruff check` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)