### PR TITLE
fix(agent): split-section-analyst — grant get_form_evaluations access for pace-dependent cadence + warmup-aware highlights

### DIFF
--- a/.claude/agents/split-section-analyst.md
+++ b/.claude/agents/split-section-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: split-section-analyst
 description: 全1kmスプリットのペース・心拍・フォーム指標を詳細分析し、環境統合評価を行うエージェント。DuckDBに保存。スプリット毎の変化パターン検出が必要な時に呼び出す。
-tools: mcp__garmin-db__get_splits_comprehensive, mcp__garmin-db__detect_form_anomalies_summary, mcp__garmin-db__get_form_anomaly_details, mcp__garmin-db__get_split_time_series_detail, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
+tools: mcp__garmin-db__get_splits_comprehensive, mcp__garmin-db__detect_form_anomalies_summary, mcp__garmin-db__get_form_anomaly_details, mcp__garmin-db__get_split_time_series_detail, mcp__garmin-db__get_form_evaluations, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
 model: sonnet
 ---
 
@@ -62,12 +62,12 @@ contract の `required_fields` と `evaluation_policy` に従い `analysis_data`
 
 **分析観点** (contract の evaluation_policy を参照):
 - ペース安定性: training type に応じた基準で評価
-- HR ドリフト: ウォームアップ後の定常区間で「前半 vs 後半」を比較して判定（contract の first-half vs second-half method）。**序盤スプリット（Split 1 や定常化前の最初の数分）のHR上昇は安静→定常への正常なウォームアップ応答であり、疲労・オーバーペース・「有酸素能力の上限」とは解釈しない**。「Split 1（コールドスタート）→ 末尾スプリット」の単純差分をドリフト指標として記述に使わない。コールドスタート由来のHR上昇に fatigue ラベルを付けない
+- HR ドリフト: ウォームアップ後の定常区間で「前半 vs 後半」を比較して判定（contract の first-half vs second-half method）。**序盤スプリット（Split 1 や定常化前の最初の数分）のHR上昇は安静→定常への正常なウォームアップ応答であり、疲労・オーバーペース・「有酸素能力の上限」とは解釈しない**。「Split 1（コールドスタート）→ 末尾スプリット」の単純差分をドリフト指標として記述に使わない。コールドスタート由来のHR上昇に fatigue ラベルを付けない。 この方針は per-split 本文だけでなく **highlights 要約にも適用**し、highlights でも「Split 1 → 末尾スプリットのドリフト◯%は疲労兆候」のようなコールドスタート基準・疲労ラベルの表現を使わない。
 - フォーム変化: GCT増加=疲労、VO増加=フォーム崩れ、ケイデンス低下=エネルギー枯渇
 - 環境統合: 上りはペース低下正常、気温25℃超はHR+5-10bpm許容
 - パワー評価: W/kg比率（体重60kg仮定）、スプリット間15%以上低下は疲労兆候
 - 歩幅評価: 5%以上低下は疲労蓄積
-- ケイデンス評価: `get_form_evaluations` の `cadence_expected` / `cadence_delta_pct` / `cadence_needs_improvement`（ペース依存 trained baseline, #215）を権威的ソースとする。**固定の「180spm目標」で各スプリットの不足を判定しない**（遅いペースでは期待ケイデンスも低い）。ペース相応かどうかで記述し、max_cadence との10spm以上差は「リズム乱れ」の観点として残してよい
+- ケイデンス評価: **必ず `get_form_evaluations` を呼び**、その `cadence_expected` / `cadence_delta_pct` / `cadence_needs_improvement`（ペース依存 trained baseline, #215）でケイデンスの良否を判定する。**固定の「180spm目標」「180-190spm」等の閾値表現は一切使わない**（遅いペースでは期待ケイデンスも低いため）。各スプリットのケイデンスは「期待値◯spm に対し実測◯spm（ペース相応/やや低い等）」の形で記述し、max_cadence との10spm以上差は「リズム乱れ」の観点として残してよい
 - 計測エラー: contract の `anomaly_thresholds` に該当する異常値を指摘
 
 **文体**: 日本語コーチングトーン、具体的数値、1-2文/スプリット。


### PR DESCRIPTION
## 概要（#228 のフォローアップ）

#228 で per-split の HR 解釈は改善したが、E2E検証で残課題2点を確認したため修正（プロンプトのみ）。

1. **ケイデンス**: split agent に `get_form_evaluations` のアクセス権を付与し、ペース依存 trained baseline（`cadence_expected`/`cadence_needs_improvement`, #215）で評価。固定「180-190spm」表現を撤廃。（#228 では split agent がこのツールにアクセスできず固定180に戻っていた = 設計ミスの是正）
2. **HRドリフト**: コールドスタート基準・疲労ラベルの不使用を **highlights 要約にも適用**する旨を明記（#228 では本文のみ直り highlights に残存していた）

## 変更（`.claude/agents/split-section-analyst.md` のみ）
- frontmatter `tools:` に `mcp__garmin-db__get_form_evaluations` を追加
- ケイデンス評価行: 「必ず get_form_evaluations を呼びペース依存baselineで判定、固定閾値表現は使わない」
- HRドリフト行: 「highlights要約にもコールドスタート基準・疲労ラベル不使用を適用」を追記

## 検証
Level: L3。マージ後に fixture 20636804823 で split-section-analyst を実行し、(a) highlights にコールドスタート基準ドリフト/疲労表記がない (b) ケイデンスに固定180表記がなくペース依存判定になっている、を確認する。

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)