### PR TITLE
feat(db): add athlete profile reader/inserter + MCP tools (save/get_athlete_profile)

### DIFF
--- a/packages/garmin-mcp-server/src/garmin_mcp/database/inserters/athlete.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/database/inserters/athlete.py
@@ -1,0 +1,114 @@
+"""Athlete profile DB inserter.
+
+Persists the athlete's current focus, race goals, and season retrospectives as a
+single profile object across three tables (``athlete_profile``,
+``athlete_goals``, ``season_retrospectives``).
+
+Write semantics:
+- ``athlete_profile`` is UPSERTed on ``user_id`` (the PK), refreshing
+  ``updated_at`` on every save.
+- ``athlete_goals`` and ``season_retrospectives`` are fully replaced per
+  ``user_id`` (DELETE then INSERT), so each save reflects the supplied lists
+  exactly without duplication.
+- Surrogate keys are drawn from ``seq_athlete_goals_id`` /
+  ``seq_season_retrospectives_id`` via ``nextval``, mirroring the
+  ``seq_section_analyses_id`` pattern in ``db_writer.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def insert_athlete_profile(profile: dict[str, Any], db_path: str | None = None) -> None:
+    """Insert (or update) an athlete profile with its goals and retrospectives.
+
+    Args:
+        profile: Profile dict with keys ``user_id`` (defaults to ``"default"``),
+            ``current_focus``, ``focus_notes``, ``goals`` (list of goal dicts),
+            and ``retrospectives`` (list of retrospective dicts).
+        db_path: Path to DuckDB database. If None, uses default.
+    """
+    if db_path is None:
+        from garmin_mcp.utils.paths import get_database_dir
+
+        db_path = str(get_database_dir() / "garmin_performance.duckdb")
+
+    from garmin_mcp.database.connection import get_write_connection
+
+    user_id = profile.get("user_id") or "default"
+    goals = profile.get("goals") or []
+    retrospectives = profile.get("retrospectives") or []
+
+    with get_write_connection(db_path) as conn:
+        # UPSERT the single-row profile (PK = user_id), refreshing updated_at.
+        # updated_at uses the table DEFAULT (CURRENT_TIMESTAMP) on insert and is
+        # refreshed via now() on conflict.
+        conn.execute(
+            """
+            INSERT INTO athlete_profile (user_id, current_focus, focus_notes)
+            VALUES (?, ?, ?)
+            ON CONFLICT (user_id) DO UPDATE SET
+                current_focus = EXCLUDED.current_focus,
+                focus_notes = EXCLUDED.focus_notes,
+                updated_at = now()
+            """,
+            [user_id, profile.get("current_focus"), profile.get("focus_notes")],
+        )
+
+        # Replace goals for this user_id (DELETE then INSERT).
+        conn.execute("DELETE FROM athlete_goals WHERE user_id = ?", [user_id])
+        for goal in goals:
+            conn.execute(
+                """
+                INSERT INTO athlete_goals (
+                    goal_id, user_id, race_name, race_date, priority,
+                    goal_type, distance_km, target_time_seconds, status, notes
+                ) VALUES (
+                    nextval('seq_athlete_goals_id'), ?, ?, ?, ?, ?, ?, ?, ?, ?
+                )
+                """,
+                [
+                    user_id,
+                    goal.get("race_name"),
+                    goal.get("race_date"),
+                    goal.get("priority"),
+                    goal.get("goal_type"),
+                    goal.get("distance_km"),
+                    goal.get("target_time_seconds"),
+                    goal.get("status", "active"),
+                    goal.get("notes"),
+                ],
+            )
+
+        # Replace retrospectives for this user_id (DELETE then INSERT).
+        conn.execute("DELETE FROM season_retrospectives WHERE user_id = ?", [user_id])
+        for retro in retrospectives:
+            conn.execute(
+                """
+                INSERT INTO season_retrospectives (
+                    retro_id, user_id, season_label, period_start, period_end,
+                    narrative, key_learnings
+                ) VALUES (
+                    nextval('seq_season_retrospectives_id'), ?, ?, ?, ?, ?, ?
+                )
+                """,
+                [
+                    user_id,
+                    retro.get("season_label"),
+                    retro.get("period_start"),
+                    retro.get("period_end"),
+                    retro.get("narrative"),
+                    retro.get("key_learnings"),
+                ],
+            )
+
+        logger.info(
+            "Saved athlete profile user_id=%s (%d goals, %d retrospectives)",
+            user_id,
+            len(goals),
+            len(retrospectives),
+        )

--- a/packages/garmin-mcp-server/src/garmin_mcp/database/readers/athlete.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/database/readers/athlete.py
@@ -1,0 +1,88 @@
+"""Athlete profile DB reader."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from garmin_mcp.database.readers.base import BaseDBReader
+
+logger = logging.getLogger(__name__)
+
+
+class AthleteReader(BaseDBReader):
+    """Reads the athlete profile (focus + goals + retrospectives) from DuckDB."""
+
+    def get_athlete_profile(self, user_id: str = "default") -> dict[str, Any]:
+        """Get the merged athlete profile for a user.
+
+        Args:
+            user_id: Profile owner identifier (defaults to ``"default"``).
+
+        Returns:
+            Dict with ``user_id``, ``current_focus``, ``focus_notes``,
+            ``updated_at`` (str), ``goals`` (list) and ``retrospectives`` (list).
+            When no profile row exists, ``current_focus``/``focus_notes``/
+            ``updated_at`` are ``None`` and the lists are empty.
+            All date/timestamp values are converted to ``str``.
+        """
+        with self._get_connection() as conn:
+            profile_row = conn.execute(
+                "SELECT current_focus, focus_notes, updated_at "
+                "FROM athlete_profile WHERE user_id = ?",
+                [user_id],
+            ).fetchone()
+
+            if profile_row is None:
+                result: dict[str, Any] = {
+                    "user_id": user_id,
+                    "current_focus": None,
+                    "focus_notes": None,
+                    "updated_at": None,
+                }
+            else:
+                result = {
+                    "user_id": user_id,
+                    "current_focus": profile_row[0],
+                    "focus_notes": profile_row[1],
+                    "updated_at": (
+                        str(profile_row[2]) if profile_row[2] is not None else None
+                    ),
+                }
+
+            goal_rows = conn.execute(
+                "SELECT goal_id, race_name, race_date, priority, goal_type, "
+                "distance_km, target_time_seconds, status, notes "
+                "FROM athlete_goals WHERE user_id = ? ORDER BY goal_id",
+                [user_id],
+            ).fetchall()
+            goal_columns = [desc[0] for desc in conn.description]
+            result["goals"] = [
+                self._row_to_dict(goal_columns, row) for row in goal_rows
+            ]
+
+            retro_rows = conn.execute(
+                "SELECT retro_id, season_label, period_start, period_end, "
+                "narrative, key_learnings "
+                "FROM season_retrospectives WHERE user_id = ? ORDER BY retro_id",
+                [user_id],
+            ).fetchall()
+            retro_columns = [desc[0] for desc in conn.description]
+            result["retrospectives"] = [
+                self._row_to_dict(retro_columns, row) for row in retro_rows
+            ]
+
+            return result
+
+    @staticmethod
+    def _row_to_dict(columns: list[str], row: tuple) -> dict[str, Any]:
+        """Zip a row into a dict, converting date/datetime values to str."""
+        import datetime as _dt
+
+        record: dict[str, Any] = {}
+        for col, value in zip(columns, row, strict=False):
+            if isinstance(value, _dt.date | _dt.datetime):
+                record[col] = str(value)
+            else:
+                record[col] = value
+        return record

--- a/packages/garmin-mcp-server/src/garmin_mcp/handlers/athlete_handler.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/handlers/athlete_handler.py
@@ -1,0 +1,82 @@
+"""Handler for athlete profile tool calls."""
+
+import logging
+from typing import Any
+
+from mcp.types import TextContent
+
+from garmin_mcp.database.db_reader import GarminDBReader
+from garmin_mcp.handlers.base import format_json_response
+
+logger = logging.getLogger(__name__)
+
+
+class AthleteHandler:
+    """Handles athlete profile-related tool calls."""
+
+    _tool_names: set[str] = {
+        "save_athlete_profile",
+        "get_athlete_profile",
+    }
+
+    def __init__(self, db_reader: GarminDBReader) -> None:
+        self._db_reader = db_reader
+
+    def handles(self, name: str) -> bool:
+        return name in self._tool_names
+
+    async def handle(self, name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        if name == "save_athlete_profile":
+            return await self._save_athlete_profile(arguments)
+        elif name == "get_athlete_profile":
+            return await self._get_athlete_profile(arguments)
+        else:
+            raise ValueError(f"Unknown tool: {name}")
+
+    async def _save_athlete_profile(
+        self, arguments: dict[str, Any]
+    ) -> list[TextContent]:
+        from garmin_mcp.database.inserters.athlete import insert_athlete_profile
+
+        try:
+            profile = arguments["profile"]
+            insert_athlete_profile(
+                profile=profile,
+                db_path=str(self._db_reader.db_path),
+            )
+            result: dict[str, Any] = {
+                "status": "saved",
+                "user_id": profile.get("user_id", "default"),
+                "goal_count": len(profile.get("goals") or []),
+                "retrospective_count": len(profile.get("retrospectives") or []),
+            }
+        except Exception as e:
+            logger.error(f"Save athlete profile failed: {e}")
+            result = {"error": str(e)}
+
+        return [
+            TextContent(
+                type="text",
+                text=format_json_response(result, default=str),
+            )
+        ]
+
+    async def _get_athlete_profile(
+        self, arguments: dict[str, Any]
+    ) -> list[TextContent]:
+        from garmin_mcp.database.readers.athlete import AthleteReader
+
+        try:
+            reader = AthleteReader(db_path=str(self._db_reader.db_path))
+            user_id = arguments.get("user_id", "default")
+            result = reader.get_athlete_profile(user_id=user_id)
+        except Exception as e:
+            logger.error(f"Get athlete profile failed: {e}")
+            result = {"error": str(e)}
+
+        return [
+            TextContent(
+                type="text",
+                text=format_json_response(result, default=str),
+            )
+        ]

--- a/packages/garmin-mcp-server/src/garmin_mcp/server.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/server.py
@@ -19,6 +19,7 @@ from mcp.types import TextContent, Tool
 
 from garmin_mcp.database.db_reader import GarminDBReader
 from garmin_mcp.handlers.analysis_handler import AnalysisHandler
+from garmin_mcp.handlers.athlete_handler import AthleteHandler
 from garmin_mcp.handlers.base import ToolHandler
 from garmin_mcp.handlers.export_handler import ExportHandler
 from garmin_mcp.handlers.metadata_handler import MetadataHandler
@@ -93,6 +94,7 @@ def _init_handlers() -> None:
         TimeSeriesHandler(db_reader),
         ExportHandler(db_reader),
         TrainingPlanHandler(db_reader),
+        AthleteHandler(db_reader),
     ]
 
 

--- a/packages/garmin-mcp-server/src/garmin_mcp/tool_schemas.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/tool_schemas.py
@@ -729,6 +729,36 @@ _TRAINING_PLAN_TOOLS: list[dict] = [
     },
 ]
 
+_ATHLETE_TOOLS: list[dict] = [
+    {
+        "name": "save_athlete_profile",
+        "description": "Save the athlete profile (current focus, race goals, and season retrospectives) as a single object to DuckDB. The profile row is upserted on user_id; goals and retrospectives are fully replaced per user_id.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "profile": {
+                    "type": "object",
+                    "description": "Profile JSON with user_id (default 'default'), current_focus, focus_notes, goals (list of {race_name, race_date, priority, goal_type, distance_km, target_time_seconds, status, notes}), and retrospectives (list of {season_label, period_start, period_end, narrative, key_learnings}).",
+                },
+            },
+            "required": ["profile"],
+        },
+    },
+    {
+        "name": "get_athlete_profile",
+        "description": "Get the athlete profile (current focus, goals, and retrospectives) merged into a single object. Returns an empty structure (current_focus=None, goals=[], retrospectives=[]) when no profile is registered.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string",
+                    "description": "Profile owner identifier (default: 'default')",
+                },
+            },
+        },
+    },
+]
+
 _SERVER_TOOLS: list[dict] = [
     {
         "name": "get_server_info",
@@ -767,6 +797,7 @@ def get_tool_definitions() -> list[Tool]:
         + _PERFORMANCE_TOOLS
         + _TIME_SERIES_TOOLS
         + _TRAINING_PLAN_TOOLS
+        + _ATHLETE_TOOLS
         + _SERVER_TOOLS
     )
     return [
@@ -791,6 +822,7 @@ TOOL_NAMES: set[str] = {
         _PERFORMANCE_TOOLS,
         _TIME_SERIES_TOOLS,
         _TRAINING_PLAN_TOOLS,
+        _ATHLETE_TOOLS,
         _SERVER_TOOLS,
     ]
     for schema in group

--- a/packages/garmin-mcp-server/tests/database/inserters/test_athlete.py
+++ b/packages/garmin-mcp-server/tests/database/inserters/test_athlete.py
@@ -1,0 +1,123 @@
+"""Integration tests for the athlete profile inserter + reader roundtrip.
+
+Uses the module-scoped ``initialized_db_path`` fixture (schema pre-initialized
+via file copy) to avoid per-test GarminDBWriter DDL overhead.
+"""
+
+import pytest
+
+from garmin_mcp.database.inserters.athlete import insert_athlete_profile
+from garmin_mcp.database.readers.athlete import AthleteReader
+
+
+def _profile_with_two_goals() -> dict:
+    return {
+        "user_id": "default",
+        "current_focus": "回復力と筋持久力",
+        "focus_notes": "スピードは到達済み",
+        "goals": [
+            {
+                "race_name": "さいたまマラソン",
+                "race_date": "2027-02-01",
+                "priority": "A",
+                "goal_type": "marathon",
+                "target_time_seconds": 16200,
+                "status": "active",
+                "notes": "サブ4.5",
+            },
+            {
+                "race_name": "新潟シティマラソン",
+                "race_date": "2026-10-11",
+                "priority": "B",
+                "goal_type": "marathon",
+                "status": "active",
+                "notes": "中間目標。ドレスリハーサル",
+            },
+        ],
+        "retrospectives": [
+            {
+                "season_label": "2025-2026",
+                "narrative": "ハーフ2:13後に故障",
+                "key_learnings": "強い実戦直後の故障に注意",
+            }
+        ],
+    }
+
+
+@pytest.mark.integration
+def test_save_then_get_profile_roundtrip(initialized_db_path) -> None:
+    """Save a profile (2 goals, 1 retro), then get it back with matching values."""
+    db_path = str(initialized_db_path)
+    insert_athlete_profile(_profile_with_two_goals(), db_path=db_path)
+
+    result = AthleteReader(db_path=db_path).get_athlete_profile()
+
+    assert result["user_id"] == "default"
+    assert result["current_focus"] == "回復力と筋持久力"
+    assert result["focus_notes"] == "スピードは到達済み"
+    assert result["updated_at"] is not None
+
+    assert len(result["goals"]) == 2
+    first = result["goals"][0]
+    assert first["race_name"] == "さいたまマラソン"
+    assert first["race_date"] == "2027-02-01"
+    assert first["priority"] == "A"
+    assert first["goal_type"] == "marathon"
+    assert first["target_time_seconds"] == 16200
+    assert first["status"] == "active"
+    assert first["notes"] == "サブ4.5"
+
+    second = result["goals"][1]
+    assert second["race_name"] == "新潟シティマラソン"
+    assert second["priority"] == "B"
+
+    assert len(result["retrospectives"]) == 1
+    retro = result["retrospectives"][0]
+    assert retro["season_label"] == "2025-2026"
+    assert retro["narrative"] == "ハーフ2:13後に故障"
+    assert retro["key_learnings"] == "強い実戦直後の故障に注意"
+
+
+@pytest.mark.integration
+def test_save_profile_replaces_goals(initialized_db_path) -> None:
+    """Re-saving with fewer goals fully replaces the prior set (no duplication)."""
+    db_path = str(initialized_db_path)
+    insert_athlete_profile(_profile_with_two_goals(), db_path=db_path)
+
+    single_goal_profile = {
+        "user_id": "default",
+        "current_focus": "新フォーカス",
+        "goals": [
+            {
+                "race_name": "東京マラソン",
+                "race_date": "2027-03-01",
+                "priority": "A",
+                "goal_type": "marathon",
+                "status": "active",
+            }
+        ],
+        "retrospectives": [],
+    }
+    insert_athlete_profile(single_goal_profile, db_path=db_path)
+
+    result = AthleteReader(db_path=db_path).get_athlete_profile()
+
+    assert result["current_focus"] == "新フォーカス"
+    assert len(result["goals"]) == 1
+    assert result["goals"][0]["race_name"] == "東京マラソン"
+    assert result["retrospectives"] == []
+
+
+@pytest.mark.integration
+def test_get_profile_empty(initialized_db_path) -> None:
+    """Getting an unregistered user_id returns the empty profile structure."""
+    db_path = str(initialized_db_path)
+
+    result = AthleteReader(db_path=db_path).get_athlete_profile(user_id="ghost")
+
+    assert result["user_id"] == "ghost"
+    assert result["current_focus"] is None
+    assert result["focus_notes"] is None
+    assert result["updated_at"] is None
+    assert result["goals"] == []
+    assert result["retrospectives"] == []

--- a/packages/garmin-mcp-server/tests/unit/test_tool_contract.py
+++ b/packages/garmin-mcp-server/tests/unit/test_tool_contract.py
@@ -7,6 +7,7 @@ from typing import Protocol
 import pytest
 
 from garmin_mcp.handlers.analysis_handler import AnalysisHandler
+from garmin_mcp.handlers.athlete_handler import AthleteHandler
 from garmin_mcp.handlers.export_handler import ExportHandler
 from garmin_mcp.handlers.metadata_handler import MetadataHandler
 from garmin_mcp.handlers.performance_handler import PerformanceHandler
@@ -30,6 +31,7 @@ HANDLER_CLASSES: list[type[_HasToolNames]] = [
     SplitsHandler,
     TimeSeriesHandler,
     TrainingPlanHandler,
+    AthleteHandler,
 ]
 
 # Tools handled directly in server.py, not by any handler class


### PR DESCRIPTION
## Summary

目標・現フェーズ・昨季の振り返りを単一 profile オブジェクトとして保存/取得する Reader/Inserter と MCP ツール（`save_athlete_profile` / `get_athlete_profile`）を追加。

Epic #268（週次トレーニングレビューサイクル）第2波。

## Changes
- `database/inserters/athlete.py` (new) — `insert_athlete_profile()`（profile を user_id PK で UPSERT、goals/retrospectives は user_id 単位で DELETE→INSERT 洗い替え、seq で採番）
- `database/readers/athlete.py` (new) — `AthleteReader.get_athlete_profile()`（3テーブルをマージ、date/timestamp→str、未登録は空構造）
- `handlers/athlete_handler.py` (new) — `AthleteHandler`
- `server.py` — `_handlers` に `AthleteHandler` 追加
- `tool_schemas.py` — `_ATHLETE_TOOLS` 新設
- `tests/database/inserters/test_athlete.py` (new) — integration 3件
- `tests/unit/test_tool_contract.py` — `HANDLER_CLASSES` に `AthleteHandler` 追加（契約テスト同期）

## Validation (L1) — メインセッションで実行済み
- integration 3件 PASS（roundtrip / replaces_goals / empty）
- contract/schema/server/handler 回帰 226件 PASS

Closes #270