### PR TITLE
feat(db): add weekly_review reader/inserter + MCP tools (save/get_weekly_review)

### DIFF
--- a/packages/garmin-mcp-server/src/garmin_mcp/database/inserters/athlete.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/database/inserters/athlete.py
@@ -17,6 +17,7 @@ Write semantics:
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -112,3 +113,72 @@ def insert_athlete_profile(profile: dict[str, Any], db_path: str | None = None) 
             len(goals),
             len(retrospectives),
         )
+
+
+def insert_weekly_review(review: dict[str, Any], db_path: str | None = None) -> bool:
+    """Insert (or update) a weekly review record.
+
+    The record is UPSERTed on the ``(user_id, week_start_date)`` unique index
+    (``idx_weekly_reviews_week``), so re-saving the same week overwrites the
+    prior review in place. The free-form ``review_data`` payload is serialized
+    to JSON and stored as a VARCHAR column. Surrogate keys are drawn from
+    ``seq_weekly_reviews_id`` via ``nextval``.
+
+    Args:
+        review: Review dict with keys ``user_id`` (defaults to ``"default"``),
+            ``week_start_date``, ``week_end_date``, ``review_date``,
+            ``review_data`` (dict, serialized to JSON), ``agent_name``, and
+            ``agent_version``.
+        db_path: Path to DuckDB database. If None, uses default.
+
+    Returns:
+        ``True`` on success.
+    """
+    if db_path is None:
+        from garmin_mcp.utils.paths import get_database_dir
+
+        db_path = str(get_database_dir() / "garmin_performance.duckdb")
+
+    from garmin_mcp.database.connection import get_write_connection
+
+    user_id = review.get("user_id") or "default"
+    review_data_json = json.dumps(review.get("review_data"), ensure_ascii=False)
+
+    with get_write_connection(db_path) as conn:
+        # UPSERT keyed on the (user_id, week_start_date) unique index.
+        # created_at is left to the table DEFAULT (CURRENT_TIMESTAMP) on insert
+        # to avoid the DuckDB Binder error seen when passing CURRENT_TIMESTAMP
+        # in an ON CONFLICT INSERT (mirrors athlete_profile handling).
+        conn.execute(
+            """
+            INSERT INTO weekly_reviews (
+                review_id, user_id, week_start_date, week_end_date,
+                review_date, review_data, agent_name, agent_version
+            ) VALUES (
+                nextval('seq_weekly_reviews_id'), ?, ?, ?, ?, ?, ?, ?
+            )
+            ON CONFLICT (user_id, week_start_date) DO UPDATE SET
+                week_end_date = EXCLUDED.week_end_date,
+                review_date = EXCLUDED.review_date,
+                review_data = EXCLUDED.review_data,
+                agent_name = EXCLUDED.agent_name,
+                agent_version = EXCLUDED.agent_version
+            """,
+            [
+                user_id,
+                review.get("week_start_date"),
+                review.get("week_end_date"),
+                review.get("review_date"),
+                review_data_json,
+                review.get("agent_name"),
+                review.get("agent_version"),
+            ],
+        )
+
+        logger.info(
+            "Saved weekly review user_id=%s week_start_date=%s",
+            user_id,
+            review.get("week_start_date"),
+        )
+
+    return True

--- a/packages/garmin-mcp-server/src/garmin_mcp/database/readers/athlete.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/database/readers/athlete.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -73,6 +74,76 @@ class AthleteReader(BaseDBReader):
             ]
 
             return result
+
+    def get_weekly_review(
+        self, week_start_date: str | None = None, user_id: str = "default"
+    ) -> dict[str, Any] | None:
+        """Get a single weekly review record.
+
+        Args:
+            week_start_date: Week start (``YYYY-MM-DD``). When ``None``, the most
+                recent review (highest ``week_start_date``) is returned.
+            user_id: Profile owner identifier (defaults to ``"default"``).
+
+        Returns:
+            A dict with the review columns (date/timestamp values converted to
+            ``str``) where ``review_data`` is JSON-decoded back into a dict, or
+            ``None`` when no matching review exists.
+        """
+        with self._get_connection() as conn:
+            select_cols = (
+                "review_id, user_id, week_start_date, week_end_date, review_date, "
+                "review_data, created_at, agent_name, agent_version "
+                "FROM weekly_reviews WHERE user_id = ?"
+            )
+            if week_start_date is None:
+                row = conn.execute(
+                    f"SELECT {select_cols} ORDER BY week_start_date DESC LIMIT 1",
+                    [user_id],
+                ).fetchone()
+            else:
+                row = conn.execute(
+                    f"SELECT {select_cols} AND week_start_date = ?",
+                    [user_id, week_start_date],
+                ).fetchone()
+
+            if row is None:
+                return None
+
+            columns = [desc[0] for desc in conn.description]
+            return self._review_row_to_dict(columns, row)
+
+    def list_weekly_reviews(
+        self, limit: int = 8, user_id: str = "default"
+    ) -> list[dict[str, Any]]:
+        """List recent weekly reviews in descending week order.
+
+        Args:
+            limit: Maximum number of reviews to return (default 8).
+            user_id: Profile owner identifier (defaults to ``"default"``).
+
+        Returns:
+            A list of review dicts (newest first). Each ``review_data`` is
+            JSON-decoded back into a dict.
+        """
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                "SELECT review_id, user_id, week_start_date, week_end_date, "
+                "review_date, review_data, created_at, agent_name, agent_version "
+                "FROM weekly_reviews WHERE user_id = ? "
+                "ORDER BY week_start_date DESC LIMIT ?",
+                [user_id, limit],
+            ).fetchall()
+            columns = [desc[0] for desc in conn.description]
+            return [self._review_row_to_dict(columns, row) for row in rows]
+
+    @classmethod
+    def _review_row_to_dict(cls, columns: list[str], row: tuple) -> dict[str, Any]:
+        """Convert a weekly_reviews row, JSON-decoding ``review_data``."""
+        record = cls._row_to_dict(columns, row)
+        raw = record.get("review_data")
+        record["review_data"] = json.loads(raw) if raw is not None else None
+        return record
 
     @staticmethod
     def _row_to_dict(columns: list[str], row: tuple) -> dict[str, Any]:

--- a/packages/garmin-mcp-server/src/garmin_mcp/handlers/athlete_handler.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/handlers/athlete_handler.py
@@ -17,6 +17,8 @@ class AthleteHandler:
     _tool_names: set[str] = {
         "save_athlete_profile",
         "get_athlete_profile",
+        "save_weekly_review",
+        "get_weekly_review",
     }
 
     def __init__(self, db_reader: GarminDBReader) -> None:
@@ -30,6 +32,10 @@ class AthleteHandler:
             return await self._save_athlete_profile(arguments)
         elif name == "get_athlete_profile":
             return await self._get_athlete_profile(arguments)
+        elif name == "save_weekly_review":
+            return await self._save_weekly_review(arguments)
+        elif name == "get_weekly_review":
+            return await self._get_weekly_review(arguments)
         else:
             raise ValueError(f"Unknown tool: {name}")
 
@@ -72,6 +78,52 @@ class AthleteHandler:
             result = reader.get_athlete_profile(user_id=user_id)
         except Exception as e:
             logger.error(f"Get athlete profile failed: {e}")
+            result = {"error": str(e)}
+
+        return [
+            TextContent(
+                type="text",
+                text=format_json_response(result, default=str),
+            )
+        ]
+
+    async def _save_weekly_review(self, arguments: dict[str, Any]) -> list[TextContent]:
+        from garmin_mcp.database.inserters.athlete import insert_weekly_review
+
+        try:
+            review = arguments["review"]
+            insert_weekly_review(
+                review=review,
+                db_path=str(self._db_reader.db_path),
+            )
+            result: dict[str, Any] = {
+                "status": "saved",
+                "user_id": review.get("user_id", "default"),
+                "week_start_date": review.get("week_start_date"),
+            }
+        except Exception as e:
+            logger.error(f"Save weekly review failed: {e}")
+            result = {"error": str(e)}
+
+        return [
+            TextContent(
+                type="text",
+                text=format_json_response(result, default=str),
+            )
+        ]
+
+    async def _get_weekly_review(self, arguments: dict[str, Any]) -> list[TextContent]:
+        from garmin_mcp.database.readers.athlete import AthleteReader
+
+        try:
+            reader = AthleteReader(db_path=str(self._db_reader.db_path))
+            user_id = arguments.get("user_id", "default")
+            result = reader.get_weekly_review(
+                week_start_date=arguments.get("week_start_date"),
+                user_id=user_id,
+            )
+        except Exception as e:
+            logger.error(f"Get weekly review failed: {e}")
             result = {"error": str(e)}
 
         return [

--- a/packages/garmin-mcp-server/src/garmin_mcp/tool_schemas.py
+++ b/packages/garmin-mcp-server/src/garmin_mcp/tool_schemas.py
@@ -757,6 +757,37 @@ _ATHLETE_TOOLS: list[dict] = [
             },
         },
     },
+    {
+        "name": "save_weekly_review",
+        "description": "Save a weekly training review to DuckDB. The record is upserted on (user_id, week_start_date), so re-saving the same week overwrites the prior review. The free-form review_data payload is stored as JSON.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "review": {
+                    "type": "object",
+                    "description": "Review JSON with user_id (default 'default'), week_start_date, week_end_date, review_date, review_data (object, e.g. {this_week, garmin_next_week, verdict, recommendations, overall}), agent_name, and agent_version.",
+                },
+            },
+            "required": ["review"],
+        },
+    },
+    {
+        "name": "get_weekly_review",
+        "description": "Get a single weekly review. When week_start_date is omitted, the most recent review is returned. review_data is JSON-decoded back into an object. Returns null when no matching review exists.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "week_start_date": {
+                    "type": "string",
+                    "description": "Week start date (YYYY-MM-DD). When omitted, returns the most recent review.",
+                },
+                "user_id": {
+                    "type": "string",
+                    "description": "Profile owner identifier (default: 'default')",
+                },
+            },
+        },
+    },
 ]
 
 _SERVER_TOOLS: list[dict] = [

--- a/packages/garmin-mcp-server/tests/database/inserters/test_athlete.py
+++ b/packages/garmin-mcp-server/tests/database/inserters/test_athlete.py
@@ -6,7 +6,10 @@ via file copy) to avoid per-test GarminDBWriter DDL overhead.
 
 import pytest
 
-from garmin_mcp.database.inserters.athlete import insert_athlete_profile
+from garmin_mcp.database.inserters.athlete import (
+    insert_athlete_profile,
+    insert_weekly_review,
+)
 from garmin_mcp.database.readers.athlete import AthleteReader
 
 
@@ -121,3 +124,80 @@ def test_get_profile_empty(initialized_db_path) -> None:
     assert result["updated_at"] is None
     assert result["goals"] == []
     assert result["retrospectives"] == []
+
+
+def _weekly_review(
+    week_start_date: str = "2026-06-08", volume_km: float = 28.8
+) -> dict:
+    return {
+        "user_id": "default",
+        "week_start_date": week_start_date,
+        "week_end_date": "2026-06-14",
+        "review_date": "2026-06-14",
+        "review_data": {
+            "this_week": {"volume_km": volume_km, "run_count": 4},
+            "garmin_next_week": [
+                {"date": "2026-06-16", "title": "Tempo", "type": "fbtAdaptiveWorkout"}
+            ],
+            "verdict": [
+                {
+                    "date": "2026-06-20",
+                    "session": "Anaerobic",
+                    "rating": "🔴",
+                    "comment": "強度過多に注意",
+                }
+            ],
+            "recommendations": ["Z2を維持する"],
+            "overall": "順調に積み上げ",
+        },
+        "agent_name": "weekly-review",
+        "agent_version": "1.0",
+    }
+
+
+@pytest.mark.integration
+def test_save_then_get_weekly_review(initialized_db_path) -> None:
+    """Save a weekly review, then get it back with review_data JSON restored."""
+    db_path = str(initialized_db_path)
+    review = _weekly_review()
+    assert insert_weekly_review(review, db_path=db_path) is True
+
+    result = AthleteReader(db_path=db_path).get_weekly_review()
+
+    assert result is not None
+    assert result["user_id"] == "default"
+    assert result["week_start_date"] == "2026-06-08"
+    assert result["week_end_date"] == "2026-06-14"
+    assert result["review_date"] == "2026-06-14"
+    assert result["agent_name"] == "weekly-review"
+    assert result["agent_version"] == "1.0"
+    assert result["review_data"] == review["review_data"]
+    assert result["review_data"]["this_week"]["volume_km"] == 28.8
+    assert result["review_data"]["verdict"][0]["rating"] == "🔴"
+
+
+@pytest.mark.integration
+def test_weekly_review_upsert_same_week(initialized_db_path) -> None:
+    """Saving the same (user_id, week_start_date) twice keeps a single row."""
+    db_path = str(initialized_db_path)
+    insert_weekly_review(_weekly_review(volume_km=28.8), db_path=db_path)
+    insert_weekly_review(_weekly_review(volume_km=35.5), db_path=db_path)
+
+    reviews = AthleteReader(db_path=db_path).list_weekly_reviews()
+    assert len(reviews) == 1
+    assert reviews[0]["review_data"]["this_week"]["volume_km"] == 35.5
+
+
+@pytest.mark.integration
+def test_list_weekly_reviews_order(initialized_db_path) -> None:
+    """list_weekly_reviews returns reviews in descending week order, limited."""
+    db_path = str(initialized_db_path)
+    insert_weekly_review(_weekly_review(week_start_date="2026-05-25"), db_path=db_path)
+    insert_weekly_review(_weekly_review(week_start_date="2026-06-01"), db_path=db_path)
+    insert_weekly_review(_weekly_review(week_start_date="2026-06-08"), db_path=db_path)
+
+    reviews = AthleteReader(db_path=db_path).list_weekly_reviews(limit=2)
+
+    assert len(reviews) == 2
+    assert reviews[0]["week_start_date"] == "2026-06-08"
+    assert reviews[1]["week_start_date"] == "2026-06-01"


### PR DESCRIPTION
## Summary

週次レビュー結果を `weekly_reviews` テーブルに保存/取得する関数と MCP ツール（`save_weekly_review` / `get_weekly_review`）を追加。

Epic #268（週次トレーニングレビューサイクル）第2波。#270 の athlete モジュールに追記。

## Changes
- `database/inserters/athlete.py` — `insert_weekly_review()`（UPSERT on (user_id, week_start_date)、review_data を json.dumps、seq 採番、created_at は DEFAULT 委譲）
- `database/readers/athlete.py` — `AthleteReader.get_weekly_review()`（指定なし=最新、review_data を json.loads、date→str）/ `list_weekly_reviews()`（降順 limit）
- `handlers/athlete_handler.py` — `save_weekly_review` / `get_weekly_review` ツール追加
- `tool_schemas.py` — `_ATHLETE_TOOLS` に2スキーマ追加
- `tests/database/inserters/test_athlete.py` — integration 3件追記

## Validation (L1) — メインセッションで実行済み
- athlete テスト 6件 PASS（weekly 3件: roundtrip / upsert_same_week / list_order）
- contract/schema/server/handler 回帰 229件 PASS（契約テストが新2ツールを自動検出）

Closes #271