### PR TITLE
feat(web): add weekly review history page (/weekly-reviews)

### DIFF
--- a/packages/garmin-web/frontend/src/App.tsx
+++ b/packages/garmin-web/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import ActivityDetail from "./pages/ActivityDetail";
 import ActivityList from "./pages/ActivityList";
 import Goal from "./pages/Goal";
 import TrendsDashboard from "./pages/TrendsDashboard";
+import WeeklyReviewDetail from "./pages/WeeklyReviewDetail";
+import WeeklyReviews from "./pages/WeeklyReviews";
 
 export default function App() {
   return (
@@ -14,6 +16,11 @@ export default function App() {
           <Route path="/activities/:id" element={<ActivityDetail />} />
           <Route path="/trends" element={<TrendsDashboard />} />
           <Route path="/goal" element={<Goal />} />
+          <Route path="/weekly-reviews" element={<WeeklyReviews />} />
+          <Route
+            path="/weekly-reviews/:weekStart"
+            element={<WeeklyReviewDetail />}
+          />
         </Routes>
       </Layout>
     </BrowserRouter>

--- a/packages/garmin-web/frontend/src/api/client.ts
+++ b/packages/garmin-web/frontend/src/api/client.ts
@@ -5,6 +5,7 @@ import type {
   SectionsResponse,
   TimeSeriesResponse,
   TrackResponse,
+  WeeklyReview,
 } from "../types";
 
 export async function fetchGoal(): Promise<GoalResponse> {
@@ -13,6 +14,24 @@ export async function fetchGoal(): Promise<GoalResponse> {
     throw new Error(`Failed to fetch goal: ${response.status}`);
   }
   return (await response.json()) as GoalResponse;
+}
+
+export async function fetchWeeklyReviews(limit = 12): Promise<WeeklyReview[]> {
+  const response = await fetch(`/api/weekly-reviews?limit=${limit}`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch weekly reviews: ${response.status}`);
+  }
+  return (await response.json()) as WeeklyReview[];
+}
+
+export async function fetchWeeklyReview(
+  weekStart: string,
+): Promise<WeeklyReview> {
+  const response = await fetch(`/api/weekly-reviews/${weekStart}`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch weekly review: ${response.status}`);
+  }
+  return (await response.json()) as WeeklyReview;
 }
 
 export async function fetchActivities(params?: {

--- a/packages/garmin-web/frontend/src/components/Layout.tsx
+++ b/packages/garmin-web/frontend/src/components/Layout.tsx
@@ -33,6 +33,9 @@ export default function Layout({ children }: { children: ReactNode }) {
             <NavLink to="/goal" className={navLinkClass}>
               目標
             </NavLink>
+            <NavLink to="/weekly-reviews" className={navLinkClass}>
+              週次レビュー
+            </NavLink>
           </nav>
         </div>
       </header>

--- a/packages/garmin-web/frontend/src/pages/WeeklyReviewDetail.tsx
+++ b/packages/garmin-web/frontend/src/pages/WeeklyReviewDetail.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { fetchWeeklyReview } from "../api/client";
+import type { WeeklyReview } from "../types";
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <h2 className="mb-3 font-display text-base font-semibold text-ink">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+export default function WeeklyReviewDetail() {
+  const { weekStart } = useParams<{ weekStart: string }>();
+  const [review, setReview] = useState<WeeklyReview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (weekStart == null) {
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    fetchWeeklyReview(weekStart)
+      .then((data) => {
+        if (!cancelled) {
+          setReview(data);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [weekStart]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center gap-3 py-16 text-sm text-slate-500">
+        <span
+          aria-hidden="true"
+          className="h-5 w-5 animate-spin rounded-full border-2 border-slate-300 border-t-ink"
+        />
+        読み込み中...
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <p
+        role="alert"
+        className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+      >
+        エラー: {error}
+      </p>
+    );
+  }
+  if (review == null) {
+    return null;
+  }
+
+  const data = review.review_data;
+  const thisWeek = data?.this_week;
+  const periodization = data?.periodization;
+  const verdict = data?.verdict ?? [];
+  const recommendations = data?.recommendations ?? [];
+
+  return (
+    <div className="stagger-in space-y-6">
+      <div className="flex items-baseline justify-between gap-3">
+        <h1 className="font-display text-2xl font-bold tracking-tight text-ink">
+          週次レビュー
+        </h1>
+        <Link
+          to="/weekly-reviews"
+          className="text-sm font-medium text-slate-500 hover:text-ink"
+        >
+          ← 一覧へ
+        </Link>
+      </div>
+      <p className="font-numeric text-sm tabular-nums text-slate-500">
+        {review.week_start_date} 〜 {review.week_end_date}
+      </p>
+
+      {data == null ? (
+        <p className="py-4 text-center text-sm text-slate-500">
+          レビューデータがありません
+        </p>
+      ) : (
+        <>
+          {/* This-week actuals */}
+          <Section title="実績サマリー">
+            {thisWeek != null ? (
+              <div className="space-y-1 text-sm text-slate-700">
+                {thisWeek.volume_km != null && (
+                  <p>
+                    <span className="font-medium text-slate-500">走行距離: </span>
+                    {thisWeek.volume_km} km
+                  </p>
+                )}
+                {thisWeek.run_count != null && (
+                  <p>
+                    <span className="font-medium text-slate-500">ラン回数: </span>
+                    {thisWeek.run_count} 回
+                  </p>
+                )}
+                {thisWeek.hr_discipline != null && (
+                  <p>
+                    <span className="font-medium text-slate-500">心拍管理: </span>
+                    {thisWeek.hr_discipline}
+                  </p>
+                )}
+                {Array.isArray(thisWeek.highlights) &&
+                  thisWeek.highlights.length > 0 && (
+                    <ul className="list-disc space-y-0.5 pl-5 text-slate-600">
+                      {thisWeek.highlights.map((h, i) => (
+                        <li key={i}>{h}</li>
+                      ))}
+                    </ul>
+                  )}
+              </div>
+            ) : (
+              <p className="text-sm text-slate-500">実績データがありません</p>
+            )}
+          </Section>
+
+          {/* Periodization (#286) — render only when present */}
+          {periodization != null && (
+            <Section title="目標逆算フェーズ">
+              <div className="space-y-1 text-sm text-slate-700">
+                {periodization.a_race != null && (
+                  <p>
+                    <span className="font-medium text-slate-500">
+                      A レース: </span>
+                    {periodization.a_race}
+                    {periodization.weeks_to_a_race != null
+                      ? `（残り ${periodization.weeks_to_a_race} 週）`
+                      : "（残り週数 未確定）"}
+                  </p>
+                )}
+                {periodization.b_race != null && (
+                  <p>
+                    <span className="font-medium text-slate-500">
+                      B レース: </span>
+                    {periodization.b_race}
+                    {periodization.weeks_to_b_race != null
+                      ? `（残り ${periodization.weeks_to_b_race} 週）`
+                      : "（残り週数 未確定）"}
+                  </p>
+                )}
+                {periodization.expected_phase != null && (
+                  <p>
+                    <span className="font-medium text-slate-500">
+                      あるべきフェーズ: </span>
+                    {periodization.expected_phase}
+                  </p>
+                )}
+                {periodization.garmin_phase != null && (
+                  <p>
+                    <span className="font-medium text-slate-500">
+                      Garmin フェーズ: </span>
+                    {periodization.garmin_phase}
+                  </p>
+                )}
+                {periodization.gap != null && (
+                  <p>
+                    <span className="font-medium text-slate-500">ギャップ: </span>
+                    {periodization.gap}
+                  </p>
+                )}
+              </div>
+            </Section>
+          )}
+
+          {/* Verdict table — target-week plan evaluation */}
+          <Section title="対象週プラン評価">
+            {verdict.length > 0 ? (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-xs tracking-wide text-slate-500 uppercase">
+                    <th className="px-2 py-2 text-left font-medium">日付</th>
+                    <th className="px-2 py-2 text-left font-medium">
+                      セッション
+                    </th>
+                    <th className="px-2 py-2 text-center font-medium">評価</th>
+                    <th className="px-2 py-2 text-left font-medium">コメント</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100">
+                  {verdict.map((v, i) => (
+                    <tr key={i} className="hover:bg-slate-50">
+                      <td className="px-2 py-2 text-left font-numeric tabular-nums text-slate-700">
+                        {v.date ?? "-"}
+                      </td>
+                      <td className="px-2 py-2 text-left text-slate-700">
+                        {v.session ?? "-"}
+                      </td>
+                      <td className="px-2 py-2 text-center text-base">
+                        {v.rating ?? "-"}
+                      </td>
+                      <td className="px-2 py-2 text-left text-slate-600">
+                        {v.comment ?? "-"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <p className="text-sm text-slate-500">評価データがありません</p>
+            )}
+          </Section>
+
+          {/* Goal alignment */}
+          {data.goal_alignment != null && (
+            <Section title="目標との整合">
+              <p className="text-sm text-slate-700">{data.goal_alignment}</p>
+            </Section>
+          )}
+
+          {/* Recommendations */}
+          {recommendations.length > 0 && (
+            <Section title="推奨アクション">
+              <ul className="list-disc space-y-1 pl-5 text-sm text-slate-700">
+                {recommendations.map((rec, i) => (
+                  <li key={i}>{rec}</li>
+                ))}
+              </ul>
+            </Section>
+          )}
+
+          {/* Overall */}
+          {data.overall != null && (
+            <Section title="総評">
+              <p className="text-sm text-slate-700">{data.overall}</p>
+            </Section>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/garmin-web/frontend/src/pages/WeeklyReviews.test.tsx
+++ b/packages/garmin-web/frontend/src/pages/WeeklyReviews.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import WeeklyReviews from "./WeeklyReviews";
+
+const FIXTURE_REVIEWS = [
+  {
+    review_id: 2,
+    user_id: "default",
+    week_start_date: "2026-06-15",
+    week_end_date: "2026-06-21",
+    review_date: "2026-06-22",
+    review_data: {
+      this_week: { volume_km: 35.5, run_count: 4 },
+      verdict: [
+        { date: "2026-06-20", session: "Anaerobic", rating: "🔴", comment: "x" },
+        { date: "2026-06-21", session: "Anaerobic", rating: "🔴", comment: "y" },
+      ],
+      overall: "2週目は強度過多に注意が必要でした。",
+    },
+    created_at: null,
+    agent_name: "weekly-review",
+    agent_version: "1.0",
+  },
+  {
+    review_id: 1,
+    user_id: "default",
+    week_start_date: "2026-06-08",
+    week_end_date: "2026-06-14",
+    review_date: "2026-06-15",
+    review_data: {
+      this_week: { volume_km: 28.8, run_count: 3 },
+      verdict: [
+        { date: "2026-06-09", session: "Easy", rating: "✅", comment: "ok" },
+      ],
+      overall: "1週目は順調に積み上げられました。",
+    },
+    created_at: null,
+    agent_name: "weekly-review",
+    agent_version: "1.0",
+  },
+];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("WeeklyReviews", () => {
+  it("renders the weekly review list from API", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(FIXTURE_REVIEWS), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    render(
+      <MemoryRouter>
+        <WeeklyReviews />
+      </MemoryRouter>,
+    );
+
+    // Week range labels (newest first)
+    expect(
+      await screen.findByText("2026-06-15 〜 2026-06-21"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("2026-06-08 〜 2026-06-14")).toBeInTheDocument();
+
+    // Overall excerpts rendered
+    expect(
+      screen.getByText("2週目は強度過多に注意が必要でした。"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("1週目は順調に積み上げられました。"),
+    ).toBeInTheDocument();
+
+    // Each row links to its detail page
+    const links = screen.getAllByRole("link");
+    const hrefs = links.map((l) => l.getAttribute("href"));
+    expect(hrefs).toContain("/weekly-reviews/2026-06-15");
+    expect(hrefs).toContain("/weekly-reviews/2026-06-08");
+  });
+});

--- a/packages/garmin-web/frontend/src/pages/WeeklyReviews.tsx
+++ b/packages/garmin-web/frontend/src/pages/WeeklyReviews.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { fetchWeeklyReviews } from "../api/client";
+import type { WeeklyReview } from "../types";
+
+/** Count verdict entries with a given emoji rating. */
+export function countRating(review: WeeklyReview, rating: string): number {
+  const verdict = review.review_data?.verdict ?? [];
+  return verdict.filter((v) => v.rating === rating).length;
+}
+
+/** Short excerpt of the overall text (first ~60 chars). */
+export function overallExcerpt(review: WeeklyReview): string {
+  const overall = review.review_data?.overall;
+  if (overall == null || overall === "") {
+    return "-";
+  }
+  return overall.length > 60 ? `${overall.slice(0, 60)}…` : overall;
+}
+
+export default function WeeklyReviews() {
+  const [reviews, setReviews] = useState<WeeklyReview[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchWeeklyReviews()
+      .then((data) => {
+        if (!cancelled) {
+          setReviews(data);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center gap-3 py-16 text-sm text-slate-500">
+        <span
+          aria-hidden="true"
+          className="h-5 w-5 animate-spin rounded-full border-2 border-slate-300 border-t-ink"
+        />
+        読み込み中...
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <p
+        role="alert"
+        className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+      >
+        エラー: {error}
+      </p>
+    );
+  }
+  if (reviews == null) {
+    return null;
+  }
+
+  return (
+    <div className="stagger-in space-y-6">
+      <h1 className="font-display text-2xl font-bold tracking-tight text-ink">
+        週次レビュー
+      </h1>
+
+      <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        {reviews.length > 0 ? (
+          <ul className="divide-y divide-slate-100">
+            {reviews.map((review) => {
+              const redCount = countRating(review, "🔴");
+              const yellowCount = countRating(review, "🟡");
+              const greenCount = countRating(review, "✅");
+              return (
+                <li key={review.week_start_date}>
+                  <Link
+                    to={`/weekly-reviews/${review.week_start_date}`}
+                    className="-mx-2 flex flex-col gap-1 rounded-lg px-2 py-3 transition-colors hover:bg-slate-50"
+                  >
+                    <div className="flex items-baseline justify-between gap-3">
+                      <span className="font-display text-sm font-semibold text-ink">
+                        {review.week_start_date} 〜 {review.week_end_date}
+                      </span>
+                      <span className="font-numeric text-xs tabular-nums text-slate-500">
+                        <span className="mr-2">✅ {greenCount}</span>
+                        <span className="mr-2">🟡 {yellowCount}</span>
+                        <span>🔴 {redCount}</span>
+                      </span>
+                    </div>
+                    <p className="text-sm text-slate-600">
+                      {overallExcerpt(review)}
+                    </p>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <p className="py-4 text-center text-sm text-slate-500">
+            週次レビューが登録されていません
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/packages/garmin-web/frontend/src/types.ts
+++ b/packages/garmin-web/frontend/src/types.ts
@@ -43,6 +43,70 @@ export interface GoalResponse {
   retrospectives: SeasonRetrospective[];
 }
 
+// --- Weekly reviews (Issue #283) ---
+
+export interface WeeklyReviewVerdict {
+  date?: string;
+  session?: string;
+  rating?: string; // "✅" | "🟡" | "🔴"
+  comment?: string;
+  [key: string]: unknown;
+}
+
+export interface WeeklyReviewPeriodization {
+  weeks_to_a_race?: number | null;
+  a_race?: string | null;
+  weeks_to_b_race?: number | null;
+  b_race?: string | null;
+  expected_phase?: string | null;
+  garmin_phase?: string | null;
+  gap?: string | null;
+  [key: string]: unknown;
+}
+
+export interface WeeklyReviewThisWeek {
+  volume_km?: number | null;
+  run_count?: number | null;
+  intensity_distribution?: Record<string, unknown>;
+  hr_discipline?: string | null;
+  highlights?: string[];
+  [key: string]: unknown;
+}
+
+export interface WeeklyReviewPlanItem {
+  date?: string;
+  title?: string;
+  type?: string;
+  [key: string]: unknown;
+}
+
+export interface WeeklyReviewData {
+  plan_week_start?: string | null;
+  actuals_week_start?: string | null;
+  this_week?: WeeklyReviewThisWeek;
+  garmin_next_week?: WeeklyReviewPlanItem[];
+  periodization?: WeeklyReviewPeriodization;
+  verdict?: WeeklyReviewVerdict[];
+  goal_alignment?: string | null;
+  recommendations?: string[];
+  overall?: string | null;
+  [key: string]: unknown;
+}
+
+export interface WeeklyReview {
+  review_id: number;
+  user_id: string;
+  week_start_date: string;
+  week_end_date: string;
+  review_date: string | null;
+  review_data: WeeklyReviewData | null;
+  created_at: string | null;
+  agent_name: string | null;
+  agent_version: string | null;
+}
+
+export type WeeklyReviewListResponse = WeeklyReview[];
+
 // --- Activity detail (Issue #199) ---
 
 export interface SplitRow {

--- a/packages/garmin-web/src/garmin_web/api/weekly_reviews.py
+++ b/packages/garmin-web/src/garmin_web/api/weekly_reviews.py
@@ -1,0 +1,33 @@
+"""Weekly review API router (read-only)."""
+
+from fastapi import APIRouter, HTTPException, Request
+from garmin_mcp.database.connection import get_connection
+
+from garmin_web.queries.weekly_reviews import get_weekly_review, list_weekly_reviews
+
+router = APIRouter(prefix="/api")
+
+
+@router.get("/weekly-reviews")
+def list_weekly_reviews_endpoint(request: Request, limit: int = 12) -> list[dict]:
+    """Return recent weekly reviews (newest first).
+
+    Read-only: registration/updates are owned by the CLI (`/weekly-review`).
+    """
+    db_path = getattr(request.app.state, "db_path", None)
+    with get_connection(db_path) as conn:
+        return list_weekly_reviews(conn, limit=limit)
+
+
+@router.get("/weekly-reviews/{week_start_date}")
+def get_weekly_review_endpoint(request: Request, week_start_date: str) -> dict:
+    """Return a single weekly review by its week-start date.
+
+    Raises 404 when no review exists for the given week.
+    """
+    db_path = getattr(request.app.state, "db_path", None)
+    with get_connection(db_path) as conn:
+        review = get_weekly_review(conn, week_start_date)
+    if review is None:
+        raise HTTPException(status_code=404, detail="Weekly review not found")
+    return review

--- a/packages/garmin-web/src/garmin_web/app.py
+++ b/packages/garmin-web/src/garmin_web/app.py
@@ -11,6 +11,7 @@ from garmin_web.api.activities import router as activities_router
 from garmin_web.api.activity_detail import router as activity_detail_router
 from garmin_web.api.goal import router as goal_router
 from garmin_web.api.trends import router as trends_router
+from garmin_web.api.weekly_reviews import router as weekly_reviews_router
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +53,7 @@ def create_app(
     app.include_router(activity_detail_router)
     app.include_router(trends_router)
     app.include_router(goal_router)
+    app.include_router(weekly_reviews_router)
 
     resolved_static_dir = Path(static_dir) if static_dir else _DEFAULT_STATIC_DIR
     _mount_spa(app, resolved_static_dir)

--- a/packages/garmin-web/src/garmin_web/queries/weekly_reviews.py
+++ b/packages/garmin-web/src/garmin_web/queries/weekly_reviews.py
@@ -1,0 +1,89 @@
+"""Read-only queries for the weekly_reviews table.
+
+Reads per-week review records saved by the CLI (`/weekly-review`). The Web app
+is display-only; registration/updates are owned by the CLI. Each ``review_data``
+payload is JSON-decoded back into a dict and all date/timestamp values are
+converted to ``str`` so the result is JSON-serializable at the MCP/API boundary.
+"""
+
+import datetime as _dt
+import json
+
+import duckdb
+
+_REVIEW_COLUMNS = (
+    "review_id, user_id, week_start_date, week_end_date, review_date, "
+    "review_data, created_at, agent_name, agent_version"
+)
+
+_SELECT_LIST = f"""
+    SELECT {_REVIEW_COLUMNS}
+    FROM weekly_reviews
+    WHERE user_id = ?
+    ORDER BY week_start_date DESC
+    LIMIT ?
+"""
+
+_SELECT_ONE = f"""
+    SELECT {_REVIEW_COLUMNS}
+    FROM weekly_reviews
+    WHERE user_id = ? AND week_start_date = ?
+"""
+
+
+def _review_row_to_dict(columns: list[str], row: tuple) -> dict:
+    """Zip a row into a dict, JSON-decoding review_data and stringifying dates."""
+    record: dict = {}
+    for col, value in zip(columns, row, strict=True):
+        if isinstance(value, _dt.date | _dt.datetime):
+            record[col] = str(value)
+        else:
+            record[col] = value
+    raw = record.get("review_data")
+    record["review_data"] = json.loads(raw) if raw is not None else None
+    return record
+
+
+def list_weekly_reviews(
+    conn: duckdb.DuckDBPyConnection,
+    limit: int = 12,
+    user_id: str = "default",
+) -> list[dict]:
+    """List recent weekly reviews in descending week order.
+
+    Args:
+        conn: Open DuckDB connection (read-only is sufficient).
+        limit: Maximum number of reviews to return (default 12).
+        user_id: Profile owner identifier (defaults to ``"default"``).
+
+    Returns:
+        A list of review dicts (newest first). Each ``review_data`` is
+        JSON-decoded back into a dict; date/timestamp values are ``str``.
+    """
+    result = conn.execute(_SELECT_LIST, [user_id, limit])
+    columns = [desc[0] for desc in result.description]
+    return [_review_row_to_dict(columns, row) for row in result.fetchall()]
+
+
+def get_weekly_review(
+    conn: duckdb.DuckDBPyConnection,
+    week_start_date: str,
+    user_id: str = "default",
+) -> dict | None:
+    """Get a single weekly review by its week-start date.
+
+    Args:
+        conn: Open DuckDB connection (read-only is sufficient).
+        week_start_date: Week start (``YYYY-MM-DD``), the saved record key.
+        user_id: Profile owner identifier (defaults to ``"default"``).
+
+    Returns:
+        A review dict with ``review_data`` JSON-decoded and date/timestamp
+        values converted to ``str``, or ``None`` when no matching review exists.
+    """
+    result = conn.execute(_SELECT_ONE, [user_id, week_start_date])
+    row = result.fetchone()
+    if row is None:
+        return None
+    columns = [desc[0] for desc in result.description]
+    return _review_row_to_dict(columns, row)

--- a/packages/garmin-web/tests/conftest.py
+++ b/packages/garmin-web/tests/conftest.py
@@ -727,3 +727,131 @@ def empty_goal_db_path(tmp_path: Path) -> Path:
     finally:
         conn.close()
     return db_path
+
+
+# --- Weekly review page fixtures (Issue #283) --------------------------
+# Mirror the weekly_reviews schema in
+# garmin_mcp/database/migrations/add_athlete_tables.py (review_data is stored
+# as a JSON VARCHAR). The Web app is read-only; data is written here directly.
+
+_CREATE_WEEKLY_REVIEWS = """
+    CREATE TABLE weekly_reviews (
+        review_id INTEGER PRIMARY KEY,
+        user_id VARCHAR DEFAULT 'default',
+        week_start_date DATE NOT NULL,
+        week_end_date DATE NOT NULL,
+        review_date DATE,
+        review_data VARCHAR,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        agent_name VARCHAR,
+        agent_version VARCHAR
+    )
+"""
+
+
+def _review_data(week_label: str, red_count: int) -> dict:
+    """Build a representative review_data payload (verdict, periodization, ...)."""
+    verdict = [
+        {
+            "date": "2026-06-16",
+            "session": "Tempo",
+            "rating": "✅",
+            "comment": "狙い通りのテンポ走でした。",
+        },
+        {
+            "date": "2026-06-18",
+            "session": "Easy",
+            "rating": "🟡",
+            "comment": "心拍がやや高めでした。",
+        },
+    ]
+    verdict += [
+        {
+            "date": "2026-06-20",
+            "session": "Anaerobic",
+            "rating": "🔴",
+            "comment": "強度過多に注意してください。",
+        }
+        for _ in range(red_count)
+    ]
+    return {
+        "plan_week_start": None,
+        "actuals_week_start": None,
+        "this_week": {
+            "volume_km": 35.5,
+            "run_count": 4,
+            "hr_discipline": "Zone 2 中心で良好でした。",
+            "highlights": ["週末ロング走を完遂"],
+        },
+        "garmin_next_week": [
+            {"date": "2026-06-23", "title": "Tempo", "type": "fbtAdaptiveWorkout"},
+        ],
+        "periodization": {
+            "weeks_to_a_race": None,
+            "a_race": "さいたまマラソン",
+            "weeks_to_b_race": 17,
+            "b_race": "新潟シティマラソン",
+            "expected_phase": "有酸素ベース構築期",
+            "garmin_phase": "ベース期",
+            "gap": "強度がやや先行気味です。",
+        },
+        "verdict": verdict,
+        "goal_alignment": f"{week_label} は目標方針におおむね沿っています。",
+        "recommendations": ["Z2を維持する（HR 135-145bpm）", "ロング走を1本入れる"],
+        "overall": f"{week_label} は順調に積み上げられた良い週でした。",
+    }
+
+
+# (week_start_date, week_end_date, review_date, week_label, red_count)
+_WEEKLY_REVIEW_ROWS = [
+    ("2026-06-01", "2026-06-07", "2026-06-08", "6/1週", 1),
+    ("2026-06-08", "2026-06-14", "2026-06-15", "6/8週", 0),
+    ("2026-06-15", "2026-06-21", "2026-06-22", "6/15週", 2),
+]
+
+
+def _insert_weekly_reviews(conn: duckdb.DuckDBPyConnection) -> None:
+    for idx, (start, end, review_date, label, red) in enumerate(
+        _WEEKLY_REVIEW_ROWS, start=1
+    ):
+        conn.execute(
+            "INSERT INTO weekly_reviews ("
+            "review_id, user_id, week_start_date, week_end_date, review_date,"
+            " review_data, agent_name, agent_version"
+            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                idx,
+                "default",
+                start,
+                end,
+                review_date,
+                json.dumps(_review_data(label, red), ensure_ascii=False),
+                "weekly-review",
+                "1.0",
+            ],
+        )
+
+
+@pytest.fixture
+def weekly_reviews_db_path(tmp_path: Path) -> Path:
+    """DuckDB with weekly_reviews table populated (3 weeks, June 2026)."""
+    db_path = tmp_path / "test_garmin_web_weekly_reviews.duckdb"
+    conn = duckdb.connect(str(db_path))
+    try:
+        conn.execute(_CREATE_WEEKLY_REVIEWS)
+        _insert_weekly_reviews(conn)
+    finally:
+        conn.close()
+    return db_path
+
+
+@pytest.fixture
+def empty_weekly_reviews_db_path(tmp_path: Path) -> Path:
+    """DuckDB with an empty weekly_reviews table."""
+    db_path = tmp_path / "test_garmin_web_weekly_reviews_empty.duckdb"
+    conn = duckdb.connect(str(db_path))
+    try:
+        conn.execute(_CREATE_WEEKLY_REVIEWS)
+    finally:
+        conn.close()
+    return db_path

--- a/packages/garmin-web/tests/test_api_weekly_reviews.py
+++ b/packages/garmin-web/tests/test_api_weekly_reviews.py
@@ -1,0 +1,38 @@
+"""API tests for the weekly-reviews endpoints."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from garmin_web.app import create_app
+
+
+@pytest.mark.integration
+def test_api_weekly_reviews_list(weekly_reviews_db_path):
+    client = TestClient(create_app(db_path=weekly_reviews_db_path))
+    response = client.get("/api/weekly-reviews")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload) == 3
+    # newest first
+    assert payload[0]["week_start_date"] == "2026-06-15"
+    assert isinstance(payload[0]["review_data"], dict)
+
+
+@pytest.mark.integration
+def test_api_weekly_review_detail(weekly_reviews_db_path):
+    client = TestClient(create_app(db_path=weekly_reviews_db_path))
+    response = client.get("/api/weekly-reviews/2026-06-08")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["week_start_date"] == "2026-06-08"
+    assert payload["review_data"]["periodization"]["b_race"] == "新潟シティマラソン"
+
+
+@pytest.mark.integration
+def test_api_weekly_review_detail_404(weekly_reviews_db_path):
+    client = TestClient(create_app(db_path=weekly_reviews_db_path))
+    response = client.get("/api/weekly-reviews/2099-01-01")
+
+    assert response.status_code == 404

--- a/packages/garmin-web/tests/test_queries_weekly_reviews.py
+++ b/packages/garmin-web/tests/test_queries_weekly_reviews.py
@@ -1,0 +1,58 @@
+"""Integration tests for garmin_web.queries.weekly_reviews."""
+
+import pytest
+from garmin_mcp.database.connection import get_connection
+
+from garmin_web.queries.weekly_reviews import get_weekly_review, list_weekly_reviews
+
+
+@pytest.mark.integration
+def test_list_weekly_reviews_desc(weekly_reviews_db_path):
+    with get_connection(weekly_reviews_db_path) as conn:
+        reviews = list_weekly_reviews(conn)
+
+    # 3 weeks inserted, newest first (week_start_date DESC)
+    assert len(reviews) == 3
+    starts = [r["week_start_date"] for r in reviews]
+    assert starts == ["2026-06-15", "2026-06-08", "2026-06-01"]
+    # date/timestamp values are str
+    assert isinstance(reviews[0]["week_start_date"], str)
+    # review_data is JSON-decoded back into a dict
+    assert isinstance(reviews[0]["review_data"], dict)
+
+    # limit is honored
+    with get_connection(weekly_reviews_db_path) as conn:
+        limited = list_weekly_reviews(conn, limit=2)
+    assert len(limited) == 2
+    assert limited[0]["week_start_date"] == "2026-06-15"
+    assert limited[1]["week_start_date"] == "2026-06-08"
+
+
+@pytest.mark.integration
+def test_get_weekly_review_detail(weekly_reviews_db_path):
+    with get_connection(weekly_reviews_db_path) as conn:
+        review = get_weekly_review(conn, "2026-06-15")
+
+    assert review is not None
+    assert review["week_start_date"] == "2026-06-15"
+    assert review["agent_name"] == "weekly-review"
+
+    data = review["review_data"]
+    assert isinstance(data, dict)
+    # verdict restored with emoji ratings; 6/15週 has 2 red verdicts
+    ratings = [v["rating"] for v in data["verdict"]]
+    assert ratings.count("🔴") == 2
+    # periodization (#286) restored, including null week count
+    assert data["periodization"]["a_race"] == "さいたまマラソン"
+    assert data["periodization"]["weeks_to_a_race"] is None
+    assert data["periodization"]["weeks_to_b_race"] == 17
+    # legacy keys
+    assert data["this_week"]["volume_km"] == 35.5
+    assert isinstance(data["recommendations"], list)
+
+
+@pytest.mark.integration
+def test_get_weekly_review_missing(empty_weekly_reviews_db_path):
+    with get_connection(empty_weekly_reviews_db_path) as conn:
+        review = get_weekly_review(conn, "2099-01-01")
+    assert review is None


### PR DESCRIPTION
## Summary

DuckDB `weekly_reviews` を Web で参照する履歴一覧 + 詳細ページを追加。verdict ✅/🟡/🔴・periodization・recommendations・overall を表示。

Epic #268 / Phase 2（これで Phase 2 完了）。

## Changes
- `queries/weekly_reviews.py` (new) — `list_weekly_reviews(conn, limit)` / `get_weekly_review(conn, week_start_date)`（review_data json.loads、date→str、降順）
- `api/weekly_reviews.py` (new) — `GET /api/weekly-reviews`（一覧）/ `GET /api/weekly-reviews/{week_start_date}`（詳細、不在は 404）
- `app.py` — router include / `conftest.py` — fixture 追加
- frontend: `WeeklyReviews.tsx`（一覧、🔴件数集計）, `WeeklyReviewDetail.tsx`（実績/periodization/評価表/recommendations/overall）, `client.ts`, `types.ts`, `App.tsx`（`/weekly-reviews`・`/:weekStart`）, `Layout.tsx` ナビ
- tests: backend integration 6件 + `WeeklyReviews.test.tsx`

## 表示
- periodization（#286）は存在チェックで任意表示。weeks_to_a_race=null は「未確定」。旧キー this_week/garmin_next_week を「実績サマリー」「対象週プラン評価」ラベルで表示。

## Validation (L2) — メインセッションで実行済み
- backend 全 44 passed（weekly 6件含む、回帰なし）/ ruff clean
- frontend build 成功（型エラーなし）/ vitest 28 passed

Closes #283