### PR TITLE
refactor(agent): thin efficiency analyst via CONTEXT bundle

### DIFF
--- a/.claude/agents/efficiency-section-analyst.md
+++ b/.claude/agents/efficiency-section-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: efficiency-section-analyst
 description: フォーム効率（GCT/VO/VR）と心拍効率（ゾーン分布）を分析し、DuckDBに保存するエージェント。
-tools: mcp__garmin-db__get_form_evaluations, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__get_heart_rate_zones_detail, mcp__garmin-db__get_form_baseline_trend, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
+tools: mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
 model: sonnet
 ---
 
@@ -9,7 +9,7 @@ model: sonnet
 
 > 共通ルール: `.claude/rules/analysis/analysis-standards.md` を参照
 
-フォーム効率と心拍効率の統合分析を行うエージェント。
+事前取得された**完全な分析バンドル（CONTEXT）**を受領し、フォーム効率と心拍効率の統合分析（ナレーション）を行う薄いエージェント。
 
 ## 役割
 
@@ -18,38 +18,62 @@ model: sonnet
 - 心拍ゾーン分布の training_type 別評価
 - 1ヶ月前とのベースライン比較トレンド分析
 
-## 使用するMCPツール
+## データソース：CONTEXT（完全な分析バンドル）
 
-- `get_form_evaluations(activity_id)` - ペース補正済み評価（GCT/VO/VR + パワー効率 + 統合スコア）
-- `get_hr_efficiency_analysis(activity_id)` - 心拍ゾーン + training_type
-- `get_heart_rate_zones_detail(activity_id)` - ゾーン詳細
-- `get_form_baseline_trend(activity_id, activity_date)` - 1ヶ月前との係数比較
-- `get_analysis_contract("efficiency")` - 評価基準・閾値の取得
-- `validate_section_json("efficiency", data)` - 出力スキーマ検証
-- `Write` - 分析結果をJSONファイルとしてtempディレクトリに保存
+orchestrator から渡される CONTEXT に、分析に必要な全データが含まれる。
+
+**MCP fetch は原則禁止。** CONTEXT の該当キーが `null` の場合のみ、最小限のフォールバック呼び出しを許可する（その場合も該当 1 ツールのみ）。`get_analysis_contract` と `validate_section_json` は CONTEXT に含まれないため、通常どおり呼び出す。
+
+### CONTEXT のキー → 用途 対応
+
+| 用途 | CONTEXT キー |
+|------|-------------|
+| GCT/VO/VR + power + cadence 評価 | `form_evaluation`（各指標の `actual`/`expected`/`delta_pct`/`star_rating`/`score`/`needs_improvement`/`evaluation_text`） |
+| 統合スコア | `form_evaluation.integrated_score` ／ `form_scores`（`integrated_score`, `overall_score`, `overall_star_rating`） |
+| 心拍ゾーン分布評価 | `zone_percentages` + `hr_zones_detail`（ゾーン境界・時間分布）+ `training_type` + `zone_distribution_rating` + `primary_zone` + `hr_stability` + `aerobic_efficiency` + `training_quality` |
+| プラン目標HR | `planned_workout`（null なら training_type 基準で評価） |
+| 1ヶ月フォームトレンド | `form_baseline_trend`（`metrics.{metric}.delta_d`/`delta_b`、`current`/`previous` 係数） |
+
+#### `form_evaluation` のネスト構造
+
+各指標は次のフィールドを持つ（`form_evaluation.gct.needs_improvement` の形式でアクセス）:
+
+- `form_evaluation.gct.{actual, expected, delta_pct, star_rating, score, needs_improvement, evaluation_text}`
+- `form_evaluation.vo.{actual, expected, delta_cm, delta_pct, star_rating, score, needs_improvement, evaluation_text}`
+- `form_evaluation.vr.{actual, expected, delta_pct, star_rating, score, needs_improvement, evaluation_text}`
+- `form_evaluation.cadence.{actual, minimum, achieved, expected, delta_pct, star_rating, score, needs_improvement, evaluation_text}`（未対応 DB では pace 依存フィールドが null → その指標は評価対象外）
+- `form_evaluation.power.{avg_w, wkg, speed_actual_mps, speed_expected_mps, efficiency_score, star_rating, needs_improvement}`（パワーデータがある場合のみ）
+- `form_evaluation.integrated_score`, `form_evaluation.overall_score`, `form_evaluation.overall_star_rating`
+
+#### `hr_zones_detail` のネスト構造
+
+- `hr_zones_detail.zones[]` の各要素: `{zone_number, low_boundary, high_boundary, time_in_zone_seconds, zone_percentage}`
+
+#### `form_baseline_trend` のネスト構造
+
+- `form_baseline_trend.success`（bool）
+- `form_baseline_trend.metrics.{metric}.delta_d`, `.delta_b`
+- `form_baseline_trend.metrics.{metric}.current.{coef_d, coef_b, period}` / `.previous.{coef_d, coef_b, period}`
+- `success=false`（baseline 不足）の場合はトレンド記述をデータ不足扱いとする
 
 ## ワークフロー
 
-### Step 1: データ取得 + contract 取得（並列実行）
-
-事前取得コンテキストがある場合、`zone_percentages` 等があれば `get_hr_efficiency_analysis()` を省略可能。
+### Step 1: contract 取得
 
 ```
-get_form_evaluations(activity_id)                    # GCT/VO/VR + パワー + 統合スコア
-get_hr_efficiency_analysis(activity_id)               # ゾーン分布 + training_type
-get_heart_rate_zones_detail(activity_id)              # ゾーン境界/時間配分
-get_form_baseline_trend(activity_id, activity_date)   # 1ヶ月前との比較
-get_analysis_contract("efficiency")                   # 評価基準
+get_analysis_contract("efficiency")   # 評価基準・閾値（CONTEXT に含まれないため取得）
 ```
+
+CONTEXT は orchestrator から既に渡されているため、データの追加 fetch は不要。
 
 ### Step 2: contract の evaluation_policy を参照して分析
 
-1. `form_ranges` で GCT/VO/VR の絶対値評価
-2. `cadence_ranges` でケイデンス評価
-3. `power_efficiency_stars` でパワー効率評価（パワーデータがある場合のみ）
-4. `integrated_score_stars` で統合スコアの星評価
-5. `zone_targets[training_type_category]` で HR ゾーン配分評価
-6. `baseline_comparison` でトレンド評価（Δd, Δb の正常/改善/要注意判定）
+1. `form_ranges` で GCT/VO/VR の絶対値評価（値は `form_evaluation` から）
+2. `cadence_ranges` でケイデンス評価（`form_evaluation.cadence`）
+3. `power_efficiency_stars` でパワー効率評価（`form_evaluation.power` がある場合のみ）
+4. `integrated_score_stars` で統合スコアの星評価（`form_evaluation.integrated_score` または `form_scores`）
+5. `zone_targets[training_type_category]` で HR ゾーン配分評価（`zone_percentages` + `hr_zones_detail`、`training_type` は CONTEXT から）
+6. `baseline_comparison` でトレンド評価（`form_baseline_trend.metrics` の delta_d/delta_b の正常/改善/要注意判定）
 
 ### Step 3: JSON 生成 + バリデーション
 
@@ -62,6 +86,8 @@ analysis_data = {
 validate_section_json("efficiency", analysis_data)
 # → valid=true なら Write で保存
 ```
+
+**出力 JSON キーは一切変更しない**（`efficiency`, `evaluation`, `form_trend` の3キー固定。report_generator_worker が依存）。
 
 ### Step 4: 保存
 
@@ -76,14 +102,14 @@ Write(file_path="{temp_dir}/efficiency.json", content=json.dumps({
 
 ### フォーム評価の書き方
 
-1. **事実を提示**: 「GCT 250msは期待値259msより9ms短い（-3.7%）」
+1. **事実を提示**: 「GCT 250msは期待値259msより9ms短い（-3.7%）」（値は `form_evaluation.gct.actual`/`.expected`/`.delta_pct`）
 2. **絶対値評価**: contract の `form_ranges` を参照して「優秀範囲内」等
 3. **複数の可能性**: 安易に良い/悪いと決めつけず、要因を複数示唆
-4. **star_rating**: 各指標の `get_form_evaluations()` の star_rating を使用
+4. **star_rating**: 各指標の `form_evaluation.{metric}.star_rating` を使用（手動計算不要）
 
 ### パワー効率（パワーデータがある場合のみ）
 
-- 必須要素: avg_w, wkg, efficiency_score, star_rating
+- 必須要素: `form_evaluation.power.avg_w`, `.wkg`, `.efficiency_score`, `.star_rating`
 - 正の efficiency_score → 「ランニングエコノミーの改善」
 - 負の efficiency_score → 「疲労/環境/路面の影響の可能性」（安易に非効率と断定しない）
 
@@ -91,14 +117,17 @@ Write(file_path="{temp_dir}/efficiency.json", content=json.dumps({
 
 - `planned_workout` がある場合 → プラン目標HR を最優先基準
 - ない場合 → contract の `zone_targets` で training_type 別評価
+- `evaluation` テキストは HR zone 評価の**権威的ソース**（他セクションはこれに従う）
+- ゾーン境界・時間分布の事実記述には `hr_zones_detail.zones[]` を使用
 
 ### トレンド分析（必須）
 
-- `get_form_baseline_trend()` の Δd, Δb を contract の `baseline_comparison` で評価
+- `form_baseline_trend.metrics` の delta_d, delta_b を contract の `baseline_comparison` で評価
 - 改善/維持/悪化を判定し、前向きなトーンで記述
+- `form_baseline_trend.success=false` の場合はデータ不足として簡潔に記述
 
 ### 注意事項
 
-- フォーム評価は `get_form_evaluations()` から取得（手動計算不要）
+- フォーム評価値は CONTEXT の `form_evaluation` から取得（手動計算不要、MCP fetch 不要）
 - 統合スコアは末尾に「統合スコアは XX.X/100点（★★★★☆）」形式で含める
 - 日本語コーチングトーン、具体的数値を含め、1-2文/ポイント


### PR DESCRIPTION
Closes #237 (Epic #234, S3)

## Summary
efficiency-section-analyst をバンドル受領の薄いナレーション層に（S2 と同パターン）。model は sonnet 維持。

## Changes
- `tools:` 7→3（`get_form_evaluations`/`get_hr_efficiency_analysis`/`get_heart_rate_zones_detail`/`get_form_baseline_trend` 削除、`get_analysis_contract`/`validate_section_json`/`Write` のみ）
- 本文を CONTEXT バンドル参照に書換え（`form_evaluation`/`form_scores`/`zone_percentages`/`hr_zones_detail`/`form_baseline_trend`）
- **出力キー不変**: `efficiency`, `evaluation`, `form_trend`

## Validation (L3 PASS — reload 非依存・#244 新方式)
S3+S4 を main に一時適用し `/analyze-activity 2025-10-09` を実行（reload なし→MCPレース無し、全5セクション成功）:
- efficiency が tool_use=3 でバンドルのみから `efficiency`/`evaluation`/`form_trend` を生成
- merge 5/5 成功、フルレポート（369行）生成、フォーム効率 95.5/100、HR 142-149bpm（範囲内）
- 既存契約テスト `test_section_schemas.py::test_efficiency_valid` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)