### PR TITLE
fix(analysis): separate pace variation eval by run type (pace run strict / LSD lenient)

### DIFF
--- a/.claude/agents/unified-section-analyst.md
+++ b/.claude/agents/unified-section-analyst.md
@@ -177,7 +177,9 @@ analysis_data = {
 ### トレーニングタイプ別トーン（WU/CD 欠如時の star 分岐）
 
 - **low_moderate**: リラックス、肯定的。WU/CD なしでも「問題ありません」（★5）
+  - **low_moderate のペース変動**: 歩き・信号・暑さ・他者回避など環境/意図由来の短時間ペース落ち込みは、時間重視ラン（LSD/ロングラン）では不可避とみなす。`cv_thresholds` の判定に関わらず run_evaluation の欠陥・改善点・減点にしない。time-on-feet（時間・距離の達成）を主眼に肯定的に評価する。
 - **tempo_threshold**: 改善提案、教育的。WU/CD なしは「推奨されます」（★3）
+  - **tempo_threshold のペース安定性**: ペース走は設定ペースを刻むことが目的のため、ペース変動を引き続きシビアに評価する。`cv_thresholds` の判定に従い、設定ペースからの逸脱は run_evaluation の改善点として指摘する。
 - **interval_sprint**: 安全重視、明確な指示。WU/CD なしは「必須です」（★1）
 
 ### 出力構成
@@ -310,6 +312,8 @@ analysis_data = {
 
 冒頭に文脈説明: 「今回の[トレーニングタイプ名]を次回実施する際の改善点：」。**最大2件**、次回アクション（`next_action`）は1つに絞る（数値+成功判定条件付き）。
 
+**ランナー制御可能要因への限定**: 改善提案・improvement_areas はランナーが実際にコントロールできる要因に限定する。`low_moderate`（LSD/ロングラン）では信号・障害物・地形・暑さ・他者回避など環境由来のペース変動を改善点・次回アクションにしない（必要なら environment セクションで中立に言及）。`tempo_threshold` の設定ペース逸脱は従来通り改善点として扱う。
+
 ### integrated_score
 
 - `form_scores.integrated_score` を summary テキストに「統合フォームスコア: XX.X/100」として自然に組み込み、`integrated_score` フィールドに **float** で格納
@@ -343,7 +347,7 @@ null ハンドリング: `planned_workout` null → **plan_achievement キーご
 ### Training Type 別評価
 
 - **閾値/インターバル系**: メイン区間（run）のみ評価。HR drift/全体フォームばらつきは評価しない
-- **ベースラン**: Zone 2維持 + HR drift + ペース安定性
+- **ベースラン（LSD/時間重視ロングラン）**: Zone 2維持 + HR drift を主軸に評価。ペース変動は time-on-feet 重視のため減点要因にしない（歩き・信号・暑さ由来の短時間落ち込みを欠陥扱いしない）。pace_consistency 軸は総合スコアを引き下げない
 - **テンポ走**: Zone 3-4比率 + ペース安定性 + HR drift（10-15%許容）
 - **リカバリーラン**: Zone 1-2のみ（>90%）、フォーム効率は評価不要
 


### PR DESCRIPTION
## Summary

ペース変動の評価をラン種別で分離する prompt 変更（`unified-section-analyst.md` のみ）。

- **low_moderate（LSD・aerobic_base・easy・recovery）**: 歩き・信号・暑さ・他者回避など環境/意図由来の短時間ペース落ち込みを欠陥・改善点・減点にしない。time-on-feet 達成を主眼に肯定評価。pace_consistency 軸は総合スコアを引き下げない。
- **tempo_threshold（ペース走）**: ペース安定性を引き続きシビアに評価（現状維持・明示文を追加）。
- 改善提案/improvement_areas をランナー制御可能要因に限定。

閾値（`contracts.py` の `cv_thresholds` / `training_type_criteria`）・CV計算は**変更なし**。既存の category 分離を活用し、agent の判断方針で分岐。

## Background

2026-06-14 の都市部ロングラン（aerobic_base, 11.13km, CV 6.0%）分析でペース変動を改善点として指摘してしまった。ユーザー指摘: 信号・自転車止め回避・暑さによる歩き等の不可避な短時間変動を、時間重視ロングランで欠陥扱いするのは的外れ。ペース走はシビア、LSDはゆるく分けたい。

## Validation (L3)

worktree の `.md` を main に一時適用 → `23241672820`（2026-06-14, CV 6.0%）を再分析 → `git checkout` で復元。

- **L3-A（ゆるく）PASS**: summary 4.4→**4.8**、pace_consistency 軸 3.0→**4.0**、improvement_areas **空**、recommendations は高温時HR基準のみ（ペースCV改善は消失）、phase run_evaluation **★5.0**（環境要因として正当評価）
- **L3-B（シビア維持）**: tempo_threshold/テンポ走の評価ロジックは diff 上で完全に不変＋明示文追加のみ → コードレビューで回帰なし
- **L3-C（構造）PASS**: 4セクション valid:true・analysis_data 非null

## Test Plan
- [x] L3-A ゆるく確認（2026-06-14 再分析）
- [x] L3-B シビア維持（inspection: tempo path 不変）
- [x] L3-C 構造（valid:true）

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)