### PR TITLE
fix(garmin-web): round efficiency stat values

### DIFF
--- a/packages/garmin-web/frontend/src/components/report/EfficiencyReport.test.tsx
+++ b/packages/garmin-web/frontend/src/components/report/EfficiencyReport.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import EfficiencyReport from "./EfficiencyReport";
+
+const section = {
+  data: { efficiency: "フォーム効率は良好。" },
+  parse_error: false,
+  raw: null,
+};
+
+// Raw DB floats carry ~13 decimal digits (#226).
+const formEfficiency = {
+  gct_average: 265.6500015258789,
+  gct_rating: "良好",
+  vo_average: 7.145000076293946,
+  vo_rating: "やや大",
+  vr_average: 9.696249961853027,
+  vr_rating: "標準",
+};
+
+describe("EfficiencyReport", () => {
+  it("rounds stat values", () => {
+    render(<EfficiencyReport section={section} formEfficiency={formEfficiency} />);
+
+    // GCT → integer ms, VO / VR → 1 decimal
+    expect(screen.getByText("266")).toBeInTheDocument();
+    expect(screen.getByText("7.1")).toBeInTheDocument();
+    expect(screen.getByText("9.7")).toBeInTheDocument();
+
+    // Raw long decimals must not appear
+    expect(screen.queryByText(/265\.65000/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/7\.145000/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/garmin-web/frontend/src/components/report/EfficiencyReport.tsx
+++ b/packages/garmin-web/frontend/src/components/report/EfficiencyReport.tsx
@@ -35,18 +35,21 @@ export default function EfficiencyReport({
       label: "接地時間",
       value: asNumber(formEfficiency?.gct_average),
       unit: "ms",
+      digits: 0,
       rating: asString(formEfficiency?.gct_rating),
     },
     {
       label: "上下動",
       value: asNumber(formEfficiency?.vo_average),
       unit: "cm",
+      digits: 1,
       rating: asString(formEfficiency?.vo_rating),
     },
     {
       label: "上下動比",
       value: asNumber(formEfficiency?.vr_average),
       unit: "%",
+      digits: 1,
       rating: asString(formEfficiency?.vr_rating),
     },
   ].filter((stat) => stat.value != null);
@@ -57,7 +60,7 @@ export default function EfficiencyReport({
         <>
           {stats.length > 0 && (
             <dl className="mb-4 grid grid-cols-3 gap-3">
-              {stats.map(({ label, value, unit, rating }) => (
+              {stats.map(({ label, value, unit, digits, rating }) => (
                 <div
                   key={label}
                   className="rounded-lg border border-slate-100 bg-slate-50 px-3 py-2"
@@ -67,7 +70,7 @@ export default function EfficiencyReport({
                   </dt>
                   {/* GCT / VO / VR share the violet form-metric color (#214). */}
                   <dd className="mt-0.5 font-numeric text-2xl leading-none font-semibold tabular-nums text-metric-form">
-                    {value}
+                    {value!.toFixed(digits)}
                     <span className="ml-0.5 text-xs font-normal text-slate-500">
                       {unit}
                     </span>


### PR DESCRIPTION
Closes #226

効率分析の stat タイルが DB の生 float（例: `265.6500015258789` ms）をそのまま表示していたのを丸める。接地時間=整数、上下動/上下動比=小数1桁。フロント表示のみ。

## 検証（L2 — オーケストレーターが独立実行で確認済み）
| チェック | 結果 |
|---|---|
| `vitest run` | 25 passed（EfficiencyReport rounding 1本追加） |
| `tsc + vite build` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)