### PR TITLE
fix(contracts): make cadence_ranges pace-dependent to stop absolute-180 regression

### DIFF
--- a/.claude/agents/unified-section-analyst.md
+++ b/.claude/agents/unified-section-analyst.md
@@ -117,7 +117,7 @@ Write(file_path="{ANALYSIS_TEMP_DIR}/{section}.json", content=json.dumps({
 ### 評価ルール（`get_analysis_contract("efficiency")` の evaluation_policy 参照）
 
 1. `form_ranges` で GCT/VO/VR の絶対値評価（値は `form_evaluation` から、**star_rating は手動計算せず `form_evaluation.{metric}.star_rating` を使用**）
-2. `cadence_ranges` でケイデンス評価（`form_evaluation.cadence`、null なら対象外）
+2. **ケイデンス評価はペース依存**（`form_evaluation.cadence`、null なら対象外）。**star_rating は手動計算せず `form_evaluation.cadence.star_rating` を使用し、絶対180spm目標で「未達」と評価しない**。文言は `form_evaluation.cadence.evaluation_text`（ペース依存の期待値ベース）を参照
 3. `power_efficiency_stars` でパワー効率評価（`form_evaluation.power` がある場合のみ）。正の efficiency_score →「ランニングエコノミー改善」、負 →「疲労/環境/路面の影響の可能性」（安易に非効率と断定しない）
 4. `integrated_score_stars` で統合スコアの星評価（`form_evaluation.integrated_score` または `form_scores`）
 5. `zone_targets[training_type_category]` で HR ゾーン配分評価（`zone_percentages` + `hr_zones_detail`）。**`planned_workout` がある場合はプラン目標HRを最優先基準**
@@ -280,6 +280,7 @@ analysis_data = {
 2. `needs_improvement=false` の指標 → `key_strengths`（**文字列**で記述、リストに格納）
 3. `needs_improvement` が null の指標 → 評価対象外（含めない）
 4. 達成済み目標は improvement_areas に含めない
+   - ケイデンスは `form_evaluation.cadence.needs_improvement` に従う。`false` なら improvement_areas に含めない（**絶対180spm目標で「あと N spm」等の未達表現を出さない**）
 5. `form_evaluation` が null → form ベースの improvement_areas を生成しない
 6. **`improvement_areas` は最大2件**（`key_strengths` は 3-5項目目安）
 

--- a/packages/garmin-mcp-server/src/garmin_mcp/validation/contracts.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/validation/contracts.py
@@ -241,10 +241,28 @@ _CONTRACTS: dict[str, dict[str, Any]] = {
                 },
             },
             "cadence_ranges": {
-                "ideal": ">=180 spm",
-                "near_target": "178-179 spm",
-                "acceptable": "175-177 spm",
-                "needs_improvement": "<175 spm",
+                "_note": (
+                    "Pace-dependent cadence evaluation. "
+                    "Do NOT use an absolute 180 spm target."
+                ),
+                "method": (
+                    "Compare form_evaluation.cadence.actual against "
+                    "form_evaluation.cadence.expected (pace-dependent baseline "
+                    "from the trained model)."
+                ),
+                "star_rating": (
+                    "Use form_evaluation.cadence.star_rating as-is; never "
+                    "recompute from a fixed spm threshold."
+                ),
+                "evaluation_text": (
+                    "When narrating cadence, use "
+                    "form_evaluation.cadence.evaluation_text "
+                    "(already pace-dependent)."
+                ),
+                "needs_improvement": (
+                    "Use the form_evaluation.cadence.needs_improvement flag; "
+                    "do not derive needs_improvement from an absolute spm cutoff."
+                ),
             },
             "integrated_score_stars": {
                 "5_stars": "95-100",

--- a/packages/garmin-mcp-server/tests/validation/test_contracts.py
+++ b/packages/garmin-mcp-server/tests/validation/test_contracts.py
@@ -1,5 +1,7 @@
 """Tests for analysis contracts."""
 
+import re
+
 import pytest
 
 from garmin_mcp.validation.contracts import VALID_SECTION_TYPES, get_contract
@@ -100,6 +102,40 @@ def test_efficiency_contract_has_form_ranges():
         assert metric in form
         assert "excellent" in form[metric]
         assert "needs_improvement" in form[metric]
+
+
+@pytest.mark.unit
+def test_cadence_contract_is_pace_dependent():
+    """Regression test for #252: cadence_ranges must be pace-dependent.
+
+    The old contract hard-coded an absolute 180 spm target (">=180 spm",
+    "178-179 spm", "175-177 spm", "<175 spm"), which caused the narration
+    layer to flag cadence as "needs improvement" against a fixed threshold,
+    contradicting the pace-dependent form_evaluation.cadence data layer.
+    """
+    contract = get_contract("efficiency")
+    cadence = contract["evaluation_policy"]["cadence_ranges"]
+
+    # No absolute fixed-threshold spm values (e.g. ">=180", "178-179",
+    # "175-177", "<175") anywhere in the cadence policy.
+    fixed_threshold = re.compile(r"(?:>=|<=|<|>)?\s*\d{2,3}\s*(?:-\s*\d{2,3})?\s*spm")
+    for key, value in cadence.items():
+        assert isinstance(value, str)
+        # Allow the "180 spm" mention only inside an explicit "do NOT use"
+        # warning; reject any standalone fixed-threshold spm value.
+        matches = fixed_threshold.findall(value)
+        for match in matches:
+            assert "do not use" in value.lower() or "not use" in value.lower(), (
+                f"cadence_ranges['{key}'] contains absolute spm threshold "
+                f"'{match.strip()}' outside a 'do NOT use' warning"
+            )
+
+    # Pace-dependent keys must be present and reference form_evaluation.cadence.
+    assert "method" in cadence
+    assert "star_rating" in cadence
+    joined = " ".join(cadence.values()).lower()
+    assert "form_evaluation.cadence" in joined
+    assert "pace-dependent" in joined or "pace dependent" in joined
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## 概要
ケイデンス評価が「ペース依存」でなく「絶対180spm目標」で improvement に出る回帰を修正。真因は `contracts.py` の `cadence_ranges` が旧 absolute-180 仕様のままで、`unified-section-analyst` が `get_analysis_contract("efficiency")` 経由でこれを参照し、ペース依存の `form_evaluation.cadence`（正）より絶対180（誤）に引っ張られていた。

Closes #252

## 変更
- **`validation/contracts.py`**: `cadence_ranges` から絶対spm閾値（`>=180 spm` 等）を撤廃し、`form_evaluation.cadence`（expected / star_rating / evaluation_text / needs_improvement）参照を促すペース依存ガイダンスに置換
- **`.claude/agents/unified-section-analyst.md`**:
  - efficiency 評価ルール: ケイデンスは `form_evaluation.cadence.star_rating` を使用・絶対180目標で「未達」と評価しない・文言は `evaluation_text` 参照、を明示
  - summary `improvement_areas` フィルタ: ケイデンスは `needs_improvement=false` なら含めない（「あと N spm」等の絶対目標未達表現を出さない）を明示
- **`tests/validation/test_contracts.py`**: `test_cadence_contract_is_pace_dependent` 追加（contract に固定spm閾値が無く、ペース依存キーと `form_evaluation.cadence` 参照が在ることを検証）

## 検証
- **L1 unit**: `tests/validation/test_contracts.py` 27 passed（新規 `test_cadence_contract_is_pace_dependent` 含む）
- **L3 E2E**: 修正 contract + 修正 agent.md を live 適用し Activity 23228638761 を再分析。`improvement_areas` が Zone3 1件のみ（ケイデンス消失、回帰前は180spm未達で2件）、ケイデンスは「178spmがペース依存期待値177spm±2%内…理想的」★★★★★ の strength として記述。「180spmに近づける/あとNspm」表現は消失。4セクション全て `valid:true`。

## Validation Level
L3（agent定義変更を含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)