### PR TITLE
feat(form-baseline): auto-generate missing baselines in prefetch

### DIFF
--- a/packages/garmin-mcp-server/src/garmin_mcp/form_baseline/trainer.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/form_baseline/trainer.py
@@ -1,6 +1,7 @@
 """Statistical model training for form baseline system."""
 
 from dataclasses import dataclass
+from datetime import date, datetime, timedelta
 from typing import Any, Literal
 
 import numpy as np
@@ -385,8 +386,6 @@ def train_form_baselines(
     Raises:
         None - Returns None on errors instead of raising
     """
-    from datetime import datetime
-
     from dateutil.relativedelta import relativedelta
 
     from garmin_mcp.form_baseline import utils
@@ -684,3 +683,103 @@ def train_form_baselines(
         print(f"Error in train_form_baselines: {e}")
         traceback.print_exc()
         return None
+
+
+def _month_end(d: date) -> date:
+    """Return the last day of the month containing ``d`` (handles December)."""
+    import calendar
+
+    last_day = calendar.monthrange(d.year, d.month)[1]
+    return date(d.year, d.month, last_day)
+
+
+def _target_month_ends(activity_date: str) -> list[str]:
+    """Return ``[current_month_end, prior_month_end]`` as "YYYY-MM-DD" strings.
+
+    The current-month end matches the period_end used by the monthly baseline
+    script (so periods align). The prior-month end is the day before the
+    current month's first day.
+    """
+    d = datetime.strptime(activity_date, "%Y-%m-%d").date()
+    current_end = _month_end(d)
+    prior_end = date(d.year, d.month, 1) - timedelta(days=1)
+    return [current_end.strftime("%Y-%m-%d"), prior_end.strftime("%Y-%m-%d")]
+
+
+def ensure_form_baselines_for_date(
+    activity_date: str,
+    db_path: str | None = None,
+    user_id: str = "default",
+    condition_group: str = "flat_road",
+) -> dict[str, list[str]]:
+    """Generate the form baseline for an activity's month + prior month if missing.
+
+    Self-healing helper invoked from prefetch so that form-trend comparison is
+    always available. Never raises: any error is swallowed and reflected in the
+    returned buckets. Each period is processed sequentially (single-writer).
+
+    Args:
+        activity_date: Activity date ("YYYY-MM-DD"). Determines target months.
+        db_path: Database path. If None, uses GARMIN_DATA_DIR resolution.
+        user_id: User identifier.
+        condition_group: Condition group (e.g., 'flat_road').
+
+    Returns:
+        Dict with three buckets keyed by period_end ("YYYY-MM-DD"):
+        ``{"generated": [...], "skipped": [...], "insufficient": [...]}``.
+    """
+    from garmin_mcp.database.connection import get_connection
+
+    result: dict[str, list[str]] = {
+        "generated": [],
+        "skipped": [],
+        "insufficient": [],
+    }
+
+    try:
+        period_ends = _target_month_ends(activity_date)
+    except Exception:
+        return result
+
+    for period_end in period_ends:
+        # Existence check (read connection closed before any write).
+        try:
+            with get_connection(db_path) as conn:
+                count_row = conn.execute(
+                    """
+                    SELECT COUNT(*)
+                    FROM form_baseline_history
+                    WHERE period_end = ?
+                      AND metric = 'gct'
+                      AND user_id = ?
+                      AND condition_group = ?
+                    """,
+                    [period_end, user_id, condition_group],
+                ).fetchone()
+            exists = count_row is not None and count_row[0] > 0
+        except Exception:
+            # If the existence check fails, skip this period defensively.
+            continue
+
+        if exists:
+            result["skipped"].append(period_end)
+            continue
+
+        # Missing -> train (train_form_baselines opens its own write connection).
+        try:
+            trained = train_form_baselines(
+                user_id=user_id,
+                condition_group=condition_group,
+                end_date=period_end,
+                window_months=2,
+                db_path=db_path,
+            )
+        except Exception:
+            trained = None
+
+        if trained is None:
+            result["insufficient"].append(period_end)
+        else:
+            result["generated"].append(period_end)
+
+    return result

--- a/packages/garmin-mcp-server/src/garmin_mcp/scripts/prefetch_activity_context.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/scripts/prefetch_activity_context.py
@@ -393,6 +393,25 @@ def prefetch_activity_context(activity_id: int) -> dict:
     # Heart rate zone boundaries + time distribution
     hr_zones_detail = physiology_reader.get_heart_rate_zones_detail(activity_id)
 
+    # Self-healing (Issue #266): ensure the form baseline exists for the
+    # activity's month (+ prior month) so the trend comparison below is
+    # available even if the monthly baseline script was not run. Best-effort:
+    # never blocks prefetch on failure.
+    from garmin_mcp.form_baseline.trainer import ensure_form_baselines_for_date
+
+    form_baseline_autogen: dict
+    try:
+        form_baseline_autogen = ensure_form_baselines_for_date(
+            activity_date, db_path_str
+        )
+    except Exception as e:
+        form_baseline_autogen = {
+            "generated": [],
+            "skipped": [],
+            "insufficient": [],
+            "error": str(e),
+        }
+
     # Form baseline trend (current vs 1-month-prior coefficients). Uses the
     # reader extracted from physiology_handler so logic is shared, not duplicated.
     form_baseline_trend = physiology_reader.get_form_baseline_trend(
@@ -449,6 +468,7 @@ def prefetch_activity_context(activity_id: int) -> dict:
         "form_evaluation": form_evaluation,
         "hr_zones_detail": hr_zones_detail,
         "form_baseline_trend": form_baseline_trend,
+        "form_baseline_autogen": form_baseline_autogen,
         "similar_workouts": similar_workouts,
         "vo2_max": vo2_max,
         "lactate_threshold": lactate_threshold,

--- a/packages/garmin-mcp-server/src/garmin_mcp/tool_schemas.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/tool_schemas.py
@@ -466,7 +466,7 @@ _PERFORMANCE_TOOLS: list[dict] = [
     },
     {
         "name": "prefetch_activity_context",
-        "description": "Pre-fetch shared activity context for analysis agents. Returns training_type, weather, terrain, HR efficiency (zone_percentages), form evaluation scores, phase structure, and planned workout in a single call.",
+        "description": "Pre-fetch shared activity context for analysis agents. Returns training_type, weather, terrain, HR efficiency (zone_percentages), form evaluation scores, phase structure, and planned workout in a single call. Auto-generates the form baseline for the activity's month (and prior month) if missing.",
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/packages/garmin-mcp-server/tests/form_baseline/test_trainer.py
+++ b/packages/garmin-mcp-server/tests/form_baseline/test_trainer.py
@@ -1,6 +1,6 @@
 """Tests for form_baseline.trainer module."""
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 import duckdb
 import numpy as np
@@ -10,6 +10,9 @@ import pytest
 from garmin_mcp.form_baseline.trainer import (
     GCTPowerModel,
     LinearModel,
+    _month_end,
+    _target_month_ends,
+    ensure_form_baselines_for_date,
     fit_gct_power,
     fit_linear,
     train_form_baselines,
@@ -397,3 +400,222 @@ def test_train_form_baselines_inserts_cadence_row(tmp_path):
         assert vo_vr_row[0] == 2, "VO and VR baselines should also be inserted"
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Issue #266: self-healing baseline generation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_target_month_ends_current_and_prev():
+    """_target_month_ends returns [current_month_end, prior_month_end]."""
+    assert _target_month_ends("2026-06-14") == ["2026-06-30", "2026-05-31"]
+
+
+@pytest.mark.unit
+def test_month_end_december():
+    """_month_end handles the year boundary (December)."""
+    assert _month_end(date(2026, 12, 5)) == date(2026, 12, 31)
+
+
+def _create_baseline_schema(conn: duckdb.DuckDBPyConnection) -> None:
+    """Create the activities/splits/form_baseline_history schema for ensure tests."""
+    conn.execute("""
+        CREATE TABLE activities (
+            activity_id INTEGER PRIMARY KEY,
+            activity_date DATE,
+            base_weight_kg FLOAT
+        )
+        """)
+    conn.execute("""
+        CREATE TABLE splits (
+            split_id INTEGER PRIMARY KEY,
+            activity_id INTEGER,
+            pace_seconds_per_km FLOAT,
+            ground_contact_time FLOAT,
+            vertical_oscillation FLOAT,
+            vertical_ratio FLOAT,
+            stride_length FLOAT,
+            cadence FLOAT,
+            average_speed FLOAT,
+            power FLOAT
+        )
+        """)
+    conn.execute("CREATE SEQUENCE seq_history_id START 1")
+    conn.execute("CREATE SEQUENCE form_baseline_history_seq START 1")
+    conn.execute("""
+        CREATE TABLE form_baseline_history (
+            history_id INTEGER PRIMARY KEY DEFAULT nextval('seq_history_id'),
+            user_id VARCHAR DEFAULT 'default',
+            condition_group VARCHAR DEFAULT 'flat_road',
+            metric VARCHAR,
+            model_type VARCHAR,
+            coef_alpha FLOAT,
+            coef_d FLOAT,
+            coef_a FLOAT,
+            coef_b FLOAT,
+            period_start DATE,
+            period_end DATE,
+            trained_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            n_samples INTEGER,
+            rmse FLOAT,
+            speed_range_min FLOAT,
+            speed_range_max FLOAT,
+            power_a FLOAT,
+            power_b FLOAT,
+            power_rmse FLOAT,
+            UNIQUE (user_id, condition_group, metric, period_start, period_end)
+        )
+        """)
+
+
+def _make_splits(activity_id: int) -> list[tuple]:
+    """Return 5 well-conditioned splits (within outlier bounds) for an activity."""
+    rows = []
+    for j in range(5):
+        split_id = activity_id * 10 + j
+        # Pace 330 -> 270 sec/km => speed ~3.03 -> 3.70 m/s
+        pace = 330.0 - (activity_id * 5 + j * 12) % 60
+        speed = 1000.0 / pace
+        gct = 300.0 - 20.0 * speed  # 150-350
+        vo = 12.0 - 1.0 * speed  # 5-20
+        vr = 11.0 - 1.0 * speed  # 4-15
+        cadence = 160.0 + 5.0 * speed  # 140-210
+        stride_length = 1.0 + 0.1 * speed
+        power = 180.0 + 30.0 * speed
+        rows.append(
+            (
+                split_id,
+                activity_id,
+                pace,
+                gct,
+                vo,
+                vr,
+                stride_length,
+                cadence,
+                speed,
+                power,
+            )
+        )
+    return rows
+
+
+def _seed_two_month_window(db_path: str, activity_date: str, splits_per_month: int):
+    """Seed activities/splits across the activity month and prior month.
+
+    ``splits_per_month`` controls how many 5-split activities go into EACH of the
+    two months. With 12 activities/month -> 60 splits/month (>=50) so both the
+    current and prior baseline periods (each a 2-month window) have enough data.
+    Use a small value (e.g. 1 -> 5 splits) to exercise the insufficient path.
+    """
+    conn = duckdb.connect(db_path)
+    _create_baseline_schema(conn)
+
+    d = datetime.strptime(activity_date, "%Y-%m-%d").date()
+    # Mid-points of the activity month and the prior month.
+    current_mid = date(d.year, d.month, 15)
+    prior_first = date(d.year, d.month, 1) - timedelta(days=1)
+    prior_mid = date(prior_first.year, prior_first.month, 15)
+
+    activity_rows = []
+    split_rows = []
+    next_id = 3000
+    for month_anchor in (current_mid, prior_mid):
+        for k in range(splits_per_month):
+            activity_id = next_id
+            next_id += 1
+            act_date = month_anchor + timedelta(days=k % 10)
+            activity_rows.append((activity_id, act_date, 70.0))
+            split_rows.extend(_make_splits(activity_id))
+
+    if activity_rows:
+        conn.executemany("INSERT INTO activities VALUES (?, ?, ?)", activity_rows)
+    if split_rows:
+        conn.executemany(
+            "INSERT INTO splits VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", split_rows
+        )
+    conn.close()
+
+
+def _count_baseline_rows(db_path: str) -> int:
+    """Return the total number of rows in form_baseline_history."""
+    conn = duckdb.connect(db_path, read_only=True)
+    try:
+        row = conn.execute("SELECT COUNT(*) FROM form_baseline_history").fetchone()
+        return int(row[0]) if row is not None else 0
+    finally:
+        conn.close()
+
+
+@pytest.mark.integration
+def test_ensure_generates_when_missing(tmp_path):
+    """ensure generates baselines for the activity month + prior month."""
+    db_path = str(tmp_path / "ensure_gen.duckdb")
+    activity_date = "2026-03-15"
+    _seed_two_month_window(db_path, activity_date, splits_per_month=12)
+
+    result = ensure_form_baselines_for_date(activity_date, db_path)
+
+    assert len(result["generated"]) == 2, result
+    assert result["skipped"] == []
+    assert result["insufficient"] == []
+    assert set(result["generated"]) == {"2026-03-31", "2026-02-28"}
+
+    conn = duckdb.connect(db_path, read_only=True)
+    try:
+        for period_end in ("2026-03-31", "2026-02-28"):
+            row = conn.execute(
+                """
+                SELECT COUNT(*) FROM form_baseline_history
+                WHERE period_end = ? AND metric IN ('gct', 'vo', 'vr')
+                """,
+                [period_end],
+            ).fetchone()
+            assert row is not None
+            assert row[0] == 3, f"gct/vo/vr expected for {period_end}, got {row[0]}"
+    finally:
+        conn.close()
+
+
+@pytest.mark.integration
+def test_ensure_skips_when_exists(tmp_path):
+    """ensure is idempotent: a second call skips both periods, rows unchanged."""
+    db_path = str(tmp_path / "ensure_skip.duckdb")
+    activity_date = "2026-03-15"
+    _seed_two_month_window(db_path, activity_date, splits_per_month=12)
+
+    first = ensure_form_baselines_for_date(activity_date, db_path)
+    assert len(first["generated"]) == 2
+
+    count_after_first = _count_baseline_rows(db_path)
+
+    second = ensure_form_baselines_for_date(activity_date, db_path)
+    assert len(second["skipped"]) == 2, second
+    assert second["generated"] == []
+    assert second["insufficient"] == []
+    assert set(second["skipped"]) == {"2026-03-31", "2026-02-28"}
+
+    count_after_second = _count_baseline_rows(db_path)
+
+    assert count_after_second == count_after_first, "row count must be unchanged"
+
+
+@pytest.mark.integration
+def test_ensure_insufficient_data(tmp_path):
+    """ensure records insufficient periods when splits < 50, no rows, no raise."""
+    db_path = str(tmp_path / "ensure_insufficient.duckdb")
+    activity_date = "2026-03-15"
+    # 1 activity/month -> 5 splits/month -> < 50 in each 2-month window.
+    _seed_two_month_window(db_path, activity_date, splits_per_month=1)
+
+    result = ensure_form_baselines_for_date(activity_date, db_path)
+
+    assert result["generated"] == [], result
+    assert result["skipped"] == []
+    assert len(result["insufficient"]) == 2
+    assert set(result["insufficient"]) == {"2026-03-31", "2026-02-28"}
+
+    assert (
+        _count_baseline_rows(db_path) == 0
+    ), "no baseline rows should be created on insufficient data"


### PR DESCRIPTION
## Summary

`/analyze-activity` 実行時にフォームベースラインが無ければ自動生成する self-healing を追加。これまで baseline は月次スクリプトの手動実行でしか生成されず、回し忘れるとフォームトレンド比較が `No baseline found` で欠落していた。

prefetch_activity_context（baseline トレンドの唯一の消費点）でトレンド取得の直前に、活動月+前月の baseline 有無を確認し、欠落していれば既存の `train_form_baselines()` を呼んでその場で生成する。専用 MCP tool / analyze-activity.md / agent の変更は不要。

## Changes

- `form_baseline/trainer.py` — `ensure_form_baselines_for_date()` + 純粋ヘルパ `_month_end` / `_target_month_ends` を追加。既存 `train_form_baselines(end_date=月末, window_months=2)` を再利用（period 境界が monthly スクリプトと一致）。例外を投げず `{generated/skipped/insufficient}` を返す。読み取り存在確認 → 欠落分のみ逐次学習（single-writer 競合回避）。
- `scripts/prefetch_activity_context.py` — best-effort（try/except）で ensure を実行し、返却 dict に `form_baseline_autogen` を追加。
- `tool_schemas.py` — prefetch description に自動生成の一文。
- `tests/form_baseline/test_trainer.py` — 新規テスト5件（unit 2 + integration 3）。

## Behavior

- splits<50 の月は `insufficient` に記録され、トレンドは従来どおり「データ不足」で縮退（クラッシュしない）。
- 既存月は `skipped` のみで再生成なし＝コスト増ほぼゼロ。欠落月のみ ~1-2s の学習コスト。

## Test Results (Validation L2, verified by orchestrator)

- New unit+integration: `5 passed`（target_month_ends / month_end_december / ensure generates / skips(idempotent) / insufficient）
- Full integration: `182 passed, 7 skipped`（regression なし）
- L1 in-process（実DB, activity 23241672820 / 2026-06-14）: 対象月が既存のため `skipped: ["2026-06-30","2026-05-31"]` = 冪等動作を確認
- Ruff / Black / Mypy: clean

Closes #266