### PR TITLE
feat(web): add goal reference page (/goal, GET /api/goal)

### DIFF
--- a/packages/garmin-web/frontend/src/App.tsx
+++ b/packages/garmin-web/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Layout from "./components/Layout";
 import ActivityDetail from "./pages/ActivityDetail";
 import ActivityList from "./pages/ActivityList";
+import Goal from "./pages/Goal";
 import TrendsDashboard from "./pages/TrendsDashboard";
 
 export default function App() {
@@ -12,6 +13,7 @@ export default function App() {
           <Route path="/" element={<ActivityList />} />
           <Route path="/activities/:id" element={<ActivityDetail />} />
           <Route path="/trends" element={<TrendsDashboard />} />
+          <Route path="/goal" element={<Goal />} />
         </Routes>
       </Layout>
     </BrowserRouter>

--- a/packages/garmin-web/frontend/src/api/client.ts
+++ b/packages/garmin-web/frontend/src/api/client.ts
@@ -1,10 +1,19 @@
 import type {
   ActivityDetailResponse,
   ActivitySummary,
+  GoalResponse,
   SectionsResponse,
   TimeSeriesResponse,
   TrackResponse,
 } from "../types";
+
+export async function fetchGoal(): Promise<GoalResponse> {
+  const response = await fetch("/api/goal");
+  if (!response.ok) {
+    throw new Error(`Failed to fetch goal: ${response.status}`);
+  }
+  return (await response.json()) as GoalResponse;
+}
 
 export async function fetchActivities(params?: {
   from?: string;

--- a/packages/garmin-web/frontend/src/components/Layout.tsx
+++ b/packages/garmin-web/frontend/src/components/Layout.tsx
@@ -30,6 +30,9 @@ export default function Layout({ children }: { children: ReactNode }) {
             <NavLink to="/trends" className={navLinkClass}>
               トレンド
             </NavLink>
+            <NavLink to="/goal" className={navLinkClass}>
+              目標
+            </NavLink>
           </nav>
         </div>
       </header>

--- a/packages/garmin-web/frontend/src/pages/Goal.test.tsx
+++ b/packages/garmin-web/frontend/src/pages/Goal.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Goal, { formatTargetTime } from "./Goal";
+
+const FIXTURE_GOAL = {
+  profile: {
+    current_focus: "サブ4達成に向けた持久力強化",
+    focus_notes: "週末ロング走を軸に有酸素ベースを底上げ",
+    updated_at: "2026-06-14 09:00:00",
+  },
+  goals: [
+    {
+      goal_id: 1,
+      race_name: "つくばマラソン",
+      race_date: "2026-11-22",
+      priority: "A",
+      goal_type: "marathon",
+      distance_km: 42.195,
+      target_time_seconds: 16200,
+      status: "active",
+      notes: "メインターゲット",
+    },
+    {
+      goal_id: 2,
+      race_name: "ハーフマラソン大会",
+      race_date: null,
+      priority: "B",
+      goal_type: "half",
+      distance_km: 21.0975,
+      target_time_seconds: 7200,
+      status: "active",
+      notes: "調整レース",
+    },
+  ],
+  retrospectives: [
+    {
+      retro_id: 1,
+      season_label: "2025秋シーズン",
+      period_start: "2025-09-01",
+      period_end: "2025-12-31",
+      narrative: "故障なく走り込めた一方、後半の失速が課題でした。",
+      key_learnings: "ロング走でのペース管理を重視する",
+    },
+  ],
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("formatTargetTime", () => {
+  it("formats seconds as H:MM:SS", () => {
+    expect(formatTargetTime(16200)).toBe("4:30:00");
+    expect(formatTargetTime(7200)).toBe("2:00:00");
+    expect(formatTargetTime(null)).toBe("-");
+  });
+});
+
+describe("Goal", () => {
+  it("renders profile, goals and retrospectives from API", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(FIXTURE_GOAL), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    render(
+      <MemoryRouter>
+        <Goal />
+      </MemoryRouter>,
+    );
+
+    // Profile focus
+    expect(
+      await screen.findByText("サブ4達成に向けた持久力強化"),
+    ).toBeInTheDocument();
+
+    // Race rows: names + human-readable target time
+    expect(screen.getByText("つくばマラソン")).toBeInTheDocument();
+    expect(screen.getByText("ハーフマラソン大会")).toBeInTheDocument();
+    expect(screen.getByText("4:30:00")).toBeInTheDocument();
+    expect(screen.getByText("2:00:00")).toBeInTheDocument();
+
+    // Null race date renders as 未定
+    expect(screen.getByText("未定")).toBeInTheDocument();
+
+    // Retrospective
+    expect(screen.getByText("2025秋シーズン")).toBeInTheDocument();
+    expect(
+      screen.getByText("故障なく走り込めた一方、後半の失速が課題でした。"),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/garmin-web/frontend/src/pages/Goal.tsx
+++ b/packages/garmin-web/frontend/src/pages/Goal.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from "react";
+import { fetchGoal } from "../api/client";
+import type { GoalResponse } from "../types";
+
+/** Format a target time in seconds as H:MM:SS (e.g. 16200 -> "4:30:00"). */
+export function formatTargetTime(seconds: number | null): string {
+  if (seconds == null || seconds < 0) {
+    return "-";
+  }
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  return `${hours}:${String(minutes).padStart(2, "0")}:${String(secs).padStart(
+    2,
+    "0",
+  )}`;
+}
+
+function formatDistanceKm(km: number | null): string {
+  if (km == null) {
+    return "-";
+  }
+  return `${km.toFixed(2)} km`;
+}
+
+export default function Goal() {
+  const [goal, setGoal] = useState<GoalResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchGoal()
+      .then((data) => {
+        if (!cancelled) {
+          setGoal(data);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center gap-3 py-16 text-sm text-slate-500">
+        <span
+          aria-hidden="true"
+          className="h-5 w-5 animate-spin rounded-full border-2 border-slate-300 border-t-ink"
+        />
+        読み込み中...
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <p
+        role="alert"
+        className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+      >
+        エラー: {error}
+      </p>
+    );
+  }
+  if (goal == null) {
+    return null;
+  }
+
+  const { profile, goals, retrospectives } = goal;
+  const hasProfile = profile.current_focus != null || profile.focus_notes != null;
+
+  return (
+    <div className="stagger-in space-y-6">
+      <h1 className="font-display text-2xl font-bold tracking-tight text-ink">
+        目標
+      </h1>
+
+      {/* Current phase */}
+      <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 font-display text-base font-semibold text-ink">
+          現フェーズ
+        </h2>
+        {hasProfile ? (
+          <div className="space-y-1">
+            {profile.current_focus != null && (
+              <p className="text-sm font-medium text-slate-800">
+                {profile.current_focus}
+              </p>
+            )}
+            {profile.focus_notes != null && (
+              <p className="text-sm text-slate-600">{profile.focus_notes}</p>
+            )}
+            {profile.updated_at != null && (
+              <p className="text-xs text-slate-400">
+                更新: {profile.updated_at}
+              </p>
+            )}
+          </div>
+        ) : (
+          <p className="py-4 text-center text-sm text-slate-500">
+            現フェーズが登録されていません
+          </p>
+        )}
+      </section>
+
+      {/* Target races */}
+      <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 font-display text-base font-semibold text-ink">
+          目標レース
+        </h2>
+        {goals.length > 0 ? (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-xs tracking-wide text-slate-500 uppercase">
+                <th className="px-2 py-2 text-left font-medium">優先度</th>
+                <th className="px-2 py-2 text-left font-medium">レース</th>
+                <th className="px-2 py-2 text-left font-medium">日付</th>
+                <th className="px-2 py-2 text-left font-medium">種別</th>
+                <th className="px-2 py-2 text-right font-medium">目標タイム</th>
+                <th className="px-2 py-2 text-right font-medium">距離</th>
+                <th className="px-2 py-2 text-left font-medium">状態</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 text-[15px]">
+              {goals.map((race) => (
+                <tr key={race.goal_id} className="hover:bg-slate-50">
+                  <td className="px-2 py-2 text-left">
+                    <span className="rounded-md bg-ink/5 px-2 py-0.5 font-numeric text-sm font-semibold text-ink">
+                      {race.priority ?? "-"}
+                    </span>
+                  </td>
+                  <td className="px-2 py-2 text-left font-medium text-slate-800">
+                    {race.race_name ?? "-"}
+                  </td>
+                  <td className="px-2 py-2 text-left font-numeric tabular-nums text-slate-700">
+                    {race.race_date ?? "未定"}
+                  </td>
+                  <td className="px-2 py-2 text-left text-slate-700">
+                    {race.goal_type ?? "-"}
+                  </td>
+                  <td className="px-2 py-2 text-right font-numeric tabular-nums text-slate-700">
+                    {formatTargetTime(race.target_time_seconds)}
+                  </td>
+                  <td className="px-2 py-2 text-right font-numeric tabular-nums text-slate-700">
+                    {formatDistanceKm(race.distance_km)}
+                  </td>
+                  <td className="px-2 py-2 text-left text-slate-700">
+                    {race.status ?? "-"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className="py-4 text-center text-sm text-slate-500">
+            目標レースが登録されていません
+          </p>
+        )}
+      </section>
+
+      {/* Season retrospectives */}
+      <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="mb-3 font-display text-base font-semibold text-ink">
+          昨季の振り返り
+        </h2>
+        {retrospectives.length > 0 ? (
+          <ul className="space-y-4">
+            {retrospectives.map((retro) => (
+              <li key={retro.retro_id} className="space-y-1">
+                <div className="flex items-baseline gap-3">
+                  <span className="font-display text-sm font-semibold text-ink">
+                    {retro.season_label ?? "シーズン"}
+                  </span>
+                  {(retro.period_start != null || retro.period_end != null) && (
+                    <span className="font-numeric text-xs tabular-nums text-slate-400">
+                      {retro.period_start ?? "?"} 〜 {retro.period_end ?? "?"}
+                    </span>
+                  )}
+                </div>
+                {retro.narrative != null && (
+                  <p className="text-sm text-slate-700">{retro.narrative}</p>
+                )}
+                {retro.key_learnings != null && (
+                  <p className="text-sm text-slate-600">
+                    <span className="font-medium text-slate-500">学び: </span>
+                    {retro.key_learnings}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="py-4 text-center text-sm text-slate-500">
+            振り返りが登録されていません
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/packages/garmin-web/frontend/src/types.ts
+++ b/packages/garmin-web/frontend/src/types.ts
@@ -8,6 +8,41 @@ export interface ActivitySummary {
   avg_heart_rate: number | null;
 }
 
+// --- Goal page (Issue #282) ---
+
+export interface GoalProfile {
+  current_focus: string | null;
+  focus_notes: string | null;
+  updated_at: string | null;
+}
+
+export interface GoalRace {
+  goal_id: number;
+  race_name: string | null;
+  race_date: string | null;
+  priority: string | null;
+  goal_type: string | null;
+  distance_km: number | null;
+  target_time_seconds: number | null;
+  status: string | null;
+  notes: string | null;
+}
+
+export interface SeasonRetrospective {
+  retro_id: number;
+  season_label: string | null;
+  period_start: string | null;
+  period_end: string | null;
+  narrative: string | null;
+  key_learnings: string | null;
+}
+
+export interface GoalResponse {
+  profile: GoalProfile;
+  goals: GoalRace[];
+  retrospectives: SeasonRetrospective[];
+}
+
 // --- Activity detail (Issue #199) ---
 
 export interface SplitRow {

--- a/packages/garmin-web/src/garmin_web/api/goal.py
+++ b/packages/garmin-web/src/garmin_web/api/goal.py
@@ -1,0 +1,19 @@
+"""Goal API router (read-only)."""
+
+from fastapi import APIRouter, Request
+from garmin_mcp.database.connection import get_connection
+
+from garmin_web.queries.goal import get_goal
+
+router = APIRouter(prefix="/api")
+
+
+@router.get("/goal")
+def get_goal_endpoint(request: Request) -> dict:
+    """Return the athlete goal payload (profile + goals + retrospectives).
+
+    Read-only: registration/updates are owned by the CLI (`/set-goal`).
+    """
+    db_path = getattr(request.app.state, "db_path", None)
+    with get_connection(db_path) as conn:
+        return get_goal(conn)

--- a/packages/garmin-web/src/garmin_web/app.py
+++ b/packages/garmin-web/src/garmin_web/app.py
@@ -9,6 +9,7 @@ from fastapi.responses import FileResponse
 
 from garmin_web.api.activities import router as activities_router
 from garmin_web.api.activity_detail import router as activity_detail_router
+from garmin_web.api.goal import router as goal_router
 from garmin_web.api.trends import router as trends_router
 
 logger = logging.getLogger(__name__)
@@ -50,6 +51,7 @@ def create_app(
     app.include_router(activities_router)
     app.include_router(activity_detail_router)
     app.include_router(trends_router)
+    app.include_router(goal_router)
 
     resolved_static_dir = Path(static_dir) if static_dir else _DEFAULT_STATIC_DIR
     _mount_spa(app, resolved_static_dir)

--- a/packages/garmin-web/src/garmin_web/queries/goal.py
+++ b/packages/garmin-web/src/garmin_web/queries/goal.py
@@ -1,0 +1,114 @@
+"""Read-only queries for the athlete goal tables.
+
+Reads the athlete's current focus, race goals, and season retrospectives from
+the three athlete-centric tables (``athlete_profile``, ``athlete_goals``,
+``season_retrospectives``). Registration/updates are owned by the CLI
+(``/set-goal``); the Web app is display-only.
+"""
+
+import datetime as _dt
+
+import duckdb
+
+_SELECT_PROFILE = """
+    SELECT current_focus, focus_notes, updated_at
+    FROM athlete_profile
+    WHERE user_id = ?
+"""
+
+_SELECT_GOALS = """
+    SELECT
+        goal_id,
+        race_name,
+        race_date,
+        priority,
+        goal_type,
+        distance_km,
+        target_time_seconds,
+        status,
+        notes
+    FROM athlete_goals
+    WHERE user_id = ?
+    ORDER BY goal_id
+"""
+
+_SELECT_RETROSPECTIVES = """
+    SELECT
+        retro_id,
+        season_label,
+        period_start,
+        period_end,
+        narrative,
+        key_learnings
+    FROM season_retrospectives
+    WHERE user_id = ?
+    ORDER BY retro_id
+"""
+
+
+def _row_to_dict(columns: list[str], row: tuple) -> dict:
+    """Zip a row into a dict, converting date/datetime values to str."""
+    record: dict = {}
+    for col, value in zip(columns, row, strict=True):
+        if isinstance(value, _dt.date | _dt.datetime):
+            record[col] = str(value)
+        else:
+            record[col] = value
+    return record
+
+
+def get_goal(
+    conn: duckdb.DuckDBPyConnection,
+    user_id: str = "default",
+) -> dict:
+    """Get the athlete goal payload (profile + goals + retrospectives).
+
+    Args:
+        conn: Open DuckDB connection (read-only is sufficient).
+        user_id: Profile owner identifier (defaults to ``"default"``).
+
+    Returns:
+        Dict shaped as::
+
+            {
+                "profile": {
+                    "current_focus": str | None,
+                    "focus_notes": str | None,
+                    "updated_at": str | None,
+                },
+                "goals": [ {goal columns...}, ... ],
+                "retrospectives": [ {retro columns...}, ... ],
+            }
+
+        When no profile row exists the profile fields are ``None`` and the
+        lists are empty. All date/timestamp values are converted to ``str``.
+    """
+    profile_row = conn.execute(_SELECT_PROFILE, [user_id]).fetchone()
+    if profile_row is None:
+        profile: dict = {
+            "current_focus": None,
+            "focus_notes": None,
+            "updated_at": None,
+        }
+    else:
+        profile = {
+            "current_focus": profile_row[0],
+            "focus_notes": profile_row[1],
+            "updated_at": (str(profile_row[2]) if profile_row[2] is not None else None),
+        }
+
+    goal_result = conn.execute(_SELECT_GOALS, [user_id])
+    goal_columns = [desc[0] for desc in goal_result.description]
+    goals = [_row_to_dict(goal_columns, row) for row in goal_result.fetchall()]
+
+    retro_result = conn.execute(_SELECT_RETROSPECTIVES, [user_id])
+    retro_columns = [desc[0] for desc in retro_result.description]
+    retrospectives = [
+        _row_to_dict(retro_columns, row) for row in retro_result.fetchall()
+    ]
+
+    return {
+        "profile": profile,
+        "goals": goals,
+        "retrospectives": retrospectives,
+    }

--- a/packages/garmin-web/tests/conftest.py
+++ b/packages/garmin-web/tests/conftest.py
@@ -589,3 +589,141 @@ def detail_db_path(tmp_path: Path) -> Path:
     finally:
         conn.close()
     return db_path
+
+
+# --- Goal page fixtures (Issue #282) -----------------------------------
+# Mirror the athlete-centric schema in
+# garmin_mcp/database/migrations/add_athlete_tables.py (only the columns the
+# goal query reads). The Web app is read-only; data is written here directly.
+
+_CREATE_ATHLETE_PROFILE = """
+    CREATE TABLE athlete_profile (
+        user_id VARCHAR PRIMARY KEY DEFAULT 'default',
+        current_focus VARCHAR,
+        focus_notes VARCHAR,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+"""
+
+_CREATE_ATHLETE_GOALS = """
+    CREATE TABLE athlete_goals (
+        goal_id INTEGER PRIMARY KEY,
+        user_id VARCHAR DEFAULT 'default',
+        race_name VARCHAR NOT NULL,
+        race_date DATE,
+        priority VARCHAR,
+        goal_type VARCHAR,
+        distance_km DOUBLE,
+        target_time_seconds INTEGER,
+        status VARCHAR DEFAULT 'active',
+        notes VARCHAR,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+"""
+
+_CREATE_SEASON_RETROSPECTIVES = """
+    CREATE TABLE season_retrospectives (
+        retro_id INTEGER PRIMARY KEY,
+        user_id VARCHAR DEFAULT 'default',
+        season_label VARCHAR,
+        period_start DATE,
+        period_end DATE,
+        narrative VARCHAR,
+        key_learnings VARCHAR,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+"""
+
+_GOAL_TABLE_DDLS = [
+    _CREATE_ATHLETE_PROFILE,
+    _CREATE_ATHLETE_GOALS,
+    _CREATE_SEASON_RETROSPECTIVES,
+]
+
+
+def _create_goal_tables(conn: duckdb.DuckDBPyConnection) -> None:
+    for ddl in _GOAL_TABLE_DDLS:
+        conn.execute(ddl)
+
+
+@pytest.fixture
+def goal_db_path(tmp_path: Path) -> Path:
+    """DuckDB with athlete tables: 1 profile, 2 goals, 1 retrospective."""
+    db_path = tmp_path / "test_garmin_web_goal.duckdb"
+    conn = duckdb.connect(str(db_path))
+    try:
+        _create_goal_tables(conn)
+        conn.execute(
+            "INSERT INTO athlete_profile "
+            "(user_id, current_focus, focus_notes, updated_at) "
+            "VALUES (?, ?, ?, ?)",
+            [
+                "default",
+                "サブ4達成に向けた持久力強化",
+                "週末ロング走を軸に有酸素ベースを底上げ",
+                "2026-06-14 09:00:00",
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO athlete_goals ("
+            "goal_id, user_id, race_name, race_date, priority, goal_type,"
+            " distance_km, target_time_seconds, status, notes"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (
+                    1,
+                    "default",
+                    "つくばマラソン",
+                    "2026-11-22",
+                    "A",
+                    "marathon",
+                    42.195,
+                    16200,  # 4:30:00
+                    "active",
+                    "メインターゲット",
+                ),
+                (
+                    2,
+                    "default",
+                    "ハーフマラソン大会",
+                    None,  # 日付未定
+                    "B",
+                    "half",
+                    21.0975,
+                    7200,  # 2:00:00
+                    "active",
+                    "調整レース",
+                ),
+            ],
+        )
+        conn.execute(
+            "INSERT INTO season_retrospectives ("
+            "retro_id, user_id, season_label, period_start, period_end,"
+            " narrative, key_learnings"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                1,
+                "default",
+                "2025秋シーズン",
+                "2025-09-01",
+                "2025-12-31",
+                "故障なく走り込めた一方、後半の失速が課題でした。",
+                "ロング走でのペース管理を重視する",
+            ],
+        )
+    finally:
+        conn.close()
+    return db_path
+
+
+@pytest.fixture
+def empty_goal_db_path(tmp_path: Path) -> Path:
+    """DuckDB with empty athlete tables (no profile / goals / retrospectives)."""
+    db_path = tmp_path / "test_garmin_web_goal_empty.duckdb"
+    conn = duckdb.connect(str(db_path))
+    try:
+        _create_goal_tables(conn)
+    finally:
+        conn.close()
+    return db_path

--- a/packages/garmin-web/tests/test_api_goal.py
+++ b/packages/garmin-web/tests/test_api_goal.py
@@ -1,0 +1,35 @@
+"""API tests for GET /api/goal."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from garmin_web.app import create_app
+
+
+@pytest.mark.integration
+def test_api_goal_endpoint(goal_db_path):
+    client = TestClient(create_app(db_path=goal_db_path))
+    response = client.get("/api/goal")
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["profile"]["current_focus"] == "サブ4達成に向けた持久力強化"
+    assert len(payload["goals"]) == 2
+    assert payload["goals"][0]["race_name"] == "つくばマラソン"
+    assert payload["goals"][0]["target_time_seconds"] == 16200
+    assert payload["goals"][1]["race_date"] is None
+    assert len(payload["retrospectives"]) == 1
+    assert payload["retrospectives"][0]["season_label"] == "2025秋シーズン"
+
+
+@pytest.mark.integration
+def test_api_goal_endpoint_empty(empty_goal_db_path):
+    client = TestClient(create_app(db_path=empty_goal_db_path))
+    response = client.get("/api/goal")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["goals"] == []
+    assert payload["retrospectives"] == []
+    assert payload["profile"]["current_focus"] is None

--- a/packages/garmin-web/tests/test_queries_goal.py
+++ b/packages/garmin-web/tests/test_queries_goal.py
@@ -1,0 +1,46 @@
+"""Integration tests for garmin_web.queries.goal.get_goal."""
+
+import pytest
+from garmin_mcp.database.connection import get_connection
+
+from garmin_web.queries.goal import get_goal
+
+
+@pytest.mark.integration
+def test_get_goal_returns_profile(goal_db_path):
+    with get_connection(goal_db_path) as conn:
+        result = get_goal(conn)
+
+    profile = result["profile"]
+    assert profile["current_focus"] == "サブ4達成に向けた持久力強化"
+    assert profile["focus_notes"] == "週末ロング走を軸に有酸素ベースを底上げ"
+    assert isinstance(profile["updated_at"], str)
+
+    goals = result["goals"]
+    assert len(goals) == 2
+    assert goals[0]["race_name"] == "つくばマラソン"
+    assert goals[0]["priority"] == "A"
+    assert goals[0]["race_date"] == "2026-11-22"
+    assert goals[0]["target_time_seconds"] == 16200
+    assert goals[1]["race_name"] == "ハーフマラソン大会"
+    assert goals[1]["race_date"] is None
+    # date/timestamp values are str
+    assert isinstance(goals[0]["race_date"], str)
+
+    retrospectives = result["retrospectives"]
+    assert len(retrospectives) == 1
+    assert retrospectives[0]["season_label"] == "2025秋シーズン"
+    assert retrospectives[0]["period_start"] == "2025-09-01"
+    assert retrospectives[0]["key_learnings"] == "ロング走でのペース管理を重視する"
+
+
+@pytest.mark.integration
+def test_get_goal_empty(empty_goal_db_path):
+    with get_connection(empty_goal_db_path) as conn:
+        result = get_goal(conn)
+
+    assert result["goals"] == []
+    assert result["retrospectives"] == []
+    assert result["profile"]["current_focus"] is None
+    assert result["profile"]["focus_notes"] is None
+    assert result["profile"]["updated_at"] is None


### PR DESCRIPTION
## Summary

DuckDB の目標（athlete_profile / athlete_goals / season_retrospectives）を Web で参照する読取専用ページ `/goal` を追加。登録/更新は CLI（/set-goal）が担い Web は表示のみ。

Epic #268 / Phase 2。

## Changes
- `queries/goal.py` (new) — `get_goal(conn, user_id)`（3テーブル直接SQL、date→str、未登録は空構造）
- `api/goal.py` (new) — `GET /api/goal`
- `app.py` — goal router include
- frontend: `Goal.tsx`（現フェーズ/目標レース表[目標タイムをH:MM:SS整形]/振り返り）, `client.ts` fetchGoal, `types.ts`, `App.tsx` ルート, `Layout.tsx` ナビ
- tests: `test_queries_goal.py` / `test_api_goal.py` + `Goal.test.tsx`

## Validation (L2) — メインセッションで実行済み
- backend 全 38 passed（goal 4件含む、回帰なし）
- frontend build 成功（tsc 型エラーなし）/ vitest 27 passed
- ruff: goal.py/api クリーン

Closes #282