### PR TITLE
fix(agent): split-section-analyst warmup-aware HR drift + pace-dependent cadence

### DIFF
--- a/.claude/agents/split-section-analyst.md
+++ b/.claude/agents/split-section-analyst.md
@@ -62,12 +62,12 @@ contract の `required_fields` と `evaluation_policy` に従い `analysis_data`
 
 **分析観点** (contract の evaluation_policy を参照):
 - ペース安定性: training type に応じた基準で評価
-- HR ドリフト: contract の `hr_drift` 閾値で判定
+- HR ドリフト: ウォームアップ後の定常区間で「前半 vs 後半」を比較して判定（contract の first-half vs second-half method）。**序盤スプリット（Split 1 や定常化前の最初の数分）のHR上昇は安静→定常への正常なウォームアップ応答であり、疲労・オーバーペース・「有酸素能力の上限」とは解釈しない**。「Split 1（コールドスタート）→ 末尾スプリット」の単純差分をドリフト指標として記述に使わない。コールドスタート由来のHR上昇に fatigue ラベルを付けない
 - フォーム変化: GCT増加=疲労、VO増加=フォーム崩れ、ケイデンス低下=エネルギー枯渇
 - 環境統合: 上りはペース低下正常、気温25℃超はHR+5-10bpm許容
 - パワー評価: W/kg比率（体重60kg仮定）、スプリット間15%以上低下は疲労兆候
 - 歩幅評価: 5%以上低下は疲労蓄積
-- ケイデンス評価: 180-190 spm目標、max_cadenceとの10spm以上差はリズム乱れ
+- ケイデンス評価: `get_form_evaluations` の `cadence_expected` / `cadence_delta_pct` / `cadence_needs_improvement`（ペース依存 trained baseline, #215）を権威的ソースとする。**固定の「180spm目標」で各スプリットの不足を判定しない**（遅いペースでは期待ケイデンスも低い）。ペース相応かどうかで記述し、max_cadence との10spm以上差は「リズム乱れ」の観点として残してよい
 - 計測エラー: contract の `anomaly_thresholds` に該当する異常値を指摘
 
 **文体**: 日本語コーチングトーン、具体的数値、1-2文/スプリット。


### PR DESCRIPTION
## 概要

split-section-analyst のスプリット解説の評価基準を2点修正（プロンプトのみ、コード変更なし）。

1. **HRドリフト**: 序盤の正常なウォームアップHR上昇を「疲労」「有酸素能力の上限」と誤読していた。定常区間の前半 vs 後半で判定し、Split 1（コールドスタート）基準の単純差分や fatigue ラベルを使わないよう明記。
2. **ケイデンス**: 固定「180-190spm目標」を撤廃し、#215 のペース依存 trained baseline（`cadence_expected`/`cadence_needs_improvement`）を権威的ソースに。

## 検証
Level: L3（agent定義変更）。プロンプト文言はレビュー済み（変更2箇所が正確に反映、周辺行維持）。

注: 分析エージェント定義は Claude Code 本体がmainから読むため、pre-merge での Agent 実行による E2E は構造的に不可。マージ後に fixture activity 20636804823 で /analyze-activity を実行し、split セクションが (a) 序盤HR上昇を疲労扱いしない (b) ケイデンスを固定180基準で語らない、を確認する。

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)