### PR TITLE
feat(garmin): add get_garmin_scheduled_workouts MCP tool (calendar-service)

### DIFF
--- a/packages/garmin-mcp-server/src/garmin_mcp/handlers/training_plan_handler.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/handlers/training_plan_handler.py
@@ -33,6 +33,7 @@ class TrainingPlanHandler:
         "get_training_plan",
         "upload_workout_to_garmin",
         "delete_workout_from_garmin",
+        "get_garmin_scheduled_workouts",
     }
 
     def __init__(self, db_reader: GarminDBReader) -> None:
@@ -52,6 +53,8 @@ class TrainingPlanHandler:
             return await self._upload_workout_to_garmin(arguments)
         elif name == "delete_workout_from_garmin":
             return await self._delete_workout_from_garmin(arguments)
+        elif name == "get_garmin_scheduled_workouts":
+            return await self._get_garmin_scheduled_workouts(arguments)
         else:
             raise ValueError(f"Unknown tool: {name}")
 
@@ -234,6 +237,34 @@ class TrainingPlanHandler:
                 result = {"error": "Either workout_id or plan_id is required"}
         except Exception as e:
             logger.error(f"Garmin upload failed: {e}")
+            result = {"error": str(e)}
+
+        return [
+            TextContent(
+                type="text",
+                text=format_json_response(result, default=str),
+            )
+        ]
+
+    async def _get_garmin_scheduled_workouts(
+        self, arguments: dict[str, Any]
+    ) -> list[TextContent]:
+        from garmin_mcp.training_plan.garmin_calendar import GarminCalendarReader
+
+        try:
+            reader = GarminCalendarReader()
+            workouts = reader.get_scheduled_workouts(
+                arguments["start_date"],
+                arguments["end_date"],
+            )
+            result: dict[str, Any] = {
+                "start_date": arguments["start_date"],
+                "end_date": arguments["end_date"],
+                "count": len(workouts),
+                "workouts": workouts,
+            }
+        except Exception as e:
+            logger.error(f"Get Garmin scheduled workouts failed: {e}")
             result = {"error": str(e)}
 
         return [

--- a/packages/garmin-mcp-server/src/garmin_mcp/tool_schemas.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/tool_schemas.py
@@ -709,6 +709,24 @@ _TRAINING_PLAN_TOOLS: list[dict] = [
             },
         },
     },
+    {
+        "name": "get_garmin_scheduled_workouts",
+        "description": "Fetch scheduled workouts (including adaptive plan workouts) from the Garmin Connect calendar-service for a date range. Returns workout-type calendar items sorted by date.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "start_date": {
+                    "type": "string",
+                    "description": "Inclusive start date (YYYY-MM-DD)",
+                },
+                "end_date": {
+                    "type": "string",
+                    "description": "Inclusive end date (YYYY-MM-DD)",
+                },
+            },
+            "required": ["start_date", "end_date"],
+        },
+    },
 ]
 
 _SERVER_TOOLS: list[dict] = [

--- a/packages/garmin-mcp-server/src/garmin_mcp/training_plan/garmin_calendar.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/training_plan/garmin_calendar.py
@@ -1,0 +1,118 @@
+"""Garmin Connect calendar-service reader for scheduled workouts."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# itemType values that represent scheduled workouts (vs nap/weight/activity/etc.)
+_WORKOUT_ITEM_TYPES = {"fbtAdaptiveWorkout", "workout"}
+
+
+class GarminCalendarReader:
+    """Reads scheduled workouts from the Garmin Connect calendar-service."""
+
+    def _get_garmin_client(self) -> Any:
+        """Get authenticated Garmin Connect client.
+
+        Mirrors ``GarminWorkoutUploader._get_garmin_client``.
+        """
+        from garmin_mcp.ingest.garmin_worker import GarminIngestWorker
+
+        worker = GarminIngestWorker()
+        return worker.get_garmin_client()
+
+    @staticmethod
+    def _connectapi_get(client: Any, path: str) -> Any:
+        """Perform a GET against the connectapi domain.
+
+        garminconnect exposes ``client.client`` as the underlying auth client.
+        Newer versions provide ``connectapi(path)`` directly; older ones require
+        ``get("connectapi", path, api=True).json()``. Support both.
+        """
+        inner = client.client
+        connectapi = getattr(inner, "connectapi", None)
+        if callable(connectapi):
+            return connectapi(path)
+        return inner.get("connectapi", path, api=True).json()
+
+    @staticmethod
+    def _enumerate_months(start: date, end: date) -> list[tuple[int, int]]:
+        """Enumerate (year, month) pairs spanning [start, end] inclusive.
+
+        ``month`` is 0-based to match the calendar-service convention
+        (January = 0, June = 5).
+        """
+        months: list[tuple[int, int]] = []
+        year, month = start.year, start.month
+        while (year, month) <= (end.year, end.month):
+            months.append((year, month - 1))  # 0-based month for the API
+            if month == 12:
+                year += 1
+                month = 1
+            else:
+                month += 1
+        return months
+
+    def get_scheduled_workouts(
+        self, start_date: str, end_date: str
+    ) -> list[dict[str, Any]]:
+        """Fetch scheduled workouts from the Garmin calendar-service.
+
+        Enumerates every (year, month) spanning [start_date, end_date], fetches
+        each month's calendar (``month`` is 0-based), merges ``calendarItems``,
+        keeps only workout-type items within the date range, and returns them
+        sorted by date ascending.
+
+        Args:
+            start_date: Inclusive start date "YYYY-MM-DD"
+            end_date: Inclusive end date "YYYY-MM-DD"
+
+        Returns:
+            List of dicts: {date, title, item_type, training_plan_id,
+            training_plan_name, workout_uuid}. Missing keys are None.
+        """
+        start = date.fromisoformat(start_date)
+        end = date.fromisoformat(end_date)
+
+        client = self._get_garmin_client()
+
+        results: list[dict[str, Any]] = []
+        for year, month in self._enumerate_months(start, end):
+            path = f"/calendar-service/year/{year}/month/{month}"
+            payload = self._connectapi_get(client, path)
+            items = (payload or {}).get("calendarItems") or []
+
+            for item in items:
+                item_type = item.get("itemType")
+                if item_type not in _WORKOUT_ITEM_TYPES:
+                    continue
+
+                date_str = item.get("date")
+                if not date_str:
+                    continue
+                try:
+                    item_date = date.fromisoformat(date_str)
+                except ValueError:
+                    logger.warning("Skipping calendar item with bad date: %r", date_str)
+                    continue
+
+                if not (start <= item_date <= end):
+                    continue
+
+                results.append(
+                    {
+                        "date": date_str,
+                        "title": item.get("title"),
+                        "item_type": item_type,
+                        "training_plan_id": item.get("trainingPlanId"),
+                        "training_plan_name": item.get("trainingPlanName"),
+                        "workout_uuid": item.get("workoutUuid"),
+                    }
+                )
+
+        results.sort(key=lambda r: r["date"])
+        return results

--- a/packages/garmin-mcp-server/tests/training_plan/test_garmin_calendar.py
+++ b/packages/garmin-mcp-server/tests/training_plan/test_garmin_calendar.py
@@ -1,0 +1,156 @@
+"""Tests for GarminCalendarReader."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from garmin_mcp.training_plan.garmin_calendar import GarminCalendarReader
+
+
+def _make_reader_with_calendar(
+    mocker, calendar_by_path: dict[str, dict[str, Any]]
+) -> tuple[GarminCalendarReader, Any]:
+    """Build a reader whose client.client.connectapi returns path-specific dicts."""
+
+    def connectapi(path: str) -> dict[str, Any]:
+        return calendar_by_path.get(path, {"calendarItems": []})
+
+    inner = mocker.MagicMock()
+    inner.connectapi.side_effect = connectapi
+    client = mocker.MagicMock()
+    client.client = inner
+
+    reader = GarminCalendarReader()
+    mocker.patch.object(reader, "_get_garmin_client", return_value=client)
+    return reader, inner
+
+
+@pytest.mark.unit
+class TestGarminCalendarReader:
+    def test_get_scheduled_workouts_filters_types(self, mocker):
+        """Only workout-type items (fbtAdaptiveWorkout/workout) are returned."""
+        calendar = {
+            "/calendar-service/year/2026/month/5": {
+                "calendarItems": [
+                    {
+                        "date": "2026-06-16",
+                        "title": "Tempo",
+                        "itemType": "fbtAdaptiveWorkout",
+                        "trainingPlanId": 99,
+                        "trainingPlanName": "Adaptive",
+                        "workoutUuid": "uuid-tempo",
+                    },
+                    {
+                        "date": "2026-06-16",
+                        "title": "Nap",
+                        "itemType": "nap",
+                    },
+                    {
+                        "date": "2026-06-17",
+                        "title": "Weight",
+                        "itemType": "weight",
+                    },
+                    {
+                        "date": "2026-06-18",
+                        "title": "Morning Run",
+                        "itemType": "activity",
+                    },
+                    {
+                        "date": "2026-06-19",
+                        "title": "Base",
+                        "itemType": "workout",
+                        "workoutUuid": "uuid-base",
+                    },
+                ]
+            }
+        }
+        reader, _ = _make_reader_with_calendar(mocker, calendar)
+
+        result = reader.get_scheduled_workouts("2026-06-15", "2026-06-21")
+
+        item_types = {r["item_type"] for r in result}
+        assert item_types == {"fbtAdaptiveWorkout", "workout"}
+        assert len(result) == 2
+        first = result[0]
+        assert first["date"] == "2026-06-16"
+        assert first["title"] == "Tempo"
+        assert first["training_plan_id"] == 99
+        assert first["training_plan_name"] == "Adaptive"
+        assert first["workout_uuid"] == "uuid-tempo"
+
+    def test_get_scheduled_workouts_spans_months(self, mocker):
+        """A range spanning two months fetches both 0-based months and merges."""
+        calendar = {
+            "/calendar-service/year/2026/month/5": {  # June (0-based 5)
+                "calendarItems": [
+                    {
+                        "date": "2026-06-30",
+                        "title": "June Base",
+                        "itemType": "workout",
+                    },
+                ]
+            },
+            "/calendar-service/year/2026/month/6": {  # July (0-based 6)
+                "calendarItems": [
+                    {
+                        "date": "2026-07-02",
+                        "title": "July Tempo",
+                        "itemType": "fbtAdaptiveWorkout",
+                    },
+                ]
+            },
+        }
+        reader, inner = _make_reader_with_calendar(mocker, calendar)
+
+        result = reader.get_scheduled_workouts("2026-06-29", "2026-07-05")
+
+        called_paths = {call.args[0] for call in inner.connectapi.call_args_list}
+        assert "/calendar-service/year/2026/month/5" in called_paths
+        assert "/calendar-service/year/2026/month/6" in called_paths
+
+        dates = [r["date"] for r in result]
+        assert dates == ["2026-06-30", "2026-07-02"]
+
+    def test_get_scheduled_workouts_date_filter(self, mocker):
+        """Items outside [start, end] are excluded."""
+        calendar = {
+            "/calendar-service/year/2026/month/5": {
+                "calendarItems": [
+                    {
+                        "date": "2026-06-14",  # before start
+                        "title": "Too Early",
+                        "itemType": "workout",
+                    },
+                    {
+                        "date": "2026-06-18",  # in range
+                        "title": "In Range",
+                        "itemType": "workout",
+                    },
+                    {
+                        "date": "2026-06-25",  # after end
+                        "title": "Too Late",
+                        "itemType": "workout",
+                    },
+                ]
+            }
+        }
+        reader, _ = _make_reader_with_calendar(mocker, calendar)
+
+        result = reader.get_scheduled_workouts("2026-06-15", "2026-06-21")
+
+        assert len(result) == 1
+        assert result[0]["date"] == "2026-06-18"
+        assert result[0]["title"] == "In Range"
+
+
+@pytest.mark.garmin_api
+def test_get_scheduled_workouts_live():
+    """Hits the real Garmin API (skipped in CI via garmin_api marker)."""
+    reader = GarminCalendarReader()
+    result = reader.get_scheduled_workouts("2026-06-15", "2026-06-21")
+    assert isinstance(result, list)
+    for item in result:
+        assert "date" in item
+        assert "item_type" in item


### PR DESCRIPTION
## Summary

Garmin Connect の calendar-service から予定ワークアウト（Garmin Run Coach アダプティブプラン含む）を取得する MCP ツール `get_garmin_scheduled_workouts(start_date, end_date)` を追加。

Epic #268（週次トレーニングレビューサイクル）第1波。

## Changes
- `training_plan/garmin_calendar.py` (new) — `GarminCalendarReader.get_scheduled_workouts()`。期間が跨る全月を calendar-service GET（month 0始まり）→ マージ → workout 系 itemType（fbtAdaptiveWorkout/workout）のみ抽出 → date 範囲フィルタ → date 昇順
- `handlers/training_plan_handler.py` — `get_garmin_scheduled_workouts` ツール追加
- `tool_schemas.py` — `_TRAINING_PLAN_TOOLS` にスキーマ追加
- `tests/training_plan/test_garmin_calendar.py` (new) — unit 3件 + garmin_api live 1件

## connectapi 両対応
`client.client.connectapi(path)` があればそれを、無ければ `get("connectapi", path, api=True).json()` を使うヘルパで garminconnect 新旧両対応。

## Validation (L2) — メインセッションで実行済み
- unit 3件 PASS（filters_types / spans_months / date_filter）
- 関連 handler/schema/server テスト 320件 PASS（回帰なし）
- live テストは `@pytest.mark.garmin_api` で CI deselect
- 実証済み期待値: `("2026-06-15","2026-06-21")` → 6/16 Tempo・6/17 Base・6/19 Base・6/20 Anaerobic

Closes #272