### PR TITLE
feat(prefetch): expand activity context into full analysis bundle

### DIFF
--- a/packages/garmin-mcp-server/src/garmin_mcp/database/readers/physiology.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/database/readers/physiology.py
@@ -232,6 +232,132 @@ class PhysiologyReader(BaseDBReader):
             logger.error(f"Error getting VO2 max data: {e}")
             return None
 
+    def get_form_baseline_trend(
+        self,
+        activity_id: int,
+        activity_date: str,
+        user_id: str = "default",
+        condition_group: str = "flat_road",
+    ) -> dict[str, Any]:
+        """Get form baseline trend by comparing current vs 1-month-prior baselines.
+
+        Reads coefficient baselines from form_baseline_history for the period
+        containing ``activity_date`` and the period one month earlier, then
+        computes per-metric deltas.
+
+        Args:
+            activity_id: Activity ID (echoed in the result).
+            activity_date: Activity date in YYYY-MM-DD format.
+            user_id: Baseline owner (default "default").
+            condition_group: Baseline condition group (default "flat_road").
+
+        Returns:
+            Dict with keys ``success`` (bool) and either ``error`` (str) or
+            ``activity_id``/``activity_date``/``metrics`` (dict). Mirrors the
+            previous handler implementation exactly.
+        """
+        from datetime import datetime
+
+        from dateutil.relativedelta import relativedelta
+
+        try:
+            with self._get_connection() as conn:
+                # Get current period baseline
+                current_baselines = conn.execute(
+                    """
+                    SELECT metric, coef_d, coef_b, period_start, period_end
+                    FROM form_baseline_history
+                    WHERE user_id = ?
+                      AND condition_group = ?
+                      AND period_start <= ?
+                      AND period_end >= ?
+                    ORDER BY metric
+                    """,
+                    [user_id, condition_group, activity_date, activity_date],
+                ).fetchall()
+
+                if not current_baselines:
+                    return {
+                        "success": False,
+                        "error": f"No baseline found for {activity_date}",
+                    }
+
+                # Calculate 1 month before the current period start
+                current_period_start = datetime.strptime(
+                    str(current_baselines[0][3]), "%Y-%m-%d"
+                )
+                one_month_before = current_period_start - relativedelta(months=1)
+                target_date = one_month_before.strftime("%Y-%m-%d")
+
+                # Get previous period baseline (1 month before)
+                previous_baselines = conn.execute(
+                    """
+                    SELECT metric, coef_d, coef_b, period_start, period_end
+                    FROM form_baseline_history
+                    WHERE user_id = ?
+                      AND condition_group = ?
+                      AND period_start <= ?
+                      AND period_end >= ?
+                    ORDER BY metric
+                    """,
+                    [user_id, condition_group, target_date, target_date],
+                ).fetchall()
+
+            if not previous_baselines:
+                return {
+                    "success": False,
+                    "error": (
+                        "No previous baseline found for comparison "
+                        f"(target: {target_date})"
+                    ),
+                }
+
+            # Build result with current and previous coefficients
+            metrics_data: dict[str, Any] = {}
+            for curr in current_baselines:
+                metric = curr[0]
+                metrics_data[metric] = {
+                    "current": {
+                        "coef_d": curr[1],
+                        "coef_b": curr[2],
+                        "period": f"{curr[3]} to {curr[4]}",
+                    }
+                }
+
+            for prev in previous_baselines:
+                metric = prev[0]
+                if metric in metrics_data:
+                    metrics_data[metric]["previous"] = {
+                        "coef_d": prev[1],
+                        "coef_b": prev[2],
+                        "period": f"{prev[3]} to {prev[4]}",
+                    }
+                    # Calculate deltas
+                    if (
+                        metrics_data[metric]["current"]["coef_d"] is not None
+                        and prev[1] is not None
+                    ):
+                        metrics_data[metric]["delta_d"] = (
+                            metrics_data[metric]["current"]["coef_d"] - prev[1]
+                        )
+                    if (
+                        metrics_data[metric]["current"]["coef_b"] is not None
+                        and prev[2] is not None
+                    ):
+                        metrics_data[metric]["delta_b"] = (
+                            metrics_data[metric]["current"]["coef_b"] - prev[2]
+                        )
+
+            return {
+                "success": True,
+                "activity_id": activity_id,
+                "activity_date": activity_date,
+                "metrics": metrics_data,
+            }
+
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
     def get_lactate_threshold_data(self, activity_id: int) -> dict[str, Any] | None:
         """
         Get lactate threshold data from lactate_threshold table.

--- a/packages/garmin-mcp-server/src/garmin_mcp/handlers/physiology_handler.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/handlers/physiology_handler.py
@@ -53,123 +53,16 @@ class PhysiologyHandler:
     async def _get_form_baseline_trend(
         self, arguments: dict[str, Any]
     ) -> list[TextContent]:
-        from datetime import datetime
-
-        from dateutil.relativedelta import relativedelta
-
-        from garmin_mcp.database.connection import get_connection
-
         activity_id = arguments["activity_id"]
         activity_date = arguments["activity_date"]
         user_id = arguments.get("user_id", "default")
         condition_group = arguments.get("condition_group", "flat_road")
 
-        try:
-            with get_connection(self._db_reader.db_path) as conn:
-                # Get current period baseline
-                current_baselines = conn.execute(
-                    """
-                    SELECT metric, coef_d, coef_b, period_start, period_end
-                    FROM form_baseline_history
-                    WHERE user_id = ?
-                      AND condition_group = ?
-                      AND period_start <= ?
-                      AND period_end >= ?
-                    ORDER BY metric
-                    """,
-                    [user_id, condition_group, activity_date, activity_date],
-                ).fetchall()
+        result = self._db_reader.physiology.get_form_baseline_trend(
+            activity_id,
+            activity_date,
+            user_id=user_id,
+            condition_group=condition_group,
+        )
 
-                if not current_baselines:
-                    result: dict[str, Any] = {
-                        "success": False,
-                        "error": f"No baseline found for {activity_date}",
-                    }
-                    return [
-                        TextContent(
-                            type="text",
-                            text=format_json_response(result),
-                        )
-                    ]
-
-                # Calculate 1 month before the current period start
-                current_period_start = datetime.strptime(
-                    str(current_baselines[0][3]), "%Y-%m-%d"
-                )
-                one_month_before = current_period_start - relativedelta(months=1)
-                target_date = one_month_before.strftime("%Y-%m-%d")
-
-                # Get previous period baseline (1 month before)
-                previous_baselines = conn.execute(
-                    """
-                    SELECT metric, coef_d, coef_b, period_start, period_end
-                    FROM form_baseline_history
-                    WHERE user_id = ?
-                      AND condition_group = ?
-                      AND period_start <= ?
-                      AND period_end >= ?
-                    ORDER BY metric
-                    """,
-                    [user_id, condition_group, target_date, target_date],
-                ).fetchall()
-
-            if not previous_baselines:
-                result = {
-                    "success": False,
-                    "error": f"No previous baseline found for comparison (target: {target_date})",
-                }
-                return [
-                    TextContent(
-                        type="text",
-                        text=format_json_response(result),
-                    )
-                ]
-
-            # Build result with current and previous coefficients
-            metrics_data: dict[str, Any] = {}
-            for curr in current_baselines:
-                metric = curr[0]
-                metrics_data[metric] = {
-                    "current": {
-                        "coef_d": curr[1],
-                        "coef_b": curr[2],
-                        "period": f"{curr[3]} to {curr[4]}",
-                    }
-                }
-
-            for prev in previous_baselines:
-                metric = prev[0]
-                if metric in metrics_data:
-                    metrics_data[metric]["previous"] = {
-                        "coef_d": prev[1],
-                        "coef_b": prev[2],
-                        "period": f"{prev[3]} to {prev[4]}",
-                    }
-                    # Calculate deltas
-                    if (
-                        metrics_data[metric]["current"]["coef_d"] is not None
-                        and prev[1] is not None
-                    ):
-                        metrics_data[metric]["delta_d"] = (
-                            metrics_data[metric]["current"]["coef_d"] - prev[1]
-                        )
-                    if (
-                        metrics_data[metric]["current"]["coef_b"] is not None
-                        and prev[2] is not None
-                    ):
-                        metrics_data[metric]["delta_b"] = (
-                            metrics_data[metric]["current"]["coef_b"] - prev[2]
-                        )
-
-            result = {
-                "success": True,
-                "activity_id": activity_id,
-                "activity_date": activity_date,
-                "metrics": metrics_data,
-            }
-
-            return [TextContent(type="text", text=format_json_response(result))]
-
-        except Exception as e:
-            result = {"success": False, "error": str(e)}
-            return [TextContent(type="text", text=format_json_response(result))]
+        return [TextContent(type="text", text=format_json_response(result))]

--- a/packages/garmin-mcp-server/src/garmin_mcp/rag/queries/comparisons.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/rag/queries/comparisons.py
@@ -275,7 +275,9 @@ class WorkoutComparator:
             for row in results:
                 candidate = {
                     "activity_id": row[0],
-                    "activity_date": row[1],
+                    # DuckDB DATE columns return datetime.date; convert to str so
+                    # the dict is JSON-serializable at the MCP boundary (Issue #235).
+                    "activity_date": str(row[1]) if row[1] is not None else None,
                     "activity_name": row[2],
                     "avg_pace": row[3],
                     "avg_heart_rate": row[4],
@@ -376,7 +378,9 @@ class WorkoutComparator:
 
             activity_data = {
                 "activity_id": row[0],
-                "activity_date": row[1],
+                # DuckDB DATE columns return datetime.date; convert to str so
+                # the dict is JSON-serializable at the MCP boundary (Issue #235).
+                "activity_date": str(row[1]) if row[1] is not None else None,
                 "activity_name": row[2],
                 "avg_pace": row[3],
                 "avg_heart_rate": row[4],

--- a/packages/garmin-mcp-server/src/garmin_mcp/scripts/prefetch_activity_context.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/scripts/prefetch_activity_context.py
@@ -44,8 +44,19 @@ Output (JSON to stdout):
         "run": {"avg_pace": "5:45/km", "avg_hr": 155.0},
         "cooldown": {"avg_pace": "7:12/km", "avg_hr": 140.0}
       },
-      "planned_workout": null
+      "planned_workout": null,
+      "form_evaluation": {...},      # FormReader.get_form_evaluations (or null)
+      "hr_zones_detail": {"zones": [...]},  # PhysiologyReader (or null)
+      "form_baseline_trend": {"success": true, "metrics": {...}},
+      "similar_workouts": {"target_activity": {...}, "similar_activities": [...]},
+      "vo2_max": null,               # training-type conditional (or data dict)
+      "lactate_threshold": null      # training-type conditional (or data dict)
     }
+
+Bundle keys form_evaluation..lactate_threshold are additive (Issue #235);
+existing keys above are never modified. vo2_max / lactate_threshold are
+training-type conditional (tempo/threshold -> LT only; vo2max/interval/speed
+-> vo2_max only; others -> both null; unknown type -> both included).
 """
 
 import argparse
@@ -53,6 +64,37 @@ import json
 import sys
 
 from garmin_mcp.database.connection import get_connection, get_db_path
+
+# Training types for which lactate threshold is the relevant aerobic ceiling.
+_LT_TRAINING_TYPES = {"tempo", "threshold", "lactate_threshold"}
+# Training types for which VO2 max is the relevant aerobic ceiling.
+_VO2_TRAINING_TYPES = {"vo2max", "vo2_max", "interval", "speed"}
+
+
+def _should_include_vo2_max(training_type: str | None) -> bool:
+    """Decide whether vo2_max is relevant for the given training type.
+
+    Rules (see Issue #235):
+    - None training_type -> include (safe side)
+    - vo2max / interval / speed -> include
+    - everything else -> exclude
+    """
+    if training_type is None:
+        return True
+    return training_type.lower() in _VO2_TRAINING_TYPES
+
+
+def _should_include_lactate_threshold(training_type: str | None) -> bool:
+    """Decide whether lactate_threshold is relevant for the given training type.
+
+    Rules (see Issue #235):
+    - None training_type -> include (safe side)
+    - tempo / threshold -> include
+    - everything else -> exclude
+    """
+    if training_type is None:
+        return True
+    return training_type.lower() in _LT_TRAINING_TYPES
 
 
 def _classify_terrain(avg_gain_per_km: float | None) -> str:
@@ -332,6 +374,54 @@ def prefetch_activity_context(activity_id: int) -> dict:
         except Exception:
             pass  # Table may not exist
 
+    # ------------------------------------------------------------------
+    # Bundle expansion (S1, Issue #235): reuse existing readers/comparators
+    # so each section agent receives a complete analysis bundle without
+    # issuing redundant MCP calls. All keys below are additive — existing
+    # keys above are never modified (backward compatible).
+    # ------------------------------------------------------------------
+    from garmin_mcp.database.readers.form import FormReader
+    from garmin_mcp.database.readers.physiology import PhysiologyReader
+
+    db_path_str = str(db_path)
+    form_reader = FormReader(db_path_str)
+    physiology_reader = PhysiologyReader(db_path_str)
+
+    # Full pace-corrected form evaluation (needs_improvement flags, deltas, etc.)
+    form_evaluation = form_reader.get_form_evaluations(activity_id)
+
+    # Heart rate zone boundaries + time distribution
+    hr_zones_detail = physiology_reader.get_heart_rate_zones_detail(activity_id)
+
+    # Form baseline trend (current vs 1-month-prior coefficients). Uses the
+    # reader extracted from physiology_handler so logic is shared, not duplicated.
+    form_baseline_trend = physiology_reader.get_form_baseline_trend(
+        activity_id, activity_date
+    )
+
+    # VO2 max / lactate threshold are training-type conditional.
+    vo2_max = (
+        physiology_reader.get_vo2_max_data(activity_id)
+        if _should_include_vo2_max(training_type)
+        else None
+    )
+    lactate_threshold = (
+        physiology_reader.get_lactate_threshold_data(activity_id)
+        if _should_include_lactate_threshold(training_type)
+        else None
+    )
+
+    # Similar past workouts (own connection via WorkoutComparator). Called once,
+    # outside the read transaction above. Key is always present (null on error).
+    similar_workouts: dict | None
+    try:
+        from garmin_mcp.rag.queries.comparisons import WorkoutComparator
+
+        comparator = WorkoutComparator(db_path_str)
+        similar_workouts = comparator.find_similar_workouts(activity_id, limit=3)
+    except Exception:
+        similar_workouts = None
+
     return {
         "activity_id": activity_id,
         "activity_date": activity_date,
@@ -355,6 +445,13 @@ def prefetch_activity_context(activity_id: int) -> dict:
         "form_scores": form_scores,
         "phase_structure": phase_structure,
         "planned_workout": planned_workout,
+        # --- S1 bundle expansion (Issue #235, additive) ---
+        "form_evaluation": form_evaluation,
+        "hr_zones_detail": hr_zones_detail,
+        "form_baseline_trend": form_baseline_trend,
+        "similar_workouts": similar_workouts,
+        "vo2_max": vo2_max,
+        "lactate_threshold": lactate_threshold,
     }
 
 

--- a/packages/garmin-mcp-server/tests/database/test_readers_physiology.py
+++ b/packages/garmin-mcp-server/tests/database/test_readers_physiology.py
@@ -204,3 +204,175 @@ class TestGetLactateThreshold:
 
     def test_missing_activity(self, phys_reader: PhysiologyReader):
         assert phys_reader.get_lactate_threshold_data(MISSING_ID) is None
+
+
+# ---------------------------------------------------------------------------
+# get_form_baseline_trend (extracted from PhysiologyHandler in Issue #235)
+# ---------------------------------------------------------------------------
+
+
+def _seed_baseline_history(db_path: Path) -> None:
+    """Insert current (October) and previous (September) baselines.
+
+    Mirrors the previous handler's two-period comparison logic so the
+    reader output can be validated against known expectations.
+    """
+    conn = duckdb.connect(str(db_path))
+    rows = [
+        # (user_id, condition_group, metric, coef_d, coef_b, period_start, period_end)
+        ("default", "flat_road", "GCT", -0.15, 260.0, "2025-10-01", "2025-10-31"),
+        ("default", "flat_road", "VO", 0.02, 8.0, "2025-10-01", "2025-10-31"),
+        ("default", "flat_road", "GCT", -0.12, 265.0, "2025-09-01", "2025-09-30"),
+        ("default", "flat_road", "VO", 0.025, 8.5, "2025-09-01", "2025-09-30"),
+    ]
+    for i, (uid, cg, metric, cd, cb, ps, pe) in enumerate(rows):
+        conn.execute(
+            """
+            INSERT INTO form_baseline_history
+                (history_id, user_id, condition_group, metric,
+                 coef_d, coef_b, period_start, period_end)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [i, uid, cg, metric, cd, cb, ps, pe],
+        )
+    conn.close()
+
+
+@pytest.mark.unit
+class TestGetFormBaselineTrend:
+    """Tests for PhysiologyReader.get_form_baseline_trend()."""
+
+    def test_success_both_periods(self, reader_db_path: Path):
+        _seed_baseline_history(reader_db_path)
+        reader = PhysiologyReader(db_path=str(reader_db_path))
+
+        result = reader.get_form_baseline_trend(12345, "2025-10-15")
+
+        assert result["success"] is True
+        assert result["activity_id"] == 12345
+        assert result["activity_date"] == "2025-10-15"
+        gct = result["metrics"]["GCT"]
+        # coef columns are FLOAT in DuckDB → compare with tolerance.
+        assert gct["current"]["coef_d"] == pytest.approx(-0.15)
+        assert gct["previous"]["coef_d"] == pytest.approx(-0.12)
+        assert gct["delta_d"] == pytest.approx(-0.15 - (-0.12))
+        assert gct["delta_b"] == pytest.approx(260.0 - 265.0)
+
+    def test_no_current_baseline(self, reader_db_path: Path):
+        # No baselines seeded → no current period match.
+        reader = PhysiologyReader(db_path=str(reader_db_path))
+        result = reader.get_form_baseline_trend(12345, "2025-10-15")
+        assert result["success"] is False
+        assert "No baseline found" in result["error"]
+
+    def test_no_previous_baseline(self, reader_db_path: Path):
+        # Seed only the current (October) period.
+        conn = duckdb.connect(str(reader_db_path))
+        conn.execute("""
+            INSERT INTO form_baseline_history
+                (history_id, user_id, condition_group, metric,
+                 coef_d, coef_b, period_start, period_end)
+            VALUES (0, 'default', 'flat_road', 'GCT',
+                    -0.15, 260.0, '2025-10-01', '2025-10-31')
+            """)
+        conn.close()
+        reader = PhysiologyReader(db_path=str(reader_db_path))
+        result = reader.get_form_baseline_trend(12345, "2025-10-15")
+        assert result["success"] is False
+        assert "No previous baseline found" in result["error"]
+
+    def test_custom_user_id_and_condition_group(self, reader_db_path: Path):
+        # Seed under a custom user_id/condition_group only.
+        conn = duckdb.connect(str(reader_db_path))
+        custom = [
+            ("runner1", "hilly", "GCT", -0.15, 260.0, "2025-10-01", "2025-10-31"),
+            ("runner1", "hilly", "GCT", -0.12, 265.0, "2025-09-01", "2025-09-30"),
+        ]
+        for i, (uid, cg, metric, cd, cb, ps, pe) in enumerate(custom):
+            conn.execute(
+                """
+                INSERT INTO form_baseline_history
+                    (history_id, user_id, condition_group, metric,
+                     coef_d, coef_b, period_start, period_end)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [i, uid, cg, metric, cd, cb, ps, pe],
+            )
+        conn.close()
+        reader = PhysiologyReader(db_path=str(reader_db_path))
+
+        # Default user/group → not found.
+        default_result = reader.get_form_baseline_trend(12345, "2025-10-15")
+        assert default_result["success"] is False
+
+        # Custom user/group → success.
+        custom_result = reader.get_form_baseline_trend(
+            12345, "2025-10-15", user_id="runner1", condition_group="hilly"
+        )
+        assert custom_result["success"] is True
+        assert "GCT" in custom_result["metrics"]
+
+    def test_delta_with_none_coef(self, reader_db_path: Path):
+        conn = duckdb.connect(str(reader_db_path))
+        rows = [
+            ("default", "flat_road", "GCT", None, 260.0, "2025-10-01", "2025-10-31"),
+            ("default", "flat_road", "GCT", -0.12, 265.0, "2025-09-01", "2025-09-30"),
+        ]
+        for i, (uid, cg, metric, cd, cb, ps, pe) in enumerate(rows):
+            conn.execute(
+                """
+                INSERT INTO form_baseline_history
+                    (history_id, user_id, condition_group, metric,
+                     coef_d, coef_b, period_start, period_end)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [i, uid, cg, metric, cd, cb, ps, pe],
+            )
+        conn.close()
+        reader = PhysiologyReader(db_path=str(reader_db_path))
+        result = reader.get_form_baseline_trend(12345, "2025-10-15")
+        gct = result["metrics"]["GCT"]
+        # delta_d omitted because current coef_d is None.
+        assert "delta_d" not in gct
+        assert gct["delta_b"] == pytest.approx(260.0 - 265.0)
+
+    def test_baseline_reader_matches_handler(self, reader_db_path: Path):
+        """Extracted reader returns the exact dict the old handler produced.
+
+        The previous PhysiologyHandler._get_form_baseline_trend built this
+        structure inline; this asserts the migration is behavior-preserving.
+        """
+        _seed_baseline_history(reader_db_path)
+        reader = PhysiologyReader(db_path=str(reader_db_path))
+
+        result = reader.get_form_baseline_trend(12345, "2025-10-15")
+
+        # Top-level envelope matches the old handler exactly.
+        assert result["success"] is True
+        assert result["activity_id"] == 12345
+        assert result["activity_date"] == "2025-10-15"
+        assert set(result["metrics"].keys()) == {"GCT", "VO"}
+
+        # Expected per-metric coefficients (coef_* columns are FLOAT → approx).
+        # Each tuple: (curr_d, curr_b, prev_d, prev_b).
+        expected_metrics: dict[str, tuple[float, float, float, float]] = {
+            "GCT": (-0.15, 260.0, -0.12, 265.0),
+            "VO": (0.02, 8.0, 0.025, 8.5),
+        }
+        for metric, (curr_d, curr_b, prev_d, prev_b) in expected_metrics.items():
+            block = result["metrics"][metric]
+            # Structure preserved (current/previous/delta keys + period strings).
+            assert set(block.keys()) == {
+                "current",
+                "previous",
+                "delta_d",
+                "delta_b",
+            }
+            assert block["current"]["coef_d"] == pytest.approx(curr_d)
+            assert block["current"]["coef_b"] == pytest.approx(curr_b)
+            assert block["current"]["period"] == "2025-10-01 to 2025-10-31"
+            assert block["previous"]["coef_d"] == pytest.approx(prev_d)
+            assert block["previous"]["coef_b"] == pytest.approx(prev_b)
+            assert block["previous"]["period"] == "2025-09-01 to 2025-09-30"
+            assert block["delta_d"] == pytest.approx(curr_d - prev_d)
+            assert block["delta_b"] == pytest.approx(curr_b - prev_b)

--- a/packages/garmin-mcp-server/tests/handlers/test_physiology_handler.py
+++ b/packages/garmin-mcp-server/tests/handlers/test_physiology_handler.py
@@ -167,216 +167,66 @@ class TestUnknownTool:
 
 
 # ---------------------------------------------------------------------------
-# _get_form_baseline_trend tests (complex, direct DuckDB queries)
+# get_form_baseline_trend — handler now delegates to PhysiologyReader
 # ---------------------------------------------------------------------------
 
 
-def _make_mock_conn(mocker: Any, side_effects: list) -> MagicMock:
-    """Create a mock duckdb connection with sequential execute().fetchall() results.
-
-    Args:
-        mocker: pytest-mock mocker fixture.
-        side_effects: List of return values for successive fetchall() calls.
-
-    Returns:
-        The patched duckdb.connect mock.
-    """
-    mock_conn = MagicMock()
-
-    # Build chained execute().fetchall() side effects
-    mock_results = []
-    for data in side_effects:
-        mock_result = MagicMock()
-        mock_result.fetchall.return_value = data
-        mock_results.append(mock_result)
-
-    mock_conn.execute.side_effect = mock_results
-
-    # duckdb is imported locally inside _get_form_baseline_trend,
-    # so we patch the top-level duckdb module's connect function.
-    mocker.patch("duckdb.connect", return_value=mock_conn)
-    return mock_conn
-
-
 @pytest.mark.unit
-class TestFormBaselineTrend:
-    """Test _get_form_baseline_trend with mocked DuckDB connection."""
+class TestFormBaselineTrendDelegation:
+    """Handler is a thin delegator to PhysiologyReader.get_form_baseline_trend.
 
-    BASE_ARGS = {
-        "activity_id": 12345,
-        "activity_date": "2025-10-15",
-    }
+    The baseline trend logic was extracted to the reader in Issue #235;
+    these tests verify the handler forwards arguments and serializes the
+    reader's result without modification.
+    """
 
-    CURRENT_BASELINES = [
-        # (metric, coef_d, coef_b, period_start, period_end)
-        ("GCT", -0.15, 260.0, "2025-10-01", "2025-10-31"),
-        ("VO", 0.02, 8.0, "2025-10-01", "2025-10-31"),
-        ("VR", 0.01, 7.0, "2025-10-01", "2025-10-31"),
-    ]
+    BASE_ARGS = {"activity_id": 12345, "activity_date": "2025-10-15"}
 
-    PREVIOUS_BASELINES = [
-        ("GCT", -0.12, 265.0, "2025-09-01", "2025-09-30"),
-        ("VO", 0.025, 8.5, "2025-09-01", "2025-09-30"),
-        ("VR", 0.015, 7.5, "2025-09-01", "2025-09-30"),
-    ]
+    def _reader_with_physiology(self, return_value: Any) -> MagicMock:
+        reader = MagicMock()
+        reader.physiology.get_form_baseline_trend.return_value = return_value
+        return reader
 
     @pytest.mark.asyncio
-    async def test_success_both_periods(
-        self, mock_db_reader: MagicMock, mocker: MagicMock
-    ) -> None:
-        mock_db_reader.db_path = "/fake/db.duckdb"
-        _make_mock_conn(mocker, [self.CURRENT_BASELINES, self.PREVIOUS_BASELINES])
+    async def test_delegates_and_serializes(self) -> None:
+        expected = {
+            "success": True,
+            "activity_id": 12345,
+            "activity_date": "2025-10-15",
+            "metrics": {"GCT": {"current": {"coef_d": -0.15}}},
+        }
+        reader = self._reader_with_physiology(expected)
 
-        handler = PhysiologyHandler(mock_db_reader)
+        handler = PhysiologyHandler(reader)
         result = await handler.handle("get_form_baseline_trend", self.BASE_ARGS)
 
-        parsed = json.loads(result[0].text)
-        assert parsed["success"] is True
-        assert parsed["activity_id"] == 12345
-        assert parsed["activity_date"] == "2025-10-15"
-
-        metrics = parsed["metrics"]
-        assert "GCT" in metrics
-        assert "VO" in metrics
-        assert "VR" in metrics
-
-        # Verify GCT deltas
-        gct = metrics["GCT"]
-        assert gct["current"]["coef_d"] == -0.15
-        assert gct["current"]["coef_b"] == 260.0
-        assert gct["previous"]["coef_d"] == -0.12
-        assert gct["previous"]["coef_b"] == 265.0
-        assert gct["delta_d"] == pytest.approx(-0.15 - (-0.12))
-        assert gct["delta_b"] == pytest.approx(260.0 - 265.0)
-
-    @pytest.mark.asyncio
-    async def test_no_current_baseline(
-        self, mock_db_reader: MagicMock, mocker: MagicMock
-    ) -> None:
-        mock_db_reader.db_path = "/fake/db.duckdb"
-        _make_mock_conn(mocker, [[]])  # Empty current baselines
-
-        handler = PhysiologyHandler(mock_db_reader)
-        result = await handler.handle("get_form_baseline_trend", self.BASE_ARGS)
-
-        parsed = json.loads(result[0].text)
-        assert parsed["success"] is False
-        assert "No baseline found" in parsed["error"]
-
-    @pytest.mark.asyncio
-    async def test_no_previous_baseline(
-        self, mock_db_reader: MagicMock, mocker: MagicMock
-    ) -> None:
-        mock_db_reader.db_path = "/fake/db.duckdb"
-        _make_mock_conn(mocker, [self.CURRENT_BASELINES, []])
-
-        handler = PhysiologyHandler(mock_db_reader)
-        result = await handler.handle("get_form_baseline_trend", self.BASE_ARGS)
-
-        parsed = json.loads(result[0].text)
-        assert parsed["success"] is False
-        assert "No previous baseline found" in parsed["error"]
-
-    @pytest.mark.asyncio
-    async def test_exception_handling(
-        self, mock_db_reader: MagicMock, mocker: MagicMock
-    ) -> None:
-        mock_db_reader.db_path = "/fake/db.duckdb"
-        mocker.patch(
-            "duckdb.connect",
-            side_effect=RuntimeError("DB connection failed"),
+        assert json.loads(result[0].text) == expected
+        reader.physiology.get_form_baseline_trend.assert_called_once_with(
+            12345, "2025-10-15", user_id="default", condition_group="flat_road"
         )
 
-        handler = PhysiologyHandler(mock_db_reader)
-        result = await handler.handle("get_form_baseline_trend", self.BASE_ARGS)
-
-        parsed = json.loads(result[0].text)
-        assert parsed["success"] is False
-        assert "DB connection failed" in parsed["error"]
-
     @pytest.mark.asyncio
-    async def test_custom_user_id_and_condition_group(
-        self, mock_db_reader: MagicMock, mocker: MagicMock
-    ) -> None:
-        mock_db_reader.db_path = "/fake/db.duckdb"
-        mock_conn = _make_mock_conn(
-            mocker, [self.CURRENT_BASELINES, self.PREVIOUS_BASELINES]
-        )
+    async def test_custom_user_id_and_condition_group(self) -> None:
+        reader = self._reader_with_physiology({"success": True, "metrics": {}})
 
         args = {
             **self.BASE_ARGS,
             "user_id": "runner1",
             "condition_group": "hilly",
         }
-
-        handler = PhysiologyHandler(mock_db_reader)
+        handler = PhysiologyHandler(reader)
         await handler.handle("get_form_baseline_trend", args)
 
-        # Verify the first execute call used custom user_id and condition_group
-        first_call_args = mock_conn.execute.call_args_list[0]
-        params = first_call_args[0][1]
-        assert params[0] == "runner1"
-        assert params[1] == "hilly"
-
-    @pytest.mark.asyncio
-    async def test_default_user_id_and_condition_group(
-        self, mock_db_reader: MagicMock, mocker: MagicMock
-    ) -> None:
-        mock_db_reader.db_path = "/fake/db.duckdb"
-        mock_conn = _make_mock_conn(
-            mocker, [self.CURRENT_BASELINES, self.PREVIOUS_BASELINES]
+        reader.physiology.get_form_baseline_trend.assert_called_once_with(
+            12345, "2025-10-15", user_id="runner1", condition_group="hilly"
         )
 
-        handler = PhysiologyHandler(mock_db_reader)
-        await handler.handle("get_form_baseline_trend", self.BASE_ARGS)
-
-        # Verify defaults: user_id="default", condition_group="flat_road"
-        first_call_args = mock_conn.execute.call_args_list[0]
-        params = first_call_args[0][1]
-        assert params[0] == "default"
-        assert params[1] == "flat_road"
-
     @pytest.mark.asyncio
-    async def test_delta_with_none_coef(
-        self, mock_db_reader: MagicMock, mocker: MagicMock
-    ) -> None:
-        """When coef_d or coef_b is None, deltas should not be computed."""
-        mock_db_reader.db_path = "/fake/db.duckdb"
-        current = [("GCT", None, 260.0, "2025-10-01", "2025-10-31")]
-        previous = [("GCT", -0.12, 265.0, "2025-09-01", "2025-09-30")]
-        _make_mock_conn(mocker, [current, previous])
+    async def test_error_result_passed_through(self) -> None:
+        error = {"success": False, "error": "No baseline found for 2025-10-15"}
+        reader = self._reader_with_physiology(error)
 
-        handler = PhysiologyHandler(mock_db_reader)
+        handler = PhysiologyHandler(reader)
         result = await handler.handle("get_form_baseline_trend", self.BASE_ARGS)
 
-        parsed = json.loads(result[0].text)
-        assert parsed["success"] is True
-        gct = parsed["metrics"]["GCT"]
-        # delta_d should not be present because current coef_d is None
-        assert "delta_d" not in gct
-        # delta_b should still be computed
-        assert gct["delta_b"] == pytest.approx(260.0 - 265.0)
-
-    @pytest.mark.asyncio
-    async def test_metric_in_current_but_not_previous(
-        self, mock_db_reader: MagicMock, mocker: MagicMock
-    ) -> None:
-        """Metrics that exist in current but not previous should have no 'previous' or deltas."""
-        mock_db_reader.db_path = "/fake/db.duckdb"
-        current = [
-            ("GCT", -0.15, 260.0, "2025-10-01", "2025-10-31"),
-            ("NEW_METRIC", 0.5, 100.0, "2025-10-01", "2025-10-31"),
-        ]
-        previous = [("GCT", -0.12, 265.0, "2025-09-01", "2025-09-30")]
-        _make_mock_conn(mocker, [current, previous])
-
-        handler = PhysiologyHandler(mock_db_reader)
-        result = await handler.handle("get_form_baseline_trend", self.BASE_ARGS)
-
-        parsed = json.loads(result[0].text)
-        assert parsed["success"] is True
-        # NEW_METRIC should have current but no previous or deltas
-        nm = parsed["metrics"]["NEW_METRIC"]
-        assert "current" in nm
-        assert "previous" not in nm
-        assert "delta_d" not in nm
+        assert json.loads(result[0].text) == error

--- a/packages/garmin-mcp-server/tests/integration/test_prefetch_bundle_integration.py
+++ b/packages/garmin-mcp-server/tests/integration/test_prefetch_bundle_integration.py
@@ -1,0 +1,181 @@
+"""Integration tests for the expanded prefetch_activity_context bundle (Issue #235).
+
+These exercise prefetch_activity_context() against the verification DuckDB
+(fixture activity 12345678901, training_type=aerobic_base) to confirm the new
+bundle keys are populated by the real readers and that existing keys do not
+regress (backward compatibility).
+"""
+
+import json
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from garmin_mcp.scripts.prefetch_activity_context import prefetch_activity_context
+
+FIXTURE_ACTIVITY_ID = 12345678901
+
+
+def _patch_db_path(monkeypatch: pytest.MonkeyPatch, verification_db_path: Path) -> None:
+    """Point prefetch_activity_context.get_db_path() at the verification DB.
+
+    prefetch resolves the path once and passes it explicitly to every reader,
+    so patching this single entry point routes all reads to the fixture DB.
+    """
+    monkeypatch.setattr(
+        "garmin_mcp.scripts.prefetch_activity_context.get_db_path",
+        lambda *a, **k: verification_db_path,
+    )
+
+
+def _insert_form_evaluation(db_path: Path) -> None:
+    """Insert a minimal form_evaluations row for the fixture activity.
+
+    The verification fixture has no form_evaluations row; this seeds one with a
+    known gct_needs_improvement flag so the bundle's form_evaluation key is
+    populated by FormReader.get_form_evaluations.
+    """
+    conn = duckdb.connect(str(db_path))
+    conn.execute(
+        """
+        INSERT INTO form_evaluations (
+            eval_id, activity_id,
+            gct_ms_expected, vo_cm_expected, vr_pct_expected,
+            gct_ms_actual, vo_cm_actual, vr_pct_actual,
+            gct_delta_pct, vo_delta_cm, vr_delta_pct,
+            gct_star_rating, gct_score, gct_needs_improvement,
+            vo_star_rating, vo_score, vo_needs_improvement,
+            vr_star_rating, vr_score, vr_needs_improvement,
+            cadence_actual, cadence_minimum, cadence_achieved,
+            overall_score, overall_star_rating,
+            integrated_score, training_mode
+        ) VALUES (
+            1, ?,
+            245.0, 8.0, 7.0,
+            250.0, 8.5, 7.2,
+            2.0, 0.5, 2.8,
+            '★★★★☆', 4.0, false,
+            '★★★★☆', 4.0, false,
+            '★★★★☆', 4.0, false,
+            178.0, 170, true,
+            4.0, '★★★★☆',
+            90.0, 'aerobic'
+        )
+        """,
+        [FIXTURE_ACTIVITY_ID],
+    )
+    conn.close()
+
+
+# Baseline set of existing keys prior to the S1 bundle expansion. These must
+# always be present and unchanged (backward compatibility guarantee).
+EXISTING_KEYS = {
+    "activity_id",
+    "activity_date",
+    "training_type",
+    "temperature_c",
+    "humidity_pct",
+    "wind_mps",
+    "wind_direction",
+    "terrain_category",
+    "avg_elevation_gain_per_km",
+    "total_elevation_gain",
+    "total_elevation_loss",
+    "zone_percentages",
+    "primary_zone",
+    "zone_distribution_rating",
+    "hr_stability",
+    "aerobic_efficiency",
+    "training_quality",
+    "zone2_focus",
+    "zone4_threshold_work",
+    "form_scores",
+    "phase_structure",
+    "planned_workout",
+}
+
+
+@pytest.mark.integration
+class TestPrefetchBundleExpansion:
+    """Bundle expansion behavior against the verification DuckDB."""
+
+    def test_prefetch_includes_form_evaluation(
+        self, verification_db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _insert_form_evaluation(verification_db_path)
+        _patch_db_path(monkeypatch, verification_db_path)
+
+        result = prefetch_activity_context(FIXTURE_ACTIVITY_ID)
+
+        assert "form_evaluation" in result
+        form_eval = result["form_evaluation"]
+        assert form_eval is not None
+        # FormReader returns nested per-metric blocks; needs_improvement is bool.
+        assert isinstance(form_eval["gct"]["needs_improvement"], bool)
+        assert form_eval["gct"]["needs_improvement"] is False
+
+    def test_prefetch_similar_workouts_key_always_present(
+        self, verification_db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_db_path(monkeypatch, verification_db_path)
+
+        result = prefetch_activity_context(FIXTURE_ACTIVITY_ID)
+
+        # Key must always exist even when there are no similar workouts.
+        assert "similar_workouts" in result
+        assert result["similar_workouts"] is None or isinstance(
+            result["similar_workouts"], dict
+        )
+
+    def test_prefetch_vo2max_conditional_easy(
+        self, verification_db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_db_path(monkeypatch, verification_db_path)
+
+        result = prefetch_activity_context(FIXTURE_ACTIVITY_ID)
+
+        # Fixture training_type is aerobic_base → vo2_max excluded (None),
+        # lactate_threshold also excluded for non-tempo/threshold types.
+        assert result["training_type"] == "aerobic_base"
+        assert result["vo2_max"] is None
+        assert result["lactate_threshold"] is None
+
+    def test_prefetch_existing_keys_unchanged(
+        self, verification_db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _patch_db_path(monkeypatch, verification_db_path)
+
+        result = prefetch_activity_context(FIXTURE_ACTIVITY_ID)
+
+        # All pre-existing keys remain present (no regression).
+        assert EXISTING_KEYS.issubset(result.keys())
+        # New keys are strictly additive.
+        new_keys = {
+            "form_evaluation",
+            "hr_zones_detail",
+            "form_baseline_trend",
+            "similar_workouts",
+            "vo2_max",
+            "lactate_threshold",
+        }
+        assert new_keys.issubset(result.keys())
+        # Core existing values still resolve from the fixture.
+        assert result["activity_id"] == FIXTURE_ACTIVITY_ID
+        assert result["training_type"] == "aerobic_base"
+
+    def test_prefetch_bundle_is_json_serializable(
+        self, verification_db_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The whole bundle must be JSON-serializable with no custom encoder.
+
+        The MCP layer json-serializes the bundle, so any raw datetime.date
+        (e.g. similar_workouts activity_date) breaks the entire tool (Issue
+        #235). json.dumps without default= would raise on such a value.
+        """
+        _patch_db_path(monkeypatch, verification_db_path)
+
+        result = prefetch_activity_context(FIXTURE_ACTIVITY_ID)
+
+        # No default= encoder: a raw date anywhere in the bundle would raise.
+        json.dumps(result, ensure_ascii=False)

--- a/packages/garmin-mcp-server/tests/rag/queries/test_comparisons.py
+++ b/packages/garmin-mcp-server/tests/rag/queries/test_comparisons.py
@@ -1,5 +1,7 @@
 """Tests for WorkoutComparator."""
 
+import json
+from datetime import date
 from unittest.mock import patch
 
 import pytest
@@ -227,6 +229,59 @@ class TestWorkoutComparator:
         assert result is not None
         assert len(result["similar_activities"]) == 1
         assert result["similar_activities"][0]["activity_date"] == "2025-09-15"
+
+    def test_find_similar_workouts_date_objects_serialized_to_str(self, comparator):
+        """DuckDB DATE columns (datetime.date) must be returned as JSON-safe str.
+
+        Real DuckDB returns ``datetime.date`` for DATE columns; the result is
+        JSON-serialized at the MCP boundary, so raw date objects break the tool
+        (Issue #235). Both target and candidate dates must come back as str and
+        the whole result must be json.dumps-able with no custom encoder.
+        """
+        target_rows = [
+            (
+                12345,
+                date(2025, 10, 1),
+                "Run",
+                300.0,
+                150.0,
+                10.0,
+                3.5,
+                0.5,
+                180.0,
+                250.0,
+            ),
+        ]
+        similar_rows = [
+            (
+                12340,
+                date(2025, 9, 15),
+                "Run",
+                305.0,
+                148.0,
+                10.0,
+                3.3,
+                0.4,
+                178.0,
+                245.0,
+            ),
+        ]
+
+        with patch.object(
+            comparator,
+            "_execute_query",
+            side_effect=[target_rows, similar_rows],
+        ):
+            result = comparator.find_similar_workouts(
+                activity_id=12345,
+                pace_tolerance=0.1,
+                distance_tolerance=0.1,
+            )
+
+        assert result["target_activity"]["activity_date"] == "2025-10-01"
+        assert result["similar_activities"][0]["activity_date"] == "2025-09-15"
+        # No custom default= encoder: raw date objects would raise here.
+        json.dumps(result)
 
     def test_calculate_similarity_score(self, comparator):
         """Test similarity score calculation."""


### PR DESCRIPTION
Closes #235 (Epic #234, S1)

## Summary
`prefetch_activity_context` を「完全な分析バンドル」に拡張（L0 計算層）。各 section agent が個別 fetch していたデータをサーバ側で1回に集約し、後続の薄エージェント化（S2〜）の基盤を作る。**既存キーは一切変更せず追加のみ（後方互換）**。

## Changes
- **追加バンドルキー**（既存 reader を再利用）: `form_evaluation`, `hr_zones_detail`, `form_baseline_trend`, `similar_workouts`, training-type 条件付きの `vo2_max` / `lactate_threshold`
- **reader 抽出**: `PhysiologyHandler._get_form_baseline_trend` のクエリを `PhysiologyReader.get_form_baseline_trend` に抽出し、handler / prefetch 双方から共有（ロジック重複排除）
- **date シリアライズ修正**: `WorkoutComparator.find_similar_workouts` が DuckDB の `datetime.date` を生のまま返していた（docstring は `str` を宣言）→ `str()` 変換。これにより MCP の JSON 境界での `Object of type date is not JSON serializable` を解消

## Validation (L2 PASS)
- prefetch（実 activity 20636804823）が JSON エラーなく返却、追加6キー存在、`activity_date` は文字列、`vo2_max`/`lactate_threshold` は aerobic_base で None、既存キー回帰なし
- integration 180 passed / 0 failures
- 回帰テスト追加: `test_prefetch_bundle_is_json_serializable`, `test_find_similar_workouts_date_objects_serialized_to_str`（JSON シリアライズ境界をカバー）

## Note
date シリアライズ不具合は L2 検証（MCP 境界の `json.dumps`）で発見。integration テストが Python dict をアサートしていたため当初すり抜けた → 境界テストを追加して再発防止。

🤖 Generated with [Claude Code](https://claude.com/claude-code)