### PR TITLE
feat(db): add athlete_profile/goals/retrospectives/weekly_reviews tables (migration v7)

### DIFF
--- a/packages/garmin-mcp-server/src/garmin_mcp/database/db_writer.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/database/db_writer.py
@@ -515,6 +515,73 @@ class GarminDBWriter:
                 ON section_analyses(activity_id, section_type)
             """)
 
+            # Create athlete-centric tables for the weekly review cycle
+            # (see migrations/add_athlete_tables.py). Sequences mirror the
+            # seq_section_analyses_id pattern above.
+            conn.execute("CREATE SEQUENCE IF NOT EXISTS seq_athlete_goals_id START 1")
+            conn.execute(
+                "CREATE SEQUENCE IF NOT EXISTS seq_season_retrospectives_id START 1"
+            )
+            conn.execute("CREATE SEQUENCE IF NOT EXISTS seq_weekly_reviews_id START 1")
+
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS athlete_profile (
+                    user_id VARCHAR PRIMARY KEY DEFAULT 'default',
+                    current_focus VARCHAR,
+                    focus_notes VARCHAR,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS athlete_goals (
+                    goal_id INTEGER PRIMARY KEY,
+                    user_id VARCHAR DEFAULT 'default',
+                    race_name VARCHAR NOT NULL,
+                    race_date DATE,
+                    priority VARCHAR,
+                    goal_type VARCHAR,
+                    distance_km DOUBLE,
+                    target_time_seconds INTEGER,
+                    status VARCHAR DEFAULT 'active',
+                    notes VARCHAR,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS season_retrospectives (
+                    retro_id INTEGER PRIMARY KEY,
+                    user_id VARCHAR DEFAULT 'default',
+                    season_label VARCHAR,
+                    period_start DATE,
+                    period_end DATE,
+                    narrative VARCHAR,
+                    key_learnings VARCHAR,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS weekly_reviews (
+                    review_id INTEGER PRIMARY KEY,
+                    user_id VARCHAR DEFAULT 'default',
+                    week_start_date DATE NOT NULL,
+                    week_end_date DATE NOT NULL,
+                    review_date DATE,
+                    review_data VARCHAR,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    agent_name VARCHAR,
+                    agent_version VARCHAR
+                )
+            """)
+
+            conn.execute("""
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_weekly_reviews_week
+                ON weekly_reviews(user_id, week_start_date)
+            """)
+
     def _run_migrations(self) -> None:
         """Run pending database migrations after table creation."""
         from garmin_mcp.database.migrations.runner import MigrationRunner

--- a/packages/garmin-mcp-server/src/garmin_mcp/database/migrations/add_athlete_tables.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/database/migrations/add_athlete_tables.py
@@ -1,0 +1,84 @@
+"""Migration: Add athlete-centric tables for the weekly review cycle.
+
+Adds four tables that form the foundation of the weekly training review cycle:
+- athlete_profile: single-row profile holding the athlete's current focus
+- athlete_goals: race goals with target times and priorities
+- season_retrospectives: free-form season-level retrospectives
+- weekly_reviews: per-week review records (UPSERT keyed on user_id + week_start)
+
+These tables are not API-derived, so they are intentionally excluded from
+``scripts/regenerate/validator.py:AVAILABLE_TABLES``.
+
+The migration is idempotent: every statement uses ``IF NOT EXISTS`` so it can be
+applied repeatedly without error. Surrogate keys (goal_id / retro_id /
+review_id) are populated from DuckDB sequences, mirroring the
+``seq_section_analyses_id`` pattern in ``db_writer.py``.
+"""
+
+import duckdb
+
+
+def add_athlete_tables(conn: duckdb.DuckDBPyConnection) -> None:
+    """Create athlete-centric tables and their sequences (idempotent)."""
+    # Sequences for surrogate primary keys
+    conn.execute("CREATE SEQUENCE IF NOT EXISTS seq_athlete_goals_id START 1")
+    conn.execute("CREATE SEQUENCE IF NOT EXISTS seq_season_retrospectives_id START 1")
+    conn.execute("CREATE SEQUENCE IF NOT EXISTS seq_weekly_reviews_id START 1")
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS athlete_profile (
+            user_id VARCHAR PRIMARY KEY DEFAULT 'default',
+            current_focus VARCHAR,
+            focus_notes VARCHAR,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS athlete_goals (
+            goal_id INTEGER PRIMARY KEY,
+            user_id VARCHAR DEFAULT 'default',
+            race_name VARCHAR NOT NULL,
+            race_date DATE,
+            priority VARCHAR,
+            goal_type VARCHAR,
+            distance_km DOUBLE,
+            target_time_seconds INTEGER,
+            status VARCHAR DEFAULT 'active',
+            notes VARCHAR,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS season_retrospectives (
+            retro_id INTEGER PRIMARY KEY,
+            user_id VARCHAR DEFAULT 'default',
+            season_label VARCHAR,
+            period_start DATE,
+            period_end DATE,
+            narrative VARCHAR,
+            key_learnings VARCHAR,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    """)
+
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS weekly_reviews (
+            review_id INTEGER PRIMARY KEY,
+            user_id VARCHAR DEFAULT 'default',
+            week_start_date DATE NOT NULL,
+            week_end_date DATE NOT NULL,
+            review_date DATE,
+            review_data VARCHAR,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            agent_name VARCHAR,
+            agent_version VARCHAR
+        )
+    """)
+
+    conn.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_weekly_reviews_week
+        ON weekly_reviews(user_id, week_start_date)
+    """)

--- a/packages/garmin-mcp-server/src/garmin_mcp/database/migrations/registry.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/database/migrations/registry.py
@@ -93,6 +93,13 @@ def _wrap_add_cadence_columns(conn: duckdb.DuckDBPyConnection) -> None:
     add_cadence_columns(conn)
 
 
+def _wrap_athlete_tables(conn: duckdb.DuckDBPyConnection) -> None:
+    """Wrap athlete tables migration to run on an existing connection."""
+    from .add_athlete_tables import add_athlete_tables
+
+    add_athlete_tables(conn)
+
+
 def _wrap_plan_versioning(conn: duckdb.DuckDBPyConnection) -> None:
     """Wrap plan versioning migration to run on an existing connection."""
     from .add_plan_versioning import _column_exists, _table_exists
@@ -137,4 +144,5 @@ MIGRATIONS: list[tuple[int, str, Callable[[duckdb.DuckDBPyConnection], None]]] =
     (4, "remove_fk_constraints", _wrap_remove_fk),
     (5, "add_plan_versioning", _wrap_plan_versioning),
     (6, "add_cadence_columns", _wrap_add_cadence_columns),
+    (7, "add_athlete_tables", _wrap_athlete_tables),
 ]

--- a/packages/garmin-mcp-server/tests/database/test_athlete_tables_migration.py
+++ b/packages/garmin-mcp-server/tests/database/test_athlete_tables_migration.py
@@ -1,0 +1,83 @@
+"""Integration tests for migration v7 (add_athlete_tables).
+
+Verifies that applying the migration creates the four athlete-centric tables,
+that the migration is idempotent, and that the weekly_reviews UNIQUE index on
+(user_id, week_start_date) is enforced.
+"""
+
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from garmin_mcp.database.migrations.add_athlete_tables import add_athlete_tables
+
+ATHLETE_TABLES = {
+    "athlete_profile",
+    "athlete_goals",
+    "season_retrospectives",
+    "weekly_reviews",
+}
+
+
+def _table_names(conn: duckdb.DuckDBPyConnection) -> set[str]:
+    rows = conn.execute("SELECT table_name FROM information_schema.tables").fetchall()
+    return {row[0] for row in rows}
+
+
+@pytest.mark.integration
+def test_migration_creates_athlete_tables(tmp_path: Path) -> None:
+    """After applying v7, all four athlete tables exist in information_schema."""
+    db_path = tmp_path / "athlete.duckdb"
+    conn = duckdb.connect(str(db_path))
+    try:
+        add_athlete_tables(conn)
+        tables = _table_names(conn)
+    finally:
+        conn.close()
+
+    assert ATHLETE_TABLES.issubset(tables), f"Missing tables: {ATHLETE_TABLES - tables}"
+
+
+@pytest.mark.integration
+def test_migration_idempotent(tmp_path: Path) -> None:
+    """Applying the migration twice does not raise and tables still exist."""
+    db_path = tmp_path / "athlete_idempotent.duckdb"
+    conn = duckdb.connect(str(db_path))
+    try:
+        add_athlete_tables(conn)
+        # Second application must be a no-op (no exception).
+        add_athlete_tables(conn)
+        tables = _table_names(conn)
+    finally:
+        conn.close()
+
+    assert ATHLETE_TABLES.issubset(tables)
+
+
+@pytest.mark.integration
+def test_weekly_reviews_unique_week(tmp_path: Path) -> None:
+    """Inserting the same (user_id, week_start_date) twice raises UNIQUE error."""
+    db_path = tmp_path / "athlete_unique.duckdb"
+    conn = duckdb.connect(str(db_path))
+    try:
+        add_athlete_tables(conn)
+
+        conn.execute("""
+            INSERT INTO weekly_reviews
+                (review_id, user_id, week_start_date, week_end_date)
+            VALUES
+                (nextval('seq_weekly_reviews_id'), 'default',
+                 DATE '2025-06-09', DATE '2025-06-15')
+            """)
+
+        with pytest.raises(duckdb.ConstraintException):
+            conn.execute("""
+                INSERT INTO weekly_reviews
+                    (review_id, user_id, week_start_date, week_end_date)
+                VALUES
+                    (nextval('seq_weekly_reviews_id'), 'default',
+                     DATE '2025-06-09', DATE '2025-06-15')
+                """)
+    finally:
+        conn.close()

--- a/packages/garmin-mcp-server/tests/database/test_migration_runner.py
+++ b/packages/garmin-mcp-server/tests/database/test_migration_runner.py
@@ -72,10 +72,10 @@ class TestMigrationRunner:
         runner = MigrationRunner(db_path)
         applied = runner.run_pending()
 
-        assert len(applied) == 6
+        assert len(applied) == 7
         assert applied[0] == "phase0_power_prep"
-        assert applied[-1] == "add_cadence_columns"
-        assert runner.get_current_version() == 6
+        assert applied[-1] == "add_athlete_tables"
+        assert runner.get_current_version() == 7
 
     def test_run_pending_skips_applied(self, db_path: Path) -> None:
         """Running twice applies nothing the second time."""
@@ -83,7 +83,7 @@ class TestMigrationRunner:
         first = runner.run_pending()
         second = runner.run_pending()
 
-        assert len(first) == 6
+        assert len(first) == 7
         assert second == []
 
     def test_run_pending_partial(self, db_path: Path) -> None:
@@ -110,11 +110,12 @@ class TestMigrationRunner:
         runner = MigrationRunner(db_path)
         applied = runner.run_pending()
 
-        assert runner.get_current_version() == 6
+        assert runner.get_current_version() == 7
         assert applied == [
             "remove_fk_constraints",
             "add_plan_versioning",
             "add_cadence_columns",
+            "add_athlete_tables",
         ]
 
     def test_migration_records_applied_at(self, db_path: Path) -> None:
@@ -128,7 +129,7 @@ class TestMigrationRunner:
         ).fetchall()
         conn.close()
 
-        assert len(rows) == 6
+        assert len(rows) == 7
         for version, name, applied_at in rows:
             assert applied_at is not None
             assert isinstance(name, str)


### PR DESCRIPTION
## Summary

週次トレーニングレビューサイクルの土台となる4テーブルを DuckDB に追加する migration v7。

Epic #268（週次トレーニングレビューサイクル）第1波。

## Changes
- `database/migrations/add_athlete_tables.py` (new) — `add_athlete_tables(conn)`。3 sequence + 4 テーブル + UNIQUE index を全て `IF NOT EXISTS` で冪等作成
- `database/migrations/registry.py` — `(7, "add_athlete_tables", _wrap_athlete_tables)` を追加
- `database/db_writer.py` — `_ensure_tables` の section_analyses 直後に同4テーブルの CREATE を追記（新規 DB 初期化時にも作成）
- `tests/database/test_athlete_tables_migration.py` (new) — integration 3件
- `tests/database/test_migration_runner.py` — migration 数 6→7 の assertion 更新

## Schema
- `athlete_profile`（単一行プロフィール: current_focus / focus_notes）
- `athlete_goals`（レース目標: race_name / race_date / priority / target_time_seconds / status）
- `season_retrospectives`（シーズン振り返り: narrative / key_learnings）
- `weekly_reviews`（週次レビュー: review_data JSON、UNIQUE(user_id, week_start_date) で UPSERT）

surrogate key は `seq_section_analyses_id` パターンに倣い sequence で採番。

## Validation (L2) — メインセッションで実行済み
- integration 3件 PASS（creates_tables / idempotent / unique_week）
- DB 全テスト 364件 PASS（回帰なし）
- `GarminDBWriter()` 新規初期化で schema_version=7・4テーブル全存在を確認

## 注記
新4テーブルは API 由来でないため `scripts/regenerate/validator.py:AVAILABLE_TABLES` には**追加しない**（regenerate での wipe 防止）。

Closes #269