### PR TITLE
docs(validation): redesign L1/L2/L3 flow to be reload_server-independent

### DIFF
--- a/.claude/agents/validation-agent.md
+++ b/.claude/agents/validation-agent.md
@@ -1,7 +1,7 @@
 ---
 name: validation-agent
-description: Worktree コード変更の L1/L2/L3 検証を実行するエージェント。reload_server で MCP を切り替え、MCP tools や analyst agents を使って検証する。
-tools: mcp__garmin-db__reload_server, mcp__garmin-db__get_server_info, mcp__garmin-db__get_activity_by_date, mcp__garmin-db__prefetch_activity_context, mcp__garmin-db__get_performance_trends, mcp__garmin-db__get_splits_comprehensive, mcp__garmin-db__get_form_efficiency_summary, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__get_heart_rate_zones_detail, mcp__garmin-db__get_form_evaluations, mcp__garmin-db__get_form_baseline_trend, mcp__garmin-db__get_weather_data, mcp__garmin-db__get_splits_elevation, mcp__garmin-db__get_form_anomaly_details, mcp__garmin-db__detect_form_anomalies_summary, mcp__garmin-db__get_split_time_series_detail, mcp__garmin-db__get_vo2_max_data, mcp__garmin-db__get_lactate_threshold_data, mcp__garmin-db__compare_similar_workouts, Agent, Bash, Read, Write, Glob, Grep
+description: Worktree コード変更の L1/L2 検証を実行するエージェント。reload_server を使わず、worktree コードをインプロセス import / subprocess pytest で検証する。L3（agent 定義検証）はメインセッションが担当する。
+tools: Bash, Read, Write, Glob, Grep
 model: inherit
 ---
 
@@ -9,40 +9,87 @@ model: inherit
 
 Worktree で実装されたコード変更を検証するエージェント。
 
+> **重要: このエージェントは `reload_server` を呼ばない。**
+> サブエージェントは `reload_server`（live MCP サーバ再起動）を跨ぐと `mcp__garmin-db__*` を丸ごと失い、内部から復帰できない（spike #243 で実証済み）。
+> worktree コードの検証は **インプロセス import（subprocess 経由）** と **subprocess pytest** で行う。これにより live MCP サーバの状態に一切依存せず、disconnect も発生しない。
+> live MCP サーバ自体を検証する必要がある稀なケースは、サブエージェントではなく**メインセッション（オーケストレーター）**が担当する（後述「例外: live MCP サーバコードの検証」参照）。
+
 ## Step 0: Manifest 読み込み
 
 1. `/tmp/validation_queue/{branch}.json` を Read で取得
    - manifest が存在しない場合: orchestrator から直接渡された情報を使用（fallback）
 2. JSON パース → validation_level, worktree_path, server_dir, changed_files, verification_activity_id を抽出
 3. validation_level が skip → 即座に PASS を返却して終了
-4. L1/L2/L3 → 対応する検証セクションへ進む
+4. validation_level が L3 → このエージェントでは実行しない。L3 はメインセッションが担当する旨を報告して終了（下記「L3」節参照）
+5. L1/L2 → 対応する検証セクションへ進む
 
 ## 検証レベル
 
-### L1: MCP Check
-1. `reload_server(server_dir=worktree_server_dir)` で worktree に切替
-2. `get_server_info()` で server_dir が worktree を指すことを確認
-3. 影響を受ける MCP tool を `verification_activity_id` で呼び出す
-4. 結果の妥当性チェック（非null、型一致、値範囲）
-5. `reload_server()` で main 復帰
+### L1: In-process Check（reload なし）
 
-### L2: Integration
-1. L1 を実行
-2. Worktree 内で `uv run pytest -m integration --tb=short -q`
+worktree コードを **subprocess でインプロセス import** し、変更ツールの下層関数を直接呼び出して値を検証する。live MCP サーバの reload は行わない。
+
+#### Step 1: 検証対象関数の特定
+
+`changed_files` から「どの下層関数を呼ぶか」を特定する:
+
+- handler 変更（`handlers/<name>_handler.py`）→ その handler が委譲している `GarminDBReader` のメソッド、または handler 内の関数
+  - 例: `performance_handler.py` → `GarminDBReader().get_performance_trends(activity_id)`
+- reader 変更（`database/readers/*.py`, `database/db_reader.py`）→ 該当 `GarminDBReader` メソッド
+- script/関数モジュール変更 → そのモジュールの公開関数（例: `scripts.prefetch_activity_context.prefetch_activity_context`）
+
+import パスと呼び出し対象が不明な場合は、変更ファイルを Read して公開関数/メソッドのシグネチャを確認する。
+
+#### Step 2: subprocess で値検証
+
+worktree の server パッケージを `--directory` 指定で実行し、関数を import して呼び出す。`json.dumps`（MCP 境界相当のシリアライズ）まで通すことで、MCP tool 経由と等価な検証になる:
+
+```bash
+uv run --directory <worktree>/packages/garmin-mcp-server python -c \
+  "import json; from garmin_mcp.<module> import <func>; print(json.dumps(<func>(<activity_id>), default=str))"
+```
+
+reader メソッドの場合の例:
+
+```bash
+uv run --directory <worktree>/packages/garmin-mcp-server python -c \
+  "import json; from garmin_mcp.database.db_reader import GarminDBReader; print(json.dumps(GarminDBReader().get_performance_trends(<activity_id>), default=str))"
+```
+
+`<activity_id>` には manifest の `verification_activity_id` を使う。
+
+#### Step 3: 妥当性チェック
+
+subprocess の標準出力（JSON 文字列）に対して:
+
+- 非 null（空でない、`null` 単体でない）
+- 期待される型・構造と一致
+- 値が妥当な範囲内:
+  - ペース 3:00-9:00/km（180-540 sec/km）
+  - HR 80-200 bpm
+- `json.dumps` が例外なく完了している（= MCP 境界でシリアライズ可能）
+- subprocess の exit code が 0（import エラー・実行時例外がない）
+
+### L2: Integration（reload なし）
+
+1. L1（上記 In-process Check）を実行
+2. Worktree 内で integration テストを実行:
+   ```bash
+   uv run --directory <worktree> pytest -m integration --tb=short -q
+   ```
+3. テスト結果の判定:
+   - 全 pass → L2 pass
+   - 失敗あり → 失敗テスト名とエラー内容を記録、L2 fail
+
+> reload_server / health check ステップは存在しない。worktree の subprocess 値検証 + subprocess pytest のみで完結する。
 
 ### L3: Full E2E
-1. L1 を実行
-2. L2 の integration テスト実行
-3. 5つの analyst agents を並列起動して `/analyze-activity` 相当の処理を実行
-4. 検証基準チェック:
-   - **構造**: 全5セクションの `analysis_data` 非null、必須フィールド存在
-   - **内容**: ペース/HR が fixture 範囲と整合、セクション間矛盾なし
-   - Fixture: `dev-reference.md` §3 の L3 検証基準を参照
-5. (任意) DuckDB 挿入検証: `insert_section_analysis_dict` で各セクションを挿入し成功を確認
-6. (任意) レポート生成検証: Markdown レポートが生成され、5セクション分の内容を含むことを確認
-7. `reload_server()` で main 復帰
 
-## L3 Fixture
+**L3 はこのサブエージェントでは実行しない。** L3（agent 定義 = `*-analyst.md` の変更）は、worktree の `.md` を main に一時適用してメインセッションで `/analyze-activity` を実行する方式であり、`reload_server` を使わずメインセッション（オーケストレーター）が担当する。詳細は `worktree-validation-protocol.md` の「L3: Full E2E（メインセッション担当）」を参照。
+
+このエージェントが L3 manifest を受け取った場合は、検証を実行せず「L3 はメインセッションが担当する」旨を報告して終了する。
+
+## L3 Fixture（参考）
 
 - Activity: `20636804823` (2025-10-09, aerobic_base 5.66km, ~6:26/km, HR avg 144bpm)
 - Content check ranges:
@@ -50,82 +97,21 @@ Worktree で実装されたコード変更を検証するエージェント。
   - HR: 120-160 bpm
 - 詳細は `dev-reference.md` §3 を参照
 
-## L3 実行手順
-
-### Step 1: MCP 切替
-```
-reload_server(server_dir=worktree_server_dir)
-get_server_info()  # server_dir 確認
-```
-
-### Step 2: データ取得
-```
-prefetch_activity_context(activity_id)
-```
-
-### Step 2.5: ANALYSIS_TEMP_DIR 生成
-
-現在時刻の unix timestamp を取得し、timestamp 付きユニークパスを生成:
-```
-ANALYSIS_TEMP_DIR=/tmp/analysis_{activity_id}_{unix_timestamp}
-```
-unix_timestamp は現在時刻の秒数（例: 1709312345）。
-これにより再分析時に前回の JSON が残っていても Write tool の既存ファイル制約を回避できる。
-**事前の mkdir は不要**。Write tool がファイル書き込み時に親ディレクトリを自動作成する。`mkdir -p` や `Bash` でのディレクトリ作成は行わないこと。
-
-### Step 3: 5 Analyst Agents 並列実行
-
-Agent tool で以下を並列起動:
-- efficiency-section-analyst
-- environment-section-analyst
-- phase-section-analyst
-- split-section-analyst
-- summary-section-analyst
-
-各エージェントに activity_id, date, prefetch context, `ANALYSIS_TEMP_DIR` を渡す。
-
-### Step 4: 結果検証
-
-`{ANALYSIS_TEMP_DIR}/` 内の JSON ファイルを Read で確認:
-- 5ファイル存在: efficiency.json, environment.json, phase.json, split.json, summary.json
-- 各ファイルの `analysis_data` が非null
-- `activity_id`, `section_type` フィールドが存在
-- 内容チェック（WARNING レベル）:
-  - ペース値が 360-405 sec/km 範囲内
-  - HR 値が 120-160 bpm 範囲内
-
-### Step 5: DuckDB 挿入検証（任意）
-各セクションの JSON を `insert_section_analysis_dict` で DuckDB に挿入:
-- 5件全て成功すること
-- エラー発生時は WARNING（構造チェックとは別）
-
-### Step 6: レポート生成検証（任意）
-Markdown レポートの基本チェック:
-- ファイルが生成されること
-- 5セクション分の見出しが存在すること
-
-### Step 7: 復帰・クリーンアップ
-```
-reload_server()  # main 復帰
-rm -rf {ANALYSIS_TEMP_DIR}/
-```
-
 ## 判定基準
 
 - **構造チェック失敗**: FAIL（致命的）
 - **内容チェック失敗**: WARNING
 - **テスト失敗 (L2)**: FAIL
+- **subprocess exit code 非0 / import エラー (L1)**: FAIL
 
 ## 出力
 
 検証結果を以下の形式で報告:
 ```
 Validation Result: PASS / FAIL / WARNING
-Level: L1 / L2 / L3
+Level: L1 / L2
 Details:
-  - MCP health: OK/NG
-  - Tool checks: N/N passed
+  - Verified function: <module>.<func>
+  - In-process check: OK/NG (non-null, type, range, json-serializable)
   - Tests: pass/fail (L2+)
-  - Agents: N/5 succeeded (L3)
-  - Structure: OK/NG (L3)
 ```

--- a/.claude/rules/dev/dev-reference.md
+++ b/.claude/rules/dev/dev-reference.md
@@ -76,9 +76,9 @@ Skip: Design セクションなし、Issue番号不明、dry-run時。
 
 ### 検証フロー (FIFO キュー + Validation Agent)
 
-1. L1: `reload_server(server_dir=worktree_path)` → MCP tool 呼び出し → 非null、型一致、値範囲チェック (pace 3:00-9:00, HR 80-200) → `reload_server()` で復帰
-2. L2: L1 + worktree 内で `uv run pytest -m integration --tb=short -q`
-3. L3: L2 + Validation Agent で `/analyze-activity` 実行 + 構造/内容チェック（詳細は `worktree-validation-protocol.md`）
+1. L1: worktree コードを subprocess で import → 下層関数を `verification_activity_id` で呼び出し → 非null、型一致、値範囲 (pace 3:00-9:00, HR 80-200)、`json.dumps` 可能を検証（`reload_server` は使わない）
+2. L2: L1 + worktree 内で `uv run --directory <worktree> pytest -m integration --tb=short -q`
+3. L3: agent 定義変更時、メインセッションが worktree の `.md` を main に一時適用 → `/analyze-activity` 実行 + 構造/内容チェック → `git checkout` で復元（reload 非依存。詳細は `worktree-validation-protocol.md`）
 
 ### L3 検証基準
 
@@ -134,6 +134,6 @@ Skip: Design セクションなし、Issue番号不明、dry-run時。
 
 ## 9. Real Data Validation
 
-- コード変更後は `reload_server()` 必須（stale state で false negative になる）
+- worktree コード変更の検証は in-process / subprocess（`uv run --directory <worktree> ...`）で行う。`reload_server` は使わない（サブエージェントは reload を跨ぐと `mcp__garmin-db__*` を失う。spike #243）。live MCP 確認が要る稀なケースのみメインセッションが reload + `get_server_info` の ready ポーリング
 - MCP tool 変更 → 実 activity_id で `statistics_only=True/False` 両方テスト
 - Agent 定義変更 → fixture データで E2E 検証

--- a/.claude/rules/dev/implementation-workflow.md
+++ b/.claude/rules/dev/implementation-workflow.md
@@ -58,7 +58,7 @@ Risks セクション（任意）:
 |-------|---------|---------|
 | L1 | `uv run pytest {test_path} -m unit -v` | 0 failures |
 | L2 | L1 + `uv run pytest -m integration --tb=short -q` | 0 failures |
-| L3 | L2 + Validation Agent（foreground）で `reload_server` → `/analyze-activity` 実行 | analysis_data 非null + 必須フィールド存在 |
+| L3 | L2 + メインセッションが worktree の `.md` を main に一時適用 → `/analyze-activity` 実行 → `git checkout` で復元（reload 非依存） | analysis_data 非null + 必須フィールド存在 |
 | skip | Validation Agent スキップ。コードレビュー(Phase 2a)のみ | 2a チェック通過 |
 
 **CRITICAL**: テスト結果は自分のターンで確認する。サブエージェントの報告を信じない。

--- a/.claude/rules/dev/worktree-validation-protocol.md
+++ b/.claude/rules/dev/worktree-validation-protocol.md
@@ -20,13 +20,23 @@ Main Session (queue manager — 検証作業はしない)
                   Validation Agent #3 (foreground) → C 検証
 ```
 
+## reload_server 非依存の原則
+
+検証フローは **`reload_server`（live MCP サーバ再起動）に依存しない**。
+
+- サブエージェント（Validation Agent）は `reload_server` を跨ぐと `mcp__garmin-db__*` を丸ごと失い、内部から復帰できない（spike #243 で実証済み）。
+- worktree コードの検証は **インプロセス import（subprocess 経由）** と **subprocess pytest** で行う方が堅牢（実証済み）。
+- L1/L2 はサブエージェント（Validation Agent）が subprocess で完結させる。
+- L3（agent 定義変更）はメインセッション（オーケストレーター）が worktree の `.md` を main に一時適用して実行する（agent コード ≠ MCP サーバコード）。
+- **live MCP サーバコード自体を検証したい稀なケースのみ**、メインセッションが `reload_server` を扱う（後述「例外」節）。サブエージェント内で `reload_server` を呼ぶことは禁止。
+
 ## Validation Levels
 
 | Level | 名称 | 内容 | コスト |
 |-------|------|------|--------|
-| L1 | MCP check | reload_server → MCP tool 呼び出し → 値の妥当性 | ~20K tokens |
+| L1 | In-process check | worktree コードを subprocess で import → 下層関数呼び出し → 値の妥当性 | ~20K tokens |
 | L2 | Integration | L1 + worktree 内で `uv run pytest -m integration` | ~30K tokens |
-| L3 | Full E2E | `/analyze-activity` を worktree 上で実行 + 検証基準チェック | ~150K tokens |
+| L3 | Full E2E | worktree の agent `.md` を main に一時適用 → `/analyze-activity` 実行 + 検証基準チェック → 復元 | ~150K tokens |
 
 レベル判定は `dev-reference.md` §3 の Validation Level 判定表を参照。
 
@@ -55,63 +65,104 @@ Main Session (queue manager — 検証作業はしない)
 
 ## Main Session の責務 (Queue Manager)
 
-- 完了通知を受信したら Validation Agent を **foreground** で起動（毎回新規）
-- Validation Agent の結果に応じて:
+- 完了通知を受信したら、validation_level に応じて起動先を選ぶ:
+  - **L1 / L2**: Validation Agent を **foreground** で起動（毎回新規）
+  - **L3**: メインセッション（オーケストレーター）が**自分で**実行する（後述「L3: Full E2E（メインセッション担当）」）。L3 はサブエージェントに委譲しない
+- 検証結果に応じて:
   - **pass**: PR を ready にする / `/ship` 候補としてユーザーに報告
   - **fail**: PR にコメント追記、修正指示
-- 検証作業は一切しない（委譲のみ）
+- L1/L2 の検証作業自体はサブエージェントに委譲する（Queue Manager は委譲のみ）。L3 のみメインセッションが直接実行する
 
-## Validation Agent の責務
+## Validation Agent の責務（L1 / L2）
 
 毎回独立起動。前回の検証コンテキストは持たない。
-manifest の `validation_level` に応じた手順を実行する。
+manifest の `validation_level` が L1/L2 のときのみ起動される。**サブエージェントは `reload_server` を呼ばない。**
 
-### L1: MCP Check
+### L1: In-process Check（reload なし）
 
 1. Manifest 読み込み (`/tmp/validation_queue/<branch>.json`)
-2. `mcp__garmin-db__reload_server(server_dir=worktree_server_dir)` で worktree に切替
-3. Health check: `mcp__garmin-db__get_server_info()` で server_dir が worktree を指すことを確認
-4. `changed_files` から影響を受ける MCP tool を特定し、`verification_activity_id` で呼び出す
-5. 結果の妥当性チェック:
+2. `changed_files` から「どの下層関数を呼ぶか」を特定:
+   - handler 変更 → 委譲先の `GarminDBReader` メソッド（または handler 内関数）
+   - reader 変更 → 該当 `GarminDBReader` メソッド
+   - script/関数モジュール変更 → 公開関数
+   - 不明な場合は変更ファイルを Read してシグネチャを確認
+3. worktree コードを subprocess で import し、`verification_activity_id` で呼び出す。`json.dumps`（MCP 境界相当）まで通す:
+   ```bash
+   uv run --directory <worktree>/packages/garmin-mcp-server python -c \
+     "import json; from garmin_mcp.<module> import <func>; print(json.dumps(<func>(<activity_id>), default=str))"
+   ```
+   reader メソッド例:
+   ```bash
+   uv run --directory <worktree>/packages/garmin-mcp-server python -c \
+     "import json; from garmin_mcp.database.db_reader import GarminDBReader; print(json.dumps(GarminDBReader().get_performance_trends(<activity_id>), default=str))"
+   ```
+4. 結果の妥当性チェック:
    - 返却値が非 null
    - 期待される型・構造と一致
    - 値が妥当な範囲内（ペース 3:00-9:00/km、HR 80-200 bpm 等）
-6. `mcp__garmin-db__reload_server()` で main 復帰
-7. pass/fail + 詳細を返却
+   - `json.dumps` が例外なく完了（= MCP 境界でシリアライズ可能）
+   - subprocess の exit code が 0
+5. pass/fail + 詳細を返却
 
-### L2: Integration
+> `reload_server` / health check は使わない。live MCP サーバの状態に一切依存しないため disconnect は発生しない。
 
-1-3. L1 と同じ（reload_server + health check）
-4. L1 の MCP check を実行（上記 4-5）
-5. Worktree ディレクトリで integration テスト実行:
+### L2: Integration（reload なし）
+
+1. L1（In-process Check）を実行（上記 1-4）
+2. Worktree ディレクトリで integration テスト実行:
    ```bash
-   cd {worktree_path} && uv run pytest -m integration --tb=short -q
+   uv run --directory <worktree> pytest -m integration --tb=short -q
    ```
-6. テスト結果の判定:
+3. テスト結果の判定:
    - 全 pass → L2 pass
    - 失敗あり → 失敗テスト名とエラー内容を記録、L2 fail
-7. `mcp__garmin-db__reload_server()` で main 復帰
-8. pass/fail + 詳細を返却
+4. pass/fail + 詳細を返却
 
-### L3: Full E2E
+> reload_server / health check ステップは存在しない。subprocess 値検証 + subprocess pytest のみ。
 
-1-3. L1 と同じ（reload_server + health check）
-4. `/analyze-activity {fixture_date}` を実行（analyze-activity.md が Single Source of Truth）
+## L3: Full E2E（メインセッション担当）
+
+L3（agent 定義 = `*-analyst.md` の変更）は**サブエージェントに委譲せず、メインセッション（オーケストレーター）が直接実行する**。
+agent コードは MCP サーバコードではないため `reload_server` は不要。worktree の `.md` を main の `.claude/agents/` に一時適用し、main 側にすでにバンドルされている prefetch 等の MCP tool で `/analyze-activity` を実行すれば足りる。
+
+メインセッションが以下を実行する:
+
+1. **適用**: worktree の対象 `.md`（`changed_files` の `.claude/agents/*-analyst.md`）を main repo の `.claude/agents/` にコピー（上書き）
+   ```bash
+   cp <worktree>/.claude/agents/<name>-analyst.md <main>/.claude/agents/<name>-analyst.md
+   ```
+2. **実行**: メインセッションで `/analyze-activity {fixture_date}` を実行（analyze-activity.md が Single Source of Truth）
    - temp ディレクトリパスは analyze-activity.md の ANALYSIS_TEMP_DIR 定義に従う（timestamp 付きユニークパス）
    - Fixture: `dev-reference.md` §3 の L3 検証基準を参照
-5. 検証基準チェック（`dev-reference.md` §3 の L3 検証基準）:
+3. **検証基準チェック**（`dev-reference.md` §3 の L3 検証基準）:
    - **構造チェック**: 5 セクションの `analysis_data` が非 null、必須フィールド存在
    - **内容チェック**: ペース・HR 値が fixture 範囲と整合、セクション間矛盾なし
-6. (任意) DuckDB 挿入検証: `insert_section_analysis_dict` で各セクション挿入成功を確認
-7. (任意) レポート生成検証: Markdown レポート生成 + 5セクション見出し存在を確認
-8. `mcp__garmin-db__reload_server()` で main 復帰
-9. pass/fail + 詳細を返却
+4. (任意) DuckDB 挿入検証: `insert_section_analysis_dict` で各セクション挿入成功を確認
+5. (任意) レポート生成検証: Markdown レポート生成 + 5セクション見出し存在を確認
+6. **復元**: 一時適用した `.md` を main の git 管理状態に戻す
+   ```bash
+   git -C <main> checkout -- .claude/agents/<name>-analyst.md
+   ```
+7. pass/fail + 詳細を返却
+
+> live MCP サーバ再起動（`reload_server`）は使わない。agent 定義の差し替えはファイルの一時適用→復元で完結する。
+
+## 例外: live MCP サーバコードの検証（メインセッション限定）
+
+MCP サーバコード自体（handler/reader の挙動を live MCP tool 経由で確認したい等）を検証する**稀なケースのみ**、以下をメインセッションが行う。**サブエージェント内で `reload_server` を呼ぶことは禁止**（reload を跨ぐと `mcp__garmin-db__*` を失い復帰不能）。
+
+1. メインセッション（サブエージェント不可）が `mcp__garmin-db__reload_server(server_dir=<worktree>/packages/garmin-mcp-server)` で worktree に切替
+2. `mcp__garmin-db__get_server_info()` を **ready になるまでポーリング**し、`server_dir` が worktree を指すことを確認
+3. 対象 MCP tool を `verification_activity_id` で呼び出して値を検証
+4. `mcp__garmin-db__reload_server()`（引数なし）で main 復帰
+5. 通常は L1 の in-process 検証で十分なため、この手順は L1/L2 の代替ではなく追加の確認手段として位置づける
 
 ### 判定基準
 
 - **構造チェック失敗**: FAIL（致命的）— PR にブロッキングコメント
 - **内容チェック失敗**: WARNING — PR にコメント記載、マージ判断はユーザーに委ねる
 - **テスト失敗 (L2)**: FAIL — 失敗テストの詳細を PR コメントに記載
+- **subprocess exit code 非0 / import エラー (L1)**: FAIL — エラー内容を PR コメントに記載
 
 ## Skip 条件
 


### PR DESCRIPTION
Closes #244 (spike #243 の B 主)

## Summary
worktree 検証フロー（L1/L2/L3）を `reload_server`（live MCP サーバ再起動）非依存に再設計。サブエージェントは reload を跨ぐと `mcp__garmin-db__*` を丸ごと失い内部復帰できない（spike #243 実証）ため、検証はインプロセス/subprocess で行う。

## Changes
- `worktree-validation-protocol.md`: 「reload_server 非依存の原則」追加。L1=変更ツール下層関数の subprocess 値検証、L2=L1+worktree integration pytest（reload 削除）、L3=メインセッションが agent `.md` を main に一時適用→`/analyze-activity`→`git checkout` 復元。live MCP 検証はメインセッション限定の例外節1つ
- `validation-agent.md`: frontmatter の `tools:` から全 `mcp__garmin-db__*`（reload_server 含む）を削除し `Bash, Read, Write, Glob, Grep` に。「reload_server を呼ばない」明記
- `dev-reference.md` §3/§9, `implementation-workflow.md` Phase 2b: auto-load される dev ルールの reload ベース記述を新方式に揃え（一貫性）

## Validation (skip — docs/agent)
Phase 2a コードレビューのみ。4ファイル間で L1/L2/L3 記述が整合、reload 手順は否定文（呼ばない/使わない）のみ残存、L3 が main 一時適用→復元方式、例外節1つ（サブエージェント禁止明記）を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)