### PR TITLE
feat(server): harden reload with eager handler init and readiness fields

### DIFF
--- a/packages/garmin-mcp-server/src/garmin_mcp/server.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/server.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import signal
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -31,6 +32,10 @@ from garmin_mcp.tool_schemas import get_tool_definitions
 logger = logging.getLogger(__name__)
 
 OVERRIDE_FILE = "/tmp/garmin-mcp-server-dir"
+
+# Process start time, recorded once at module load (ISO 8601, UTC).
+# Callers use this to detect that a reload produced a fresh process.
+_STARTED_AT: str = datetime.now(UTC).isoformat()
 
 
 def _extract_log_context(arguments: dict[str, Any]) -> str:
@@ -89,6 +94,18 @@ def _init_handlers() -> None:
         ExportHandler(db_reader),
         TrainingPlanHandler(db_reader),
     ]
+
+
+def _ensure_handlers_initialized() -> None:
+    """Idempotent eager initialization of the handler registry.
+
+    Called from the startup sequence so that the very first tool call after a
+    (re)start does not pay the lazy-init cost. Safe to call multiple times:
+    re-initializing only rebuilds the registry, which is harmless and keeps the
+    lazy fallback in _dispatch_tool intact for backward compatibility.
+    """
+    if not _handlers:
+        _init_handlers()
 
 
 def _get_server_dir() -> str:
@@ -163,6 +180,8 @@ def _handle_get_server_info() -> list[TextContent]:
         "server_dir": server_dir,
         "override_file_exists": override_exists,
         "override_dir": override_dir,
+        "started_at": _STARTED_AT,
+        "ready": bool(_handlers),
     }
 
     # DB diagnostics (best-effort, never raise)
@@ -245,6 +264,11 @@ async def _handle_reload_server(
         msg = "Server will restart from default directory."
         logger.info("reload_server called - restoring default directory")
 
+    msg += (
+        " Before calling tools, confirm readiness via get_server_info "
+        "(ready=true and a refreshed started_at)."
+    )
+
     loop = asyncio.get_event_loop()
     loop.call_later(0.5, _graceful_shutdown)
     return [
@@ -260,6 +284,10 @@ async def main() -> None:
     from garmin_mcp.utils.logging_config import setup_mcp_logging
 
     setup_mcp_logging()
+    # Eagerly initialize handlers so the first tool call after a (re)start does
+    # not pay the lazy-init cost. The lazy fallback in _dispatch_tool remains as
+    # a safety net for any code path that bypasses this entry point.
+    _ensure_handlers_initialized()
     loop = asyncio.get_event_loop()
     loop.add_signal_handler(signal.SIGTERM, _graceful_shutdown)
     async with stdio_server() as (read_stream, write_stream):

--- a/packages/garmin-mcp-server/tests/handlers/test_server.py
+++ b/packages/garmin-mcp-server/tests/handlers/test_server.py
@@ -7,7 +7,13 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
-from garmin_mcp.server import _handle_get_server_info, _handle_reload_server
+import garmin_mcp.server as server_module
+from garmin_mcp.server import (
+    _dispatch_tool,
+    _ensure_handlers_initialized,
+    _handle_get_server_info,
+    _handle_reload_server,
+)
 
 
 def _mock_get_connection(mock_conn):
@@ -383,3 +389,65 @@ class TestGracefulShutdown:
             _graceful_shutdown()
 
         mock_exit.assert_called_once_with(0)
+
+
+@pytest.mark.unit
+class TestServerReadiness:
+    """Tests for eager handler init and get_server_info readiness fields."""
+
+    def _make_mock_conn(self) -> MagicMock:
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.fetchall.return_value = [("t0",)]
+        mock_conn.execute.return_value.fetchone.return_value = ("2025-10-15",)
+        return mock_conn
+
+    def test_get_server_info_includes_started_at_and_ready(self) -> None:
+        """get_server_info response includes started_at (ISO str) and ready=True."""
+        from datetime import datetime
+
+        # Ensure handlers are initialized so ready reflects an initialized server.
+        _ensure_handlers_initialized()
+        mock_conn = self._make_mock_conn()
+        with (
+            patch(
+                "garmin_mcp.server._get_server_dir",
+                return_value="/some/path",
+            ),
+            patch("garmin_mcp.server.os.path.exists", return_value=False),
+            patch(
+                "garmin_mcp.database.connection.get_connection",
+                _mock_get_connection(mock_conn),
+            ),
+        ):
+            result = _handle_get_server_info()
+
+        data = json.loads(result[0].text)
+        assert isinstance(data["started_at"], str)
+        # started_at must be a valid ISO 8601 timestamp.
+        datetime.fromisoformat(data["started_at"])
+        assert data["ready"] is True
+
+    def test_handlers_eager_initialized(self) -> None:
+        """_ensure_handlers_initialized populates _handlers without a tool call."""
+        # Start from an uninitialized registry.
+        server_module._handlers = []
+        assert server_module._handlers == []
+
+        _ensure_handlers_initialized()
+
+        assert len(server_module._handlers) > 0
+
+    @pytest.mark.asyncio
+    async def test_dispatch_lazy_fallback_still_works(self) -> None:
+        """_dispatch_tool lazily initializes handlers when registry is empty."""
+        # Reset to an empty registry to simulate the legacy lazy path where no
+        # eager init ran (e.g. a code path bypassing main()).
+        server_module._handlers = []
+        assert server_module._handlers == []
+
+        # An unknown tool still reaches the not-found branch *after* the lazy
+        # init runs, so the registry must be populated as a side effect.
+        with pytest.raises(ValueError, match="Unknown tool"):
+            await _dispatch_tool("definitely_not_a_real_tool", {})
+
+        assert len(server_module._handlers) > 0


### PR DESCRIPTION
Closes #245 (spike #243 の A 従)

## Summary
`reload_server` で真に live 再起動が必要な稀なケース向けの堅牢化。再起動後の初回呼び出し遅延を排除し、呼び出し側が「新プロセスが ready か」を判別できるようにする。

## Changes（server.py）
- **eager handler init**: 冪等な `_ensure_handlers_initialized()` を追加し `main()` 起動時（stdio open 前）に実行。再起動直後からツール登録済みに。`_dispatch_tool` の lazy フォールバックは保持（後方互換）
- **`get_server_info` に readiness フィールド**: `started_at`（モジュールロード時の ISO 8601 UTC）と `ready`（`_handlers` 非空）を追加。呼び出し側が「新プロセスか」を判別可能に
- `reload_server` 応答 message に「get_server_info で ready 確認」を追記

## Validation (L2, reload 非依存)
#244 の新方式で検証:
- unit `tests/handlers/test_server.py`: **20 passed**（新規3件: started_at/ready, eager init, lazy fallback）
- in-process check: eager init で handlers=8、`started_at` ISO str、`ready=true`、冪等性確認
- integration suite: **180 passed, 0 failures**

eager init は `_init_handlers` がハンドラ構築のみで DB 接続を開かないため起動失敗しない（存在しない DB パスでも例外なし）。万一の失敗時も lazy フォールバックが残る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)