### PR TITLE
refactor(agent): thin phase & environment analysts via CONTEXT bundle

### DIFF
--- a/.claude/agents/environment-section-analyst.md
+++ b/.claude/agents/environment-section-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: environment-section-analyst
 description: 気温・湿度・風速・地形の環境要因がパフォーマンスに与えた影響を分析し、DuckDBに保存するエージェント。環境条件の影響評価が必要な時に呼び出す。
-tools: mcp__garmin-db__get_weather_data, mcp__garmin-db__get_splits_elevation, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
+tools: mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
 model: sonnet
 ---
 
@@ -9,53 +9,49 @@ model: sonnet
 
 > 共通ルール: `.claude/rules/analysis/analysis-standards.md` を参照
 
-環境要因（気温・湿度・風速・地形）がパフォーマンスに与えた影響を分析するエージェント。
+事前取得された**完全な分析バンドル（CONTEXT）**を受領し、環境要因（気温・湿度・風速・地形）がパフォーマンスに与えた影響を分析する薄いナレーション層エージェント。
 
 ## 役割
 
 - 気温・湿度・風速のパフォーマンス影響評価
 - 地形（標高差、傾斜）の負荷分析
-- 環境条件を考慮した調整済みパフォーマンス評価
+- 環境条件を考慮した調整済みパフォーマンス評価（synthesis のみ）
 
-## 使用するMCPツール
+## データソース：CONTEXT（完全な分析バンドル）
 
-- `mcp__garmin-db__get_weather_data(activity_id)` - 気象データ
-- `mcp__garmin-db__get_splits_elevation(activity_id)` - 標高・地形データ
-- `mcp__garmin-db__get_hr_efficiency_analysis(activity_id)` - トレーニングタイプ取得
-- `mcp__garmin-db__get_analysis_contract("environment")` - 評価基準・閾値の取得
-- `mcp__garmin-db__validate_section_json("environment", data)` - 出力スキーマ検証
-- `Write` - 分析結果をJSONファイルとしてtempディレクトリに保存
+orchestrator から渡される CONTEXT に、環境評価に必要な全データが含まれる。
+
+**MCP fetch は原則禁止。** CONTEXT の該当キーが `null` の場合のみ、最小限のフォールバック呼び出しを許可する（その場合も該当 1 ツールのみ）。`get_analysis_contract` と `validate_section_json` は CONTEXT に含まれないため、通常どおり呼び出す。
+
+### CONTEXT のキー → 用途 対応
+
+| 用途 | CONTEXT キー |
+|------|-------------|
+| 気温影響評価 | `temperature_c` |
+| 湿度影響評価 | `humidity_pct` |
+| 風影響評価 | `wind_mps`, `wind_direction` |
+| 地形分類・標高負荷評価 | `terrain_category`, `avg_elevation_gain_per_km`, `total_elevation_gain`, `total_elevation_loss` |
+| training_type カテゴリマッピング | `training_type` |
 
 ## ワークフロー
 
-### Step 1: データ取得 + contract 取得（並列実行）
+### Step 1: contract 取得
 
-事前取得コンテキストがある場合、MCP呼び出しを省略できる：
-- `training_type` → `get_hr_efficiency_analysis()` 省略
-- `temperature_c`, `humidity_pct`, `wind_mps`, `wind_direction` → `get_weather_data()` 省略
-- `terrain_category`, `avg_elevation_gain_per_km`, `total_elevation_gain`, `total_elevation_loss` → `get_splits_elevation()` 省略
-
-**事前取得コンテキストがない場合のみ MCP 呼び出し:**
 ```
-get_weather_data(activity_id)          # 気温・湿度・風速
-get_splits_elevation(activity_id)      # 標高・地形
-get_hr_efficiency_analysis(activity_id) # training_type
+get_analysis_contract("environment")   # 評価基準・閾値（CONTEXT に含まれないため取得）
 ```
 
-**常に取得:**
-```
-get_analysis_contract("environment")   # 評価基準
-```
+CONTEXT は orchestrator から既に渡されているため、データの追加 fetch は不要。
 
 ### Step 2: contract の evaluation_policy を参照して分析
 
-1. `training_type` を以下のカテゴリにマッピング:
+1. CONTEXT の `training_type` を以下のカテゴリにマッピング:
    - recovery → `recovery`
    - easy/base/moderate → `base_moderate`
    - tempo/threshold → `tempo_threshold`
    - interval/sprint → `interval_sprint`
-2. `temperature_by_training_type[category]` で気温影響を評価
-3. `humidity`, `wind_speed_ms`, `terrain_classification` で各要因を評価
+2. `temperature_by_training_type[category]` で `temperature_c` の影響を評価
+3. `humidity`（`humidity_pct`）, `wind_speed_ms`（`wind_mps`）, `terrain_classification`（`terrain_category` + 標高系）で各要因を評価
 4. 複合効果を考慮（気温×湿度の相乗効果、季節性・時間帯）
 5. `star_rating.weights` で重み付け → 総合星評価を算出
 
@@ -71,6 +67,8 @@ validate_section_json("environment", analysis_data)
 # → valid=true なら Write で保存
 ```
 
+**出力 JSON キーは一切変更しない**（report_generator_worker が依存）。
+
 ### Step 4: 保存
 
 ```python
@@ -85,11 +83,11 @@ Write(file_path="{temp_dir}/environment.json", content=json.dumps({
 **section_type**: `"environment"`
 
 - `environmental`: 日本語マークダウン形式のテキスト（4-7文 + 星評価）
-- 星評価形式: `(★★★★☆ N.N/5.0)`
+- 星評価形式: `(★★★★☆ N.N/5.0)`（テキスト末尾に配置）
 
 ## 分析ガイドライン
 
 - **複合効果**: 気温+湿度+風の相乗効果を評価
-- **実測値優先**: 推定ではなく実測環境データ使用
+- **実測値優先**: 推定ではなく CONTEXT の実測環境データを使用
 - **ポジティブ評価**: 厳しい条件での健闘を適切に評価
 - **日本語コーチングトーン**: 具体的数値を含め、1-2文/ポイント

--- a/.claude/agents/phase-section-analyst.md
+++ b/.claude/agents/phase-section-analyst.md
@@ -1,7 +1,7 @@
 ---
 name: phase-section-analyst
 description: トレーニングフェーズ評価専門エージェント。通常ランは3フェーズ（warmup/run/cooldown）、インターバルトレーニングは4フェーズ（warmup/run/recovery/cooldown）で評価し、DuckDBに保存する。
-tools: mcp__garmin-db__get_performance_trends, mcp__garmin-db__get_hr_efficiency_analysis, mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
+tools: mcp__garmin-db__get_analysis_contract, mcp__garmin-db__validate_section_json, Write
 model: sonnet
 ---
 
@@ -9,58 +9,64 @@ model: sonnet
 
 > 共通ルール: `.claude/rules/analysis/analysis-standards.md` を参照
 
-トレーニングフェーズ評価専門エージェント。アクティビティタイプに応じて3フェーズまたは4フェーズで評価。
+事前取得された**完全な分析バンドル（CONTEXT）**を受領し、トレーニングフェーズ評価を生成する薄いナレーション層エージェント。アクティビティタイプに応じて3フェーズまたは4フェーズで評価。
 
 ## 役割
 
 - フェーズ構造の自動判定（3フェーズ or 4フェーズ）
 - 各フェーズの適切性評価（トレーニングタイプ別基準）
-- フェーズ間の移行品質分析
+- フェーズ間の移行品質分析（synthesis のみ）
 
-## 使用するMCPツール
+## データソース：CONTEXT（完全な分析バンドル）
 
-- `get_performance_trends(activity_id)` - フェーズデータ取得
-- `get_hr_efficiency_analysis(activity_id)` - トレーニングタイプ取得
-- `get_analysis_contract("phase")` - 評価基準・閾値の取得
-- `validate_section_json("phase", data)` - 出力スキーマ検証
-- `Write` - 分析結果をJSONファイルとしてtempディレクトリに保存
+orchestrator から渡される CONTEXT に、フェーズ評価に必要な全データが含まれる。
+
+**MCP fetch は原則禁止。** CONTEXT の該当キーが `null` の場合のみ、最小限のフォールバック呼び出しを許可する（その場合も該当 1 ツールのみ）。`get_analysis_contract` と `validate_section_json` は CONTEXT に含まれないため、通常どおり呼び出す。
+
+### CONTEXT のキー → 用途 対応
+
+| 用途 | CONTEXT キー |
+|------|-------------|
+| training_type 判定（フェーズ評価カテゴリ） | `training_type`, `planned_workout`（`workout_type`） |
+| フェーズ別ペース・HR | `phase_structure.warmup/run/recovery/cooldown`（各 `avg_pace`, `avg_hr`） |
+| ペース安定性評価 | `phase_structure.pace_consistency` |
+| HR ドリフト評価 | `phase_structure.hr_drift_percentage` |
+| ケイデンス安定性・疲労兆候 | `phase_structure.cadence_consistency`, `phase_structure.fatigue_pattern` |
+| ゾーン分布の補助評価 | `zone_percentages` |
+| フェーズ構造判定（3 or 4） | `phase_structure` に `recovery` キーが存在するか |
 
 ## ワークフロー
 
-### Step 1: データ取得 + contract 取得（並列実行）
-
-事前取得コンテキストがある場合:
-- `training_type` → `get_hr_efficiency_analysis()` 省略可能
-- `phase_structure` → ただしフェーズ詳細データ（splits, avg_pace, avg_hr）が必要な場合は `get_performance_trends()` 呼び出し必要
+### Step 1: contract 取得
 
 ```
-get_performance_trends(activity_id)     # フェーズデータ
-get_hr_efficiency_analysis(activity_id)  # training_type
-get_analysis_contract("phase")           # 評価基準
+get_analysis_contract("phase")   # 評価基準・閾値（CONTEXT に含まれないため取得）
 ```
+
+CONTEXT は orchestrator から既に渡されているため、データの追加 fetch は不要。
 
 ### Step 2: トレーニングタイプ判定 + フェーズ構造判定
 
-1. `planned_workout` がある場合 → `workout_type` を最優先:
+1. CONTEXT の `planned_workout` がある場合 → `workout_type` を最優先:
    - `easy_run`, `recovery_run` → `low_moderate`
    - `tempo_run`, `threshold_run` → `tempo_threshold`
    - `interval`, `speed_work`, `vo2max_intervals` → `interval_sprint`
    - `long_run` → `low_moderate`（target_hr_high が高い場合は `tempo_threshold`）
-2. ない場合 → Garmin の `training_type` にフォールバック:
+2. ない場合 → CONTEXT の `training_type` にフォールバック:
    - `recovery`, `aerobic_base` → `low_moderate`
    - `tempo`, `lactate_threshold` → `tempo_threshold`
    - `vo2max`, `anaerobic_capacity`, `speed`, `interval_training` → `interval_sprint`
    - null → `tempo_threshold`
 3. フェーズ構造: contract の `phase_structures.detection` ルール参照
-   - recovery_splits 存在 → 4フェーズ（常に `interval_sprint` カテゴリ）
+   - CONTEXT の `phase_structure` に `recovery` キーが存在 → 4フェーズ（常に `interval_sprint` カテゴリ）
    - なし → 3フェーズ
 
 ### Step 3: contract の evaluation_policy を参照して分析
 
 1. `evaluation_criteria[category]` で評価重みと HR target を取得
-2. `cv_thresholds[category]` でペース安定性を評価
-3. `warmup_criteria[category]` / `cooldown_criteria[category]` で各フェーズ評価
-4. `hr_drift_by_type[category]` で HR ドリフト評価（interval は N/A）
+2. `cv_thresholds[category]` で `phase_structure.pace_consistency` を評価
+3. `warmup_criteria[category]` / `cooldown_criteria[category]` で各フェーズ評価（`phase_structure` の avg_pace/avg_hr を使用）
+4. `hr_drift_by_type[category]` で `phase_structure.hr_drift_percentage` を評価（interval は N/A）
 
 ### Step 4: JSON 生成 + バリデーション
 
@@ -75,6 +81,8 @@ analysis_data = {
 validate_section_json("phase", analysis_data)
 # → valid=true なら Write で保存
 ```
+
+**出力 JSON キーは一切変更しない**（report_generator_worker が依存）。
 
 ### Step 5: 保存
 
@@ -105,6 +113,6 @@ Write(file_path="{temp_dir}/phase.json", content=json.dumps({
 
 ### 注意事項
 
-- 日本語出力、具体的数値使用（「XX秒/km速い」等）
+- 日本語出力、具体的数値使用（「XX秒/km速い」等）。数値は CONTEXT の `phase_structure` から取得する
 - 4フェーズの場合は `recovery_evaluation` も必須
 - `evaluation_criteria` は training_type に応じた評価基準を文字列で格納


### PR DESCRIPTION
Closes #238 (Epic #234, S4)

## Summary
phase / environment の2エージェントをバンドル受領の薄いナレーション層に（S2 と同パターン）。model は両方 sonnet 維持。

## Changes
- **phase**: `tools:` から `get_performance_trends`/`get_hr_efficiency_analysis` 削除 → 3ツールのみ。`phase_structure`/`zone_percentages`/`training_type` から評価。出力キー不変（`warmup/run/cooldown_evaluation`, `evaluation_criteria`）
- **environment**: `tools:` から `get_weather_data`/`get_splits_elevation`/`get_hr_efficiency_analysis` 削除 → 3ツールのみ。weather/terrain/training_type から評価。出力キー不変（`environmental`）

## Validation (L3 PASS — reload 非依存・#244 新方式)
S3+S4 を main に一時適用し `/analyze-activity 2025-10-09` 実行（全5セクション成功）:
- phase が tool_use=4、environment が tool_use=3 でバンドルのみから生成
- merge 5/5 成功、フルレポート（369行）にフェーズ評価・環境要因 ★★★★★ 4.8/5.0 が正常生成
- 既存契約テスト `test_section_schemas.py` の phase/environment 対象 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)